### PR TITLE
Pass the post ID along with the json_insert_post action

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -871,7 +871,7 @@ class WP_JSON_Posts {
 				unstick_post( $data['ID'] );
 		}
 
-		do_action( 'json_insert_post', $post, $data, $update );
+		do_action( 'json_insert_post', $post, $data, $update, $post_ID );
 
 		return $post_ID;
 	}


### PR DESCRIPTION
- ID is not necessarily going to be in $data or $post if this is a _new_ post

May need to also look above at $data (For the stick method) - Assuming $data['ID'] is set, but will not always be the case.
