### PR TITLE
Update WP tag name semantics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ matrix:
     - php: "5.3"
       env: WP_VERSION=master
     - php: "5.4"
-      env: WP_VERSION=3.8
+      env: WP_VERSION=3.8.1
     - php: "5.2"
-      env: WP_VERSION=3.8
+      env: WP_VERSION=3.8.1
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
Tag name semantics have changed in upstream repo, so using "3.8" now actually checks out the branch rather than the "3.8.0" tag, so this is why the WP version check in the unit tests fail. This should hopefully fix it.
