### PR TITLE
Workaround for createFromFormat on PHP > 5.2

### DIFF
--- a/lib/class-wp-json-datetime.php
+++ b/lib/class-wp-json-datetime.php
@@ -1,0 +1,21 @@
+<?php
+class WP_JSON_DateTime extends DateTime
+{
+    /**
+     * Workaround for DateTime::createFromFormat on PHP > 5.2
+     * Found on http://stackoverflow.com/a/17084893/717643
+     *
+     * @param  string       $format   The format that the passed in string should be in.
+     * @param  string       $string   String representing the time.
+     * @param  DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+     * @return Datetime
+     */
+    public static function createFromFormat($format, $time, $timezone = null)
+    {
+        if ( method_exists('DateTime', 'createFromFormat') ) {
+            return parent::createFromFormat($format, $time, $timezone);
+        }
+
+        return new DateTime(date($format, strtotime($time)), $timezone);
+    }
+}

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -299,7 +299,7 @@ class WP_JSON_Posts {
 			// and C's asctime() format (and ignore invalid headers)
 			$formats = array( DateTime::RFC1123, DateTime::RFC1036, 'D M j H:i:s Y' );
 			foreach ( $formats as $format ) {
-				$check = DateTime::createFromFormat( $format, $_headers['IF_UNMODIFIED_SINCE'] );
+				$check = WP_JSON_DateTime::createFromFormat( $format, $_headers['IF_UNMODIFIED_SINCE'] );
 
 				if ( $check !== false )
 					break;
@@ -533,12 +533,12 @@ class WP_JSON_Posts {
 		// Dates
 		$timezone = $this->server->get_timezone();
 
-		$date = DateTime::createFromFormat( 'Y-m-d H:i:s', $post['post_date'], $timezone );
+		$date = WP_JSON_DateTime::createFromFormat( 'Y-m-d H:i:s', $post['post_date'], $timezone );
 		$post_fields['date'] = $date->format( 'c' );
 		$post_fields_extended['date_tz'] = $date->format( 'e' );
 		$post_fields_extended['date_gmt'] = date( 'c', strtotime( $post['post_date_gmt'] ) );
 
-		$modified = DateTime::createFromFormat( 'Y-m-d H:i:s', $post['post_modified'], $timezone );
+		$modified = WP_JSON_DateTime::createFromFormat( 'Y-m-d H:i:s', $post['post_modified'], $timezone );
 		$post_fields['modified'] = $modified->format( 'c' );
 		$post_fields_extended['modified_tz'] = $modified->format( 'e' );
 		$post_fields_extended['modified_gmt'] = date( 'c', strtotime( $post['post_modified_gmt'] ) );
@@ -895,7 +895,7 @@ class WP_JSON_Posts {
 		if ( strpos( $date, '.' ) !== false ) {
 			$date = preg_replace( '/\.\d+/', '', $date );
 		}
-		$datetime = DateTime::createFromFormat( DateTime::RFC3339, $date );
+		$datetime = WP_JSON_DateTime::createFromFormat( DateTime::RFC3339, $date );
 
 		return $datetime;
 	}
@@ -997,7 +997,7 @@ class WP_JSON_Posts {
 		// Date
 		$timezone = $this->server->get_timezone();
 
-		$date = DateTime::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date, $timezone );
+		$date = WP_JSON_DateTime::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date, $timezone );
 		$fields['date'] = $date->format( 'c' );
 		$fields['date_tz'] = $date->format( 'e' );
 		$fields['date_gmt'] = date( 'c', strtotime( $comment->comment_date_gmt ) );

--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -700,7 +700,7 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 		if ( strpos( $date, '.' ) !== false ) {
 			$date = preg_replace( '/\.\d+/', '', $date );
 		}
-		$datetime = DateTime::createFromFormat( DateTime::RFC3339, $date );
+		$datetime = WP_JSON_DateTime::createFromFormat( DateTime::RFC3339, $date );
 
 		return $datetime;
 	}

--- a/lib/wp-json.php
+++ b/lib/wp-json.php
@@ -26,6 +26,7 @@ include('./wp-load.php');
 include_once(ABSPATH . 'wp-admin/includes/admin.php');
 include_once(ABSPATH . WPINC . '/class-IXR.php');
 include_once(ABSPATH . WPINC . '/class-wp-xmlrpc-server.php');
+include_once(ABSPATH . WPINC . '/class-wp-json-datetime.php');
 include_once(ABSPATH . WPINC . '/class-wp-json-server.php');
 
 // Allow for a plugin to insert a different class to handle requests.

--- a/plugin.php
+++ b/plugin.php
@@ -9,6 +9,8 @@
  */
 include_once( dirname( __FILE__ ) . '/lib/class-jsonserializable.php' );
 
+include_once( dirname( __FILE__ ) . '/lib/class-wp-json-datetime.php' );
+
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-responsehandler.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-responseinterface.php' );
 include_once( dirname( __FILE__ ) . '/lib/class-wp-json-response.php' );


### PR DESCRIPTION
Not sure if a new class extending DateTime is the better choice for this, but since DateTime::createFromFormat is only used on two files I think it works fine.

I haven't tested all the cases where it's used, but on those where I test seems to work. On this ( http://3v4l.org/P1Kii ) fiddle it seems to return the same output on all PHP versions > 5.2
