### PR TITLE
WP_JSON_Posts::edit_post() return value is deprecated function

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -314,7 +314,7 @@ class WP_JSON_Posts {
 			return $retval;
 		}
 
-		return $this->getPost( $id );
+		return $this->get_post( $id );
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/WP-API/WP-API/blob/master/lib/class-wp-json-posts.php#L317

WP_JSON_Posts::edit_post() returns the depreciated WP_JSON_Posts::getPost() method instead of the replacement WP_JSON_Posts::get_post().
