### PR TITLE
API discovery ala RSD

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -143,6 +143,45 @@ function json_register_scripts() {
 add_action( 'wp_enqueue_scripts', 'json_register_scripts', -100 );
 
 /**
+ * Add the API URL to the WP RSD endpoint
+ */
+function json_output_rsd() {
+?>
+	<api name="WP-API" blogID="1" preferred="false" apiLink="<?php echo get_json_url() ?>" />
+<?php
+}
+add_action( 'xmlrpc_rsd_apis', 'json_output_rsd' );
+
+/**
+ * Output API link tag into page header
+ */
+function json_output_link_wp_head() {
+	$api_root = get_json_url();
+
+	if ( empty( $api_root ) )
+		return;
+
+	echo "<link rel='https://github.com/WP-API/WP-API' href='" . esc_url( $api_root ) . "' />\n";
+}
+add_action( 'wp_head', 'json_output_link_wp_head', 10, 0 );
+
+/**
+ * Send a Link header for the API
+ */
+function json_output_link_header() {
+	if ( headers_sent() )
+		return;
+
+	$api_root = get_json_url();
+
+	if ( empty($api_root) )
+		return;
+
+	header('Link: <' . $api_root . '>; rel="https://github.com/WP-API/WP-API"', false);
+}
+add_action( 'template_redirect', 'json_output_link_header', 11, 0 );
+
+/**
  * Get URL to a JSON endpoint on a site
  *
  * @todo Check if this is even necessary


### PR DESCRIPTION
As a developer of API clients, I'd really love a proper API discovery mechanism for WP-API. The XML-RPC API uses RSD, which allows clients to do an algorithm like:
1. Ask user for their blog URL
2. `GET` that URL and find the `<link rel="EditURI" .../>` tag.
3. Extract the `href` from that `<link>` and `GET` it.
4. Parse the RSD file to determine which endpoints are supported and preferred.

Of course, sometimes overzealous theme authors will strip this default `<link>` tag and we have to fallback to blindly checking `/xmlrpc.php?rsd`, but fortunately that's not too common.

My recommendation is that WP-API do (at least) one of the following:
1. Add itself to the existing RSD file. This makes it easy for existing XML-RPC clients to "upgrade" to the JSON API when available, though it still means dealing with XML which is a pain.
2. Add a new `<link>` tag to the blog `<head>` that clients can look for.
3. Send a new HTTP header on WP page responses with the path to the API
4. ???

Blindly searching for `/wp-json.php` or some rewrite-rule variant should really be avoided if at all possible.
