### PR TITLE
Plugin breaks for titles with newlines

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -476,6 +476,11 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 	 * @param boolean $replace Should we replace the existing header?
 	 */
 	public function header( $key, $value, $replace = true ) {
+		// Sanitize as per RFC2616 (Section 4.2):
+		//   Any LWS that occurs between field-content MAY be replaced with a
+		//   single SP before interpreting the field value or forwarding the
+		//   message downstream.
+		$value = preg_replace( '/\s+/', ' ', $value );
 		header( sprintf( '%s: %s', $key, $value ), $replace );
 	}
 


### PR DESCRIPTION
I'm trying to get a bunch of posts from a custom post type, but when i do i get an error message in php, destroying the JSON.

```
Warning: Header may not contain more than a single header, new line detected in *redacted*/wp-content/plugins/json-rest-api/lib/class-wp-json-server.php on line 436
```

Relevant part of the returned headers

```
Pragma: no-cache
Link: Link: </wp-json.php/posts?type=instagram&filter%5Boffset%5D=0&filter%5Borderby%5D=title&page=2>; rel="next"
X-WP-Total: 62
X-WP-TotalPages: 7
Last-Modified: Thu, 10 Oct 2013 09:57:40 GMT
Link: Link: <*redacted*/wp-json.php/posts/132>; rel="item"; title="☺️#school#love#gerls#best#lol#sweet#smile#snow#today#learning#sandess#favorite#all#in#skirts"
Link: Link: <*redacted*/wp-json.php/posts/108>; rel="item"; title="อ้วนจริงจริงเลอออ อยากผอม อยากสวย อยากสูง คงทำได้เพียง #มโน ต่อไป555"
Link: Link: <*redacted*/wp-json.php/posts/151>; rel="item"; title="สุขสันต์วันเกิดครับแม่ ลูกจะเป็นเด็กดี รักแม่ที่สุดครับ &lt;3 @nidnoi_waranya"
Link: Link: <*redacted*/wp-json.php/posts/102>; rel="item"; title="Почти первый снег и предпоследний дождь❄️☔️#snow #clouds #rain #autumn #october #cold"
Link: Link: <*redacted*/wp-json.php/posts/120>; rel="item"; title="И норм#снег#snow#Niznevartovsk"
Link: Link: <*redacted*/wp-json.php/posts/121>; rel="item"; title="И норм#снег#snow#Niznevartovsk"
Link: Link: <*redacted*/wp-json.php/posts/111>; rel="item"; title="Всегда говорите,что чувствуете и делайте то,что думаете,молчание ломает судьбы"
Link: Link: <*redacted*/wp-json.php/posts/115>; rel="item"; title="The snow is coming. #YAY #snow #switzerland"
Link: Link: <*redacted*/wp-json.php/posts/138>; rel="item"; title="THE KING OF KINGS"
```

The requested url is as follows
_redacted_/wp-json.php/posts?type=instagram&filter[offset]=0&filter[orderby]=title

The data is just some dummy data from instagram that we create a custom post type for.

It seems that if the title contains newline characters the plugin breaks. 

I believe the plugin should be able to handle it because you can so easily add newline characters in the title with wp_insert_post or any other standard way. 

The filter that removes them only run when you display a title, not when you insert them.
