### PR TITLE
Add authentication property to site index

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -456,6 +456,7 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 			'description' => get_option( 'blogdescription' ),
 			'URL' => get_option( 'siteurl' ),
 			'routes' => array(),
+			'authentication' => array(),
 			'meta' => array(
 				'links' => array(
 					'help' => 'https://github.com/rmccue/WP-API',


### PR DESCRIPTION
For integration with [authentication services](https://github.com/WP-API/OAuth1), we should expose a standard `authentication` property that clients can check to find supported methods.
