### PR TITLE
Removed test support for multiple WP versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,11 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# PHP version used in first build configuration.
 php:
+    - "5.2"
+    - "5.3"
+    - "5.4"
     - "5.5"
-
-# WordPress version used in first build configuration.
-env:
-    - WP_VERSION=master
-
-# Next we define our matrix of additional build configurations to test against.
-# The versions listed above will automatically create our first configuration,
-# so it doesn't need to be re-defined below.
-
-# WP_VERSION specifies the tag to use. The way these tests are configured to run
-# requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
-
-# Note that Travis CI supports listing these above to automatically build a
-# matrix of configurations, but we're being nice here by manually building a
-# total of four configurations even though we're testing 4 versions of PHP
-# along with 2 versions of WordPress (which would build 8 configs otherwise).
-# This takes half as long to run while still providing adequate coverage.
-
-matrix:
-  include:
-    - php: "5.2"
-    - php: "5.3"
-    - php: "5.4"
-    - php: "5.4"
 
 # Clones WordPress and configures our testing environment.
 before_script:
@@ -37,7 +15,6 @@ before_script:
     - git clone https://github.com/tierra/wordpress.git /tmp/wordpress
     - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
     - cd /tmp/wordpress
-    - git checkout $WP_VERSION
     - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
     - cp wp-tests-config-sample.php wp-tests-config.php
     - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php

--- a/tests/test_json_plugin.php
+++ b/tests/test_json_plugin.php
@@ -12,28 +12,6 @@
 class WP_Test_JSON_Plugin extends WP_UnitTestCase {
 
 	/**
-	 * If these tests are being run on Travis CI, verify that the version of
-	 * WordPress installed is the version that we requested.
-	 *
-	 * @requires PHP 5.3
-	 */
-	function test_wp_version() {
-		if ( !getenv( 'TRAVIS' ) )
-			$this->markTestSkipped( 'Travis CI was not detected.' );
-
-		$requested_version = getenv( 'WP_VERSION' ) . '-src';
-
-		// The "master" version requires special handling.
-		if ( $requested_version == 'master-src' ) {
-			$file = file_get_contents( 'https://raw.github.com/tierra/wordpress/master/src/wp-includes/version.php' );
-			preg_match( '#\$wp_version = \'([^\']+)\';#', $file, $matches );
-			$requested_version = $matches[1];
-		}
-
-		$this->assertEquals( get_bloginfo( 'version' ), $requested_version );
-	}
-
-	/**
 	 * The plugin should be installed and activated.
 	 */
 	function test_plugin_activated() {


### PR DESCRIPTION
In #76, it's proposed to just remove any unit tests against older versions of WordPress.

Doing so makes it unnecessary to use a build matrix in our Travis CI configuration, or test for the correct version of WordPress in one of the unit tests itself. So this commit removes both.

This also fixes the duplicate entry for PHP 5.4, which was resulting in an extra 5.4 build.
