### PR TITLE
Only expose meta on 'edit' context

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -524,6 +524,7 @@ class WP_JSON_Posts {
 			'title_raw'   => $post['post_title'],
 			'content_raw' => $post['post_content'],
 			'guid_raw'    => $post['guid'],
+			'post_meta'   => $this->prepare_meta( $post['ID'] ),
 		);
 
 		// Dates
@@ -575,9 +576,6 @@ class WP_JSON_Posts {
 			$_post = array_merge( $_post, $post_fields_raw );
 		elseif ( 'edit' === $context )
 			return new WP_Error( 'json_cannot_edit', __( 'Sorry, you cannot edit this post' ), array( 'status' => 403 ) );
-
-		// Post meta
-		$_post['post_meta'] = $this->prepare_meta( $post['ID'] );
 
 		// Entity meta
 		$_post['meta'] = array(


### PR DESCRIPTION
As [raised by iandunn](http://wpapiteam.wordpress.com/2014/03/25/custom-post-types-and-privacy-expectations/) and [discussed on IRC](http://irclogs.wordpress.org/chanlog.php?channel=wordpress-dev&day=2014-04-15&sort=asc#m832939), we should only expose post meta on the `edit` context.

This is a _temporary_ workaround for the permissions issues. We'll come back to this.
