### PR TITLE
Fix travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
     - export PLUGIN_SLUG=$(basename $(pwd))
     - git clone git://develop.git.wordpress.org/ /tmp/wordpress
     - mkdir "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    - cp -r . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG/"
     - cd /tmp/wordpress
     - git checkout $WP_VERSION
     - mysql -e "CREATE DATABASE wordpress_tests;" -uroot


### PR DESCRIPTION
Travis-CI builds are returning an error about not being able to clone the repo into the plugins folder, I wasn't able to reproduce it locally (copy & paste every line on the output), so instead of cloning again I just changed it to copy the files. It has the advantage that this way it can also build and test pull requests.

Also changed the git repo for WordPress to the official one: http://make.wordpress.org/core/2014/01/15/git-mirrors-for-wordpress/
