### PR TITLE
Preparing meta using get_post_meta

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -575,7 +575,7 @@ class WP_JSON_Posts {
 			return new WP_Error( 'json_cannot_edit', __( 'Sorry, you cannot edit this post' ), array( 'status' => 403 ) );
 
 		// Post meta
-		$_post['post_meta'] = $this->ta( $post['ID'] );
+		$_post['post_meta'] = $this->prepare_meta( $post['ID'] );
 
 		// Entity meta
 		$_post['meta'] = array(


### PR DESCRIPTION
Maybe it's better to use get_post_meta instead has_meta, as this way we make use of the caching system. And i don't think the meta id is relevant in any way
