### PR TITLE
Pass server object into API objects

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -28,7 +28,7 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	/**
 	 * Construct the API handler object
 	 */
-	public function __construct() {
+	public function __construct(WP_JSON_ResponseHandler $server) {
 		if ( empty( $this->base ) ) {
 			_doing_it_wrong( 'WP_JSON_CustomPostType::__construct', __( 'The route base must be overridden' ), 'WPAPI-0.6' );
 			return;
@@ -40,6 +40,8 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 
 		add_filter( 'json_endpoints', array( $this, 'registerRoutes' ) );
 		add_filter( 'json_post_type_data', array( $this, 'type_archive_link' ), 10, 2 );
+
+		parent::__construct($server);
 	}
 
 	/**

--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -66,7 +66,6 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	 * @see WP_JSON_Posts::getPost()
 	 */
 	public function getPost( $id, $context = 'view' ) {
-		global $wp_json_server;
 		$id = (int) $id;
 
 		if ( empty( $id ) )
@@ -180,8 +179,6 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	 * @return array|WP_Error Attachment data or error
 	 */
 	public function uploadAttachment( $_files, $_headers ) {
-		global $wp_json_server;
-
 		$post_type = get_post_type_object( 'attachment' );
 		if ( ! $post_type )
 			return new WP_Error( 'json_invalid_post_type', __( 'Invalid post type' ), array( 'status' => 400 ) );
@@ -239,8 +236,8 @@ class WP_JSON_Media extends WP_JSON_Posts {
 			wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $file ) );
 		}
 
-		$wp_json_server->send_status( 201 );
-		$wp_json_server->header( 'Location', json_url( '/media/' . $id ) );
+		$this->server->send_status( 201 );
+		$this->server->header( 'Location', json_url( '/media/' . $id ) );
 		return $this->getPost( $id, 'edit' );
 	}
 
@@ -252,8 +249,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	 * @return array|WP_Error Data from {@see wp_handle_sideload()}
 	 */
 	protected function uploadFromData( $_files, $_headers ) {
-		global $wp_json_server;
-		$data = $wp_json_server->get_raw_data();
+		$data = $this->server->get_raw_data();
 
 		if ( empty( $data ) ) {
 			return new WP_Error( 'json_upload_no_data', __( 'No data supplied' ), array( 'status' => 400 ) );

--- a/lib/class-wp-json-responsehandler.php
+++ b/lib/class-wp-json-responsehandler.php
@@ -1,0 +1,45 @@
+<?php
+
+interface WP_JSON_ResponseHandler {
+	/**
+	 * Send a HTTP status code
+	 *
+	 * @param int $code HTTP status
+	 */
+	public function send_status( $code );
+
+	/**
+	 * Send a HTTP header
+	 *
+	 * @param string $key Header key
+	 * @param string $value Header value
+	 * @param boolean $replace Should we replace the existing header?
+	 */
+	public function header( $key, $value, $replace = true );
+
+	/**
+	 * Send a Link header
+	 *
+	 * @link http://tools.ietf.org/html/rfc5988
+	 * @link http://www.iana.org/assignments/link-relations/link-relations.xml
+	 *
+	 * @param string $rel Link relation. Either a registered type, or an absolute URL
+	 * @param string $link Target IRI for the link
+	 * @param array $other Other parameters to send, as an assocative array
+	 */
+	public function link_header( $rel, $link, $other = array() );
+
+	/**
+	 * Send navigation-related headers for post collections
+	 *
+	 * @param WP_Query $query
+	 */
+	public function query_navigation_headers( $query );
+
+	/**
+	 * Retrieve the raw request entity (body)
+	 *
+	 * @return string
+	 */
+	public function get_raw_data();
+}

--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -15,7 +15,7 @@ require_once ABSPATH . 'wp-admin/includes/admin.php';
  *
  * @package WordPress
  */
-class WP_JSON_Server {
+class WP_JSON_Server implements WP_JSON_ResponseHandler {
 	const METHOD_GET    = 1;
 	const METHOD_POST   = 2;
 	const METHOD_PUT    = 4;

--- a/plugin.php
+++ b/plugin.php
@@ -7,6 +7,7 @@
  * Version: 0.6
  * Plugin URI: https://github.com/rmccue/WP-API
  */
+include_once( dirname( __FILE__ ) . '/lib/class-wp-json-responsehandler.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-posts.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-customposttype.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-pages.php' );
@@ -30,20 +31,20 @@ add_action( 'init', 'json_api_init' );
  *
  * @internal This will live in default-filters.php
  */
-function json_api_default_filters() {
+function json_api_default_filters($server) {
 	global $wp_json_posts, $wp_json_pages, $wp_json_media, $wp_json_taxonomies;
 
 	// Posts
-	$wp_json_posts = new WP_JSON_Posts();
+	$wp_json_posts = new WP_JSON_Posts($server);
 	add_filter( 'json_endpoints', array( $wp_json_posts, 'registerRoutes' ), 0 );
 
 	// Pages
-	$wp_json_pages = new WP_JSON_Pages();
+	$wp_json_pages = new WP_JSON_Pages($server);
 	add_filter( 'json_endpoints', array( $wp_json_pages, 'registerRoutes' ), 1 );
 	add_filter( 'json_post_type_data', array( $wp_json_pages, 'type_archive_link' ), 10, 2 );
 
 	// Media
-	$wp_json_media = new WP_JSON_Media();
+	$wp_json_media = new WP_JSON_Media($server);
 	add_filter( 'json_endpoints',       array( $wp_json_media, 'registerRoutes' ), 1 );
 	add_filter( 'json_prepare_post',    array( $wp_json_media, 'addThumbnailData' ), 10, 3 );
 	add_filter( 'json_pre_insert_post', array( $wp_json_media, 'preinsertCheck' ),   10, 3 );
@@ -51,12 +52,12 @@ function json_api_default_filters() {
 	add_filter( 'json_post_type_data',  array( $wp_json_media, 'type_archive_link' ), 10, 2 );
 
 	// Posts
-	$wp_json_taxonomies = new WP_JSON_Taxonomies();
+	$wp_json_taxonomies = new WP_JSON_Taxonomies($server);
 	add_filter( 'json_endpoints',      array( $wp_json_taxonomies, 'registerRoutes' ), 2 );
 	add_filter( 'json_post_type_data', array( $wp_json_taxonomies, 'add_taxonomy_data' ), 10, 2 );
 	add_filter( 'json_prepare_post',   array( $wp_json_taxonomies, 'add_term_data' ), 10, 3 );
 }
-add_action( 'plugins_loaded', 'json_api_default_filters' );
+add_action( 'wp_json_server_before_serve', 'json_api_default_filters', 10, 1 );
 
 /**
  * Load the JSON API
@@ -89,6 +90,17 @@ function json_api_loaded() {
 	// Allow for a plugin to insert a different class to handle requests.
 	$wp_json_server_class = apply_filters('wp_json_server_class', 'WP_JSON_Server');
 	$wp_json_server = new $wp_json_server_class;
+
+	/**
+	 * Prepare to serve an API request.
+	 *
+	 * Endpoint objects should be created and register their hooks on this
+	 * action rather than another action to ensure they're only loaded when
+	 * needed.
+	 *
+	 * @param WP_JSON_ResponseHandler $wp_json_server Response handler object
+	 */
+	do_action('wp_json_server_before_serve', $wp_json_server);
 
 	// Fire off the request
 	$wp_json_server->serve_request( $GLOBALS['wp']->query_vars['json_route'] );


### PR DESCRIPTION
This avoids using the global $wp_json_server, which helps with internal routing
and usage of the API functions.
