### PR TITLE
Remove redundant filters

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -44,8 +44,6 @@ function json_api_default_filters($server) {
 
 	// Pages
 	$wp_json_pages = new WP_JSON_Pages($server);
-	add_filter( 'json_endpoints', array( $wp_json_pages, 'registerRoutes' ), 1 );
-	add_filter( 'json_post_type_data', array( $wp_json_pages, 'type_archive_link' ), 10, 2 );
 
 	// Media
 	$wp_json_media = new WP_JSON_Media($server);


### PR DESCRIPTION
The JSON REST API plugin hooks `WP_JSON_Pages::registerRoutes()` to the `'json_endpoints'` filter and `WP_JSON_Pages::type_archive_link()` to the `'json_post_type_data'` filter.

This is unnecessary as `WP_JSON_CustomPostType` already [hooks these functions to those filters](https://github.com/WP-API/WP-API/blob/5dfce405e8c84adf6e9491775eff22fe53725e21/lib/class-wp-json-customposttype.php#L41:L42) in its constructor and `WP_JSON_Pages` extends `WP_JSON_CustomPostType`.
