### PR TITLE
Remove redundant WP_JSON_Pages::type_archive_link()

### DIFF
--- a/lib/class-wp-json-pages.php
+++ b/lib/class-wp-json-pages.php
@@ -114,20 +114,4 @@ class WP_JSON_Pages extends WP_JSON_CustomPostType {
 
 		return apply_filters( 'json_prepare_page', $_post, $post, $context );
 	}
-
-	/**
-	 * Filter the post type archive link
-	 *
-	 * @param array $data Post type data
-	 * @param stdClass $type Internal post type data
-	 * @return array Filtered data
-	 */
-	public function type_archive_link( $data, $type ) {
-		if ( $type->name !== 'page' ) {
-			return $data;
-		}
-
-		$data['meta']['links']['archives'] = json_url( '/pages' );
-		return $data;
-	}
 }


### PR DESCRIPTION
The `WP_JSON_Pages::type_archive_link()` function is identical to the [`WP_JSON_CustomPostType::type_archive_link()` function](https://github.com/WP-API/WP-API/blob/f3ea834f857adf1fd6089ba2b4ccda94c36cbb7a/lib/class-wp-json-customposttype.php#L207:L214), so it can be removed.
