### PR TITLE
Added unit testing skeleton with mostly stubbed server tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+# Travis CI Configuration File
+
+# Tell Travis CI we're using PHP
+language: php
+
+# PHP version used in first build configuration.
+php:
+    - "5.5"
+
+# WordPress version used in first build configuration.
+env:
+    - WP_VERSION=master
+
+# Next we define our matrix of additional build configurations to test against.
+# The versions listed above will automatically create our first configuration,
+# so it doesn't need to be re-defined below.
+
+# WP_VERSION specifies the tag to use. The way these tests are configured to run
+# requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
+
+# Note that Travis CI supports listing these above to automatically build a
+# matrix of configurations, but we're being nice here by manually building a
+# total of four configurations even though we're testing 4 versions of PHP
+# along with 2 versions of WordPress (which would build 8 configs otherwise).
+# This takes half as long to run while still providing adequate coverage.
+
+matrix:
+  include:
+    - php: "5.3"
+      env: WP_VERSION=master
+    - php: "5.4"
+      env: WP_VERSION=3.8
+    - php: "5.2"
+      env: WP_VERSION=3.8
+
+# Clones WordPress and configures our testing environment.
+before_script:
+    - export PLUGIN_SLUG=$(basename $(pwd))
+    - git clone https://github.com/tierra/wordpress.git /tmp/wordpress
+    - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    - cd /tmp/wordpress
+    - git checkout $WP_VERSION
+    - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    - cp wp-tests-config-sample.php wp-tests-config.php
+    - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    - sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    - sed -i "s/yourpasswordhere//" wp-tests-config.php
+    - cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+
+script: phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true">
+    <testsuites>
+        <!-- Default test suite to run all tests -->
+        <testsuite>
+            <directory prefix="test_" suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/plugin.php
+++ b/plugin.php
@@ -67,6 +67,11 @@ add_action( 'wp_json_server_before_serve', 'json_api_default_filters', 10, 1 );
 
 /**
  * Load the JSON API
+ *
+ * @todo Extract code that should be unit tested into isolated methods such as
+ *       the wp_json_server_class filter and serving requests. This would also
+ *       help for code re-use by wp-json.php endpoint. Note that we can't unit
+ *       test any method that calls die().
  */
 function json_api_loaded() {
 	if ( empty( $GLOBALS['wp']->query_vars['json_route'] ) )

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Bootstrap the plugin unit testing environment.
+ *
+ * @package WordPress
+ * @subpackage JSON API
+ */
+
+// Activates this plugin in WordPress so it can be tested.
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( 'WP-API/plugin.php' ),
+);
+
+// If the develop repo location is defined (as WP_DEVELOP_DIR), use that
+// location. Otherwise, we'll just assume that this plugin is installed in a
+// WordPress develop SVN checkout.
+
+if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
+	require getenv( 'WP_DEVELOP_DIR' ) . '/tests/phpunit/includes/bootstrap.php';
+} else {
+	require '../../../../tests/phpunit/includes/bootstrap.php';
+}

--- a/tests/test_json_plugin.php
+++ b/tests/test_json_plugin.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Base plugin tests to ensure the JSON API is loaded correctly. These will
+ * likely need the most changes when merged into core.
+ *
+ * @group json_api
+ *
+ * @package WordPress
+ * @subpackage JSON API
+ */
+class WP_Test_JSON_Plugin extends WP_UnitTestCase {
+
+	/**
+	 * If these tests are being run on Travis CI, verify that the version of
+	 * WordPress installed is the version that we requested.
+	 *
+	 * @requires PHP 5.3
+	 */
+	function test_wp_version() {
+		if ( !getenv( 'TRAVIS' ) )
+			$this->markTestSkipped( 'Travis CI was not detected.' );
+
+		$requested_version = getenv( 'WP_VERSION' ) . '-src';
+
+		// The "master" version requires special handling.
+		if ( $requested_version == 'master-src' ) {
+			$file = file_get_contents( 'https://raw.github.com/tierra/wordpress/master/src/wp-includes/version.php' );
+			preg_match( '#\$wp_version = \'([^\']+)\';#', $file, $matches );
+			$requested_version = $matches[1];
+		}
+
+		$this->assertEquals( get_bloginfo( 'version' ), $requested_version );
+	}
+
+	/**
+	 * The plugin should be installed and activated.
+	 */
+	function test_plugin_activated() {
+		$this->assertTrue( is_plugin_active( 'WP-API/plugin.php' ) );
+	}
+
+	/**
+	 * The json_api_init hook should have been registered with init, and should
+	 * have a default priority of 10.
+	 */
+	function test_init_action_added() {
+		$this->assertEquals( 10, has_action( 'init', 'json_api_init' ) );
+	}
+
+	/**
+	 * The json_route query variable should be registered.
+	 */
+	function test_json_route_query_var() {
+		global $wp;
+		$this->assertTrue( in_array( 'json_route', $wp->public_query_vars ) );
+	}
+
+}

--- a/tests/test_json_server.php
+++ b/tests/test_json_server.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Unit tests covering WP_JSON_Server functionality.
+ *
+ * @todo Do we bother testing serve_request() or leave that for client tests?
+ *       It might be nice to at least test JSONP support here.
+ *
+ * @group json_api
+ *
+ * @package WordPress
+ * @subpackage JSON API
+ */
+class WP_Test_JSON_Server extends WP_UnitTestCase {
+
+	/**
+	 * Create WP_JSON_Server class instance for use with tests.
+	 *
+	 * @todo Use core method for fetching filtered WP_JSON_Server class when
+	 *       it's available. Ideally, we shouldn't be filtering ourselves here.
+	 */
+	function setUp() {
+		global $wp_json_server;
+
+		parent::setUp();
+
+		include_once( ABSPATH . WPINC . '/class-IXR.php' );
+		include_once( ABSPATH . WPINC . '/class-wp-xmlrpc-server.php' );
+		include_once( plugin_dir_path( dirname( __FILE__ ) ) . 'lib/class-wp-json-server.php' );
+
+		// Allow for a plugin to insert a different class to handle requests.
+		$wp_json_server_class = apply_filters('wp_json_server_class', 'WP_JSON_Server');
+		$wp_json_server = new $wp_json_server_class;
+	}
+
+	/**
+	 * The server should be able to authenticate users using basic auth.
+	 */
+	function test_valid_basic_auth() {
+		global $wp_json_server;
+
+		$user_id = $this->factory->user->create( array(
+			'user_login' => 'basic_auth',
+			'user_pass' => 'basic_auth'
+		) );
+
+		$_SERVER['PHP_AUTH_USER'] = 'basic_auth';
+		$_SERVER['PHP_AUTH_PW'] = 'basic_auth';
+
+		$result = $wp_json_server->check_authentication();
+		$this->assertTrue( $result instanceof WP_User );
+
+		unset( $_SERVER['PHP_AUTH_USER'] );
+		unset( $_SERVER['PHP_AUTH_PW'] );
+	}
+
+	/**
+	 * Errors should convert to arrays cleanly.
+	 */
+	function test_error_to_array() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Test the format of errors encoded to json.
+	 */
+	function test_json_error() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * The default routes should contain all valid callbacks. This test mostly
+	 * ensures that a set of valid routes have been properly defined.
+	 */
+	function test_get_routes() {
+		// NB: I'd mostly iterate over all endpoints, checking for is_callable(),
+		//     and dispatch() does this check, but that's only at runtime, but
+		//     you could use that as a template for this test.
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Ensure the dispatcher calls valid routes with the appropriate method.
+	 */
+	function test_dispatch() {
+		// NB: The dispatcher makes use of get_raw_data() which may not work
+		//     properly with unit tests, so that might need a workaround.
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Test sort_callback_params().
+	 *
+	 * @todo This should probably be broken out into a few unique tests with
+	 *       various methods with different reflection properties.
+	 */
+	function test_sort_callback_params() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Test for valid link header format.
+	 *
+	 * @todo This will likely require some changes to $server->header() so it's
+	 *       possible to actually write unit tests for headers.
+	 */
+	function test_link_header() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Ensure pagination link headers work properly with valid page counts.
+	 */
+	function test_query_navigation_headers() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Objects passed through prepare_response() should be expanded to arrays.
+	 */
+	function test_prepare_response() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * JsonSerializable data passed through prepare_response() should be
+	 * expanded properly.
+	 */
+	function test_json_serializable() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+	/**
+	 * Test if local RFC3339 dates are converted to MySQL datetimes with the
+	 * appropriate GMT timezone.
+	 */
+	function test_get_date_with_gmt() {
+		$this->markTestIncomplete('Missing test implementation.');
+	}
+
+}


### PR DESCRIPTION
This is a start to resolving #6 with a skeleton set of unit tests, but certainly needs a lot more love.

I've mostly outlined what I think is probably a good set of minimal tests for WP_JSON_Server at least. I'll be sure to also jump into CTP, Media, Pages, Posts, ResponseHandler, and Taxonomies later here.

Some notes:
- The Travis CI configuration uses my personal mirror of the develop repo (since there still isn't an official one), but really just because it's more work to deal with the logic of checking out SVN trunk versus tags for specific versions. This shouldn't matter though since this is a temporary setup that would be removed when merged to core.
- I've left a bunch of notes in the inline comments in numerous locations and todos. Since it's mostly stubbed, they're probably better off there for when someone (not just myself) gets around to writing these tests.
- The instructions for running the unit tests locally are simple: checkout develop.svn (or use my git mirror as well), configure the core unit tests as usual (wp-tests-config.php in root), install WP-API into `src/wp-content/plugins`, and run `phpunit` from the plugin directory. See [tierra/wordpress-plugin-tests](https://github.com/tierra/wordpress-plugin-tests) for more details if you like.
