### PR TITLE
Don't declare jsonSerialize on ResponseInterface

### DIFF
--- a/lib/class-wp-json-responseinterface.php
+++ b/lib/class-wp-json-responseinterface.php
@@ -31,5 +31,5 @@ interface WP_JSON_ResponseInterface extends JsonSerializable {
 	 *
 	 * @return mixed Any JSON-serializable value
 	 */
-	public function jsonSerialize();
+	// public function jsonSerialize();
 }


### PR DESCRIPTION
For PHP <5.3.9, duplicate abstract methods can't be declared (5.3.9+
allows them with the same signature). This comments it out to leave the
documentation intact.
