### PR TITLE
Undefined index errors for /wp-json.php/posts/POST_ID/comments

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1030,7 +1030,7 @@ class WP_JSON_Posts {
 		$date = DateTime::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date, $timezone );
 		$fields['date'] = $date->format( 'c' );
 		$fields['date_tz'] = $date->format( 'e' );
-		$fields['date_gmt'] = date( 'c', strtotime( $post->comment_date_gmt ) );
+		$fields['date_gmt'] = date( 'c', strtotime( $comment->comment_date_gmt ) );
 
 		// Meta
 		$meta = array(


### PR DESCRIPTION
Fixes the first issue described on GSoC #382: http://gsoc.trac.wordpress.org/ticket/382

There are undefined index errors thrown in the prepare_comment() function due to $post never being defined.

There is also an instance of `$post->comment_date_gm`t that is supposed to be `$comment->comment_date_gmt`.

Adding `$post = (array) get_post( $fields['post'] );` at line 966 of class=wp-json-posts.php fixes the undefined index.

And changing line 1033 of class-wp-json-posts.php from`$fields['date_gmt'] = date( 'c', strtotime( $post->comment_date_gmt ) );` to `$fields['date_gmt'] = date( 'c', strtotime( $comment->comment_date_gmt ) );` fixes the second issue.
