### PR TITLE
Add term_link to prepare_term

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -191,7 +191,7 @@ class WP_JSON_Taxonomies {
 			'slug'   => $term->slug,
 			'parent' => (int) $term->parent,
 			'count'  => (int) $term->count,
-			'link'   => get_term_link($term, $term->taxonomy),
+			'link'   => get_term_link( $term, $term->taxonomy ),
 			'meta'   => array(
 				'links' => array(
 					'collection' => json_url( $base_url ),


### PR DESCRIPTION
Maybe it's a good idea to add the term_link to term data, as we can't get it in any other way. Or there is another way?
