### PR TITLE
Correct the local testing instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ testing environment in a few easy steps:
 
 5. Browse to http://vagrant.local/wp/wp-admin/ and activate the WP API plugin
 
-   ```Username: admin
+   ```
+   Username: admin
    Password: password
    ```
 


### PR DESCRIPTION
The testing instructions are rather lacking with missing steps to get up and running from a clean environment.

Notably, this at least brings the "Quick Setup" section up to working order with a proper clone of Chassis, installing the Vagrant hostupdater plugin, and providing the default admin credentials to get into the WordPress admin panel.

This also actually just installs phpunit system-wide instead of just downloading a local phar, which the instructions didn't even use properly.

I've updated instructions to also clone from the official WordPress git repo rather than my personal one.

And finally, phpunit needs to be run from the main plugin directory, not the tests subdirectory.

Note that this still isn't complete. Before you can run phpunit, you still need to configure the Chassis `wp-tests-config.php` file with the appropriate DB config, which I have not added instructions for still.

Honestly, I think rather than using Chassis, it would be better to just setup our own Vagrant config with the appropriate provisioning to not only just checkout WordPress once, but to automatically install PHPUnit, configure the test DB details, etc. Chassis gets us most of the way there, but it doesn't go as far as it could to make this process simple. This PR should help a little though at least.
