### PR TITLE
Post Author != logged in user Check in insert_post wrong...

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -787,11 +787,13 @@ class WP_JSON_Posts {
 				if ( ! current_user_can( $post_type->cap->edit_others_posts ) )
 					return new WP_Error( 'json_cannot_edit_others', __( 'You are not allowed to edit posts as this user.' ), array( 'status' => 401 ) );
 
-				$author = get_userdata( $post['post_author'] );
+				$author = get_userdata( $data['author'] );
 
 				if ( ! $author )
 					return new WP_Error( 'json_invalid_author', __( 'Invalid author ID.' ), array( 'status' => 400 ) );
 			}
+
+			$post['post_author'] = $data['author'];
 		}
 
 		// Post password


### PR DESCRIPTION
Hi!

In Line 790 of /lib/class-wp-json-posts.php (protected function insert_post), the userdata of a user != logged in user should be fetched and checked if it exists:

$author = get_userdata( $post['post_author'] );

As $post['post_author'] at this time is set to 0, there is always an error.
I think, this line should read

$author = get_userdata( $data['author'] );

as this is the correct User ID for the to post to be inserted.

Also, there should be a line

$post['post_author'] = $data['author'];

after the check (Line 534).

Regards,
Kuchen und Kakao
