### PR TITLE
Remove undefined variable on error handling.

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -126,19 +126,19 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 	 * @return array List of associative arrays with code and message keys
 	 */
 	protected function error_to_response( $error ) {
-		if ( is_array( $data ) && isset( $data['status'] ) ) {
-			$status = $data['status'];
-		}
-		else {
-			$status = 500;
-		}
+		$status = 500;
 
 		$data = array();
 		foreach ( (array) $error->errors as $code => $messages ) {
 			foreach ( (array) $messages as $message ) {
+				if ( isset( $error->error_data[$code]['status'] ) ) {
+					$status = $error->error_data[$code]['status'];
+				}
+
 				$data[] = array( 'code' => $code, 'message' => $message );
 			}
 		}
+
 		$response = new WP_JSON_Response( $data, $status );
 
 		return $response;


### PR DESCRIPTION
Not sure if this would be the best way to handle the error response. For now it doesn't throw a notice of the $data variable undefined, and returns the $status code of the last error on the response (didn't find a place where there's more than one error). I found it going to **/users/1/posts** endpoint
