### PR TITLE
Fix testing instructions with Chassis

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ testing environment in a few easy steps:
 
    ```bash
    cd api-tester
-   cp local-config-sample.php local-config.php
-   mkdir -p content/plugins
+   mkdir -p content/plugins content/themes
+   cp -r wp/wp-content/themes/* content/themes
    git clone git@github.com:WP-API/WP-API.git content/plugins/json-rest-api
    ```
 


### PR DESCRIPTION
At the moment, the testing instructions don't note that you need to create a content directory and bring in the themes. We should fix this. :)
