### PR TITLE
Add response object

### DIFF
--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -236,9 +236,8 @@ class WP_JSON_Media extends WP_JSON_Posts {
 			wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $file ) );
 		}
 
-		$this->server->send_status( 201 );
-		$this->server->header( 'Location', json_url( '/media/' . $id ) );
-		return $this->getPost( $id, 'edit' );
+		$headers = array( 'Location' => json_url( '/media/' . $id ) );
+		return new WP_JSON_Response( $this->getPost( $id, 'edit' ), 201, $headers );
 	}
 
 	/**

--- a/lib/class-wp-json-response.php
+++ b/lib/class-wp-json-response.php
@@ -1,0 +1,155 @@
+<?php
+
+class WP_JSON_Response implements WP_JSON_ResponseInterface {
+	/**
+	 * Constructor
+	 *
+	 * @param mixed $data Response data
+	 * @param integer $status HTTP status code
+	 * @param array $headers HTTP header map
+	 */
+	public function __construct($data = null, $status = 200, $headers = array()) {
+		$this->data = $data;
+		$this->set_status( $status );
+		$this->set_headers( $headers );
+	}
+
+	/**
+	 * Get headers associated with the response
+	 *
+	 * @return array Map of header name to header value
+	 */
+	public function get_headers() {
+		return $this->headers;
+	}
+
+	/**
+	 * Set all header values
+	 *
+	 * @param array $headers Map of header name to header value
+	 */
+	public function set_headers($headers) {
+		$this->headers = $headers;
+	}
+
+	/**
+	 * Set a single HTTP header
+	 *
+	 * @param string $key Header name
+	 * @param string $value Header value
+	 * @param boolean $replace Replace an existing header of the same name?
+	 */
+	public function header($key, $value, $replace = true) {
+		if ( $replace || ! isset( $this->headers[ $key ] ) ) {
+			$this->headers[ $key ] = $value;
+		}
+		else {
+			$this->headers[ $key ] .= ', ' . $value;
+		}
+	}
+
+	/**
+	 * Set a single link header
+	 *
+	 * @internal The $rel parameter is first, as this looks nicer when sending multiple
+	 *
+	 * @link http://tools.ietf.org/html/rfc5988
+	 * @link http://www.iana.org/assignments/link-relations/link-relations.xml
+	 *
+	 * @param string $rel Link relation. Either an IANA registered type, or an absolute URL
+	 * @param string $link Target IRI for the link
+	 * @param array $other Other parameters to send, as an assocative array
+	 */
+	public function link_header( $rel, $link, $other = array() ) {
+		$header = '<' . $link . '>; rel="' . $rel . '"';
+		foreach ( $other as $key => $value ) {
+			if ( 'title' == $key )
+				$value = '"' . $value . '"';
+			$header .= '; ' . $key . '=' . $value;
+		}
+		return $this->header( 'Link', $header, false );
+	}
+
+	/**
+	 * Send navigation-related headers for post collections
+	 *
+	 * @param WP_Query $query
+	 */
+	public function query_navigation_headers( $query ) {
+		$max_page = $query->max_num_pages;
+		$paged = $query->get('paged');
+
+		if ( !$paged )
+			$paged = 1;
+
+		$nextpage = intval($paged) + 1;
+
+		if ( ! $query->is_single() ) {
+			if ( $paged > 1 ) {
+				$request = remove_query_arg( 'page' );
+				$request = add_query_arg( 'page', $paged - 1, $request );
+				$this->link_header( 'prev', $request );
+			}
+
+			if ( $nextpage <= $max_page ) {
+				$request = remove_query_arg( 'page' );
+				$request = add_query_arg( 'page', $nextpage, $request );
+				$this->link_header( 'next', $request );
+			}
+		}
+
+		$this->header( 'X-WP-Total', $query->found_posts );
+		$this->header( 'X-WP-TotalPages', $max_page );
+
+		do_action('json_query_navigation_headers', $this, $query);
+	}
+
+	/**
+	 * Get the HTTP return code for the response
+	 *
+	 * @return integer 3-digit HTTP status code
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+	/**
+	 * Set the HTTP status code
+	 *
+	 * @param int $code HTTP status
+	 */
+	public function set_status( $code ) {
+		$this->status = absint( $code );
+	}
+
+	/**
+	 * Get the response data
+	 *
+	 * @return mixed
+	 */
+	public function get_data() {
+		return $this->data;
+	}
+
+	/**
+	 * Set the response data
+	 *
+	 * @param mixed $data
+	 */
+	public function set_data( $data ) {
+		$this->data = $data;
+	}
+
+	/**
+	 * Get the response data for JSON serialization
+	 *
+	 * It is expected that in most implementations, this will return the same as
+	 * {@see get_data()}, however this may be different if you want to do custom
+	 * JSON data handling.
+	 *
+	 * @return mixed Any JSON-serializable value
+	 */
+	public function jsonSerialize() {
+		return $this->get_data();
+	}
+}

--- a/lib/class-wp-json-responseinterface.php
+++ b/lib/class-wp-json-responseinterface.php
@@ -1,0 +1,35 @@
+<?php
+
+interface WP_JSON_ResponseInterface extends JsonSerializable {
+	/**
+	 * Get headers associated with the response
+	 *
+	 * @return array Map of header name to header value
+	 */
+	public function get_headers();
+
+	/**
+	 * Get the HTTP return code for the response
+	 *
+	 * @return integer 3-digit HTTP status code
+	 */
+	public function get_status();
+
+	/**
+	 * Get the response data
+	 *
+	 * @return mixed
+	 */
+	public function get_data();
+
+	/**
+	 * Get the response data for JSON serialization
+	 *
+	 * It is expected that in most implementations, this will return the same as
+	 * {@see get_data()}, however this may be different if you want to do custom
+	 * JSON data handling.
+	 *
+	 * @return mixed Any JSON-serializable value
+	 */
+	public function jsonSerialize();
+}

--- a/plugin.php
+++ b/plugin.php
@@ -10,6 +10,9 @@
 include_once( dirname( __FILE__ ) . '/lib/class-jsonserializable.php' );
 
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-responsehandler.php' );
+include_once( dirname( __FILE__ ) . '/lib/class-wp-json-responseinterface.php' );
+include_once( dirname( __FILE__ ) . '/lib/class-wp-json-response.php' );
+
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-posts.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-customposttype.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-pages.php' );


### PR DESCRIPTION
Setting response data directly via the server acts like a form of global state. It makes it much harder to embed requests in each other (e.g. `/post/2` embeds a call for its post parent to `/post/1`), since the headers are always sent. This is a little crappy, since the API is designed to be composible, and this is standing in the way of that.

However, we don't want this to be overly complicated to use. The benefit of returning raw data is you can work with it easily.
## Proposal
- A new `WP_JSON_ResponseInterface` interface which can be returned from any endpoint with the following methods:
  - `get_headers()` - Returns an array of headers which can be sent
  - `get_status()` - Returns an integer code for HTTP response status
  - `get_data()` - Returns whatever data it's encapsulating
  - `jsonSerialize()` - A wrapper to call `get_data()` in most cases, allowing this interface to work right off the bat after #24 is merged, without changing the server classes
- A new `WP_JSON_Response` class which implements `WP_JSON_ResponseInterface` and adds the following methods:
  - `__construct($data, $status = 200, $headers = array())`
  - `header($key, $value, $replace = true)` - Set a single header (replaces `WP_JSON_Server::header()`)
  - `link_header($rel, $link, $other = array())` - Set a single link header (replaces `WP_JSON_Server::link_header()`)
  - `set_headers($headers)` - Set all headers
  - `set_status($code)` - Set the status code (replaces `WP_JSON_Server::send_status`)

After #24 is merged, this can be dropped in with no changes, but will only send the data. We can then work on moving all the status/header **setting** code to the response object, and the **sending** code to the server.
## Bad Parts
- Makes it slightly harder to use the response (you have to use `$response->get_data()` instead of just `$response`) - On the other hand: You can now access extra data that you couldn't before (status/headers)
- We still need special handling for `WP_Error` - Maybe someday `WP_Error` can extend `WP_JSON_ResponseInterface` :thought_balloon:

Further feedback much appreciated.
