### PR TITLE
Add the post id to the $post array when creating a new post...

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -863,6 +863,11 @@ class WP_JSON_Posts {
 			return $post_ID;
 		}
 
+		// If this is a new post, add the post ID to $post
+		if ( ! $update ) {
+			$post['ID'] = $post_ID;
+		}
+
 		// Sticky
 		if ( isset( $post['sticky'] ) )  {
 			if ( $post['sticky'] )


### PR DESCRIPTION
... so anything hooked into the actions have this available

Initially had proposed adding the post ID as an additional variable passed to the action - I think this method makes more sense. See https://github.com/WP-API/WP-API/pull/147 for my comment there
