### PR TITLE
Pass post ID to json_prepare_meta filter.

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -632,7 +632,7 @@ class WP_JSON_Posts {
 			    unset( $custom_fields[$meta_key] );
 		}
 
-		return apply_filters( 'json_prepare_meta', $custom_fields );
+		return apply_filters( 'json_prepare_meta', $custom_fields, $post_id );
 	}
 
 	protected function prepare_author( $author ) {


### PR DESCRIPTION
This allows callsbacks to manipulate the fields on a per-post basis. Otherwise all posts would have to be treated the same.
