### PR TITLE
Force WP_JSON_CustomPostType to accept JSON for post editing/creation

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -53,12 +53,12 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	public function registerRoutes( $routes ) {
 		$routes[ $this->base ] = array(
 			array( array( $this, 'getPosts' ), WP_JSON_Server::READABLE ),
-			array( array( $this, 'newPost' ),  WP_JSON_Server::CREATABLE ),
+			array( array( $this, 'newPost' ),  WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 		);
 
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
 			array( array( $this, 'getPost' ),    WP_JSON_Server::READABLE ),
-			array( array( $this, 'editPost' ),   WP_JSON_Server::EDITABLE ),
+			array( array( $this, 'editPost' ),   WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
 			array( array( $this, 'deletePost' ), WP_JSON_Server::DELETABLE ),
 		);
 		return $routes;


### PR DESCRIPTION
Closes #90
