### PR TITLE
data parameter is overwritten with JSON decoded data, even on failure

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -372,7 +372,9 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 				}
 				if ( $supported & self::ACCEPT_JSON ) {
 					$data = json_decode( $this->get_raw_data(), true );
-					$args = array_merge( $args, array( 'data' => $data ) );
+					if ( $data !== null ) {
+						$args = array_merge( $args, array( 'data' => $data ) );
+					}
 				}
 				elseif ( $supported & self::ACCEPT_RAW ) {
 					$data = $this->get_raw_data();


### PR DESCRIPTION
Discovered by @rachelbaker.

If you pass `data[title]=Hello%20World` in the POST body, the `data` parameter internally gets overwritten with the result of `json_decode`. We should check `json_last_error` and skip if it's non-zero.
