### PR TITLE
Add json_ensure_response

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -218,7 +218,7 @@ class WP_JSON_Posts {
 			return $result;
 		}
 
-		$response = $this->get_post( $result );
+		$response = json_ensure_response( $this->get_post( $result ) );
 		$response->set_status( 201 );
 		$response->header( 'Location', json_url( '/posts/' . $result ) );
 		return $response;

--- a/plugin.php
+++ b/plugin.php
@@ -286,3 +286,27 @@ function get_json_url( $blog_id = null, $path = '', $scheme = 'json' ) {
 function json_url( $path = '', $scheme = 'json' ) {
 	return get_json_url( null, $path, $scheme );
 }
+
+/**
+ * Ensure a JSON response is a response object
+ *
+ * This ensures that the response is consistent, and implements
+ * {@see WP_JSON_ResponseInterface}, allowing usage of
+ * `set_status`/`header`/etc without needing to double-check the object. Will
+ * also allow {@see WP_Error} to indicate error responses, so users should
+ * immediately check for this value.
+ *
+ * @param WP_Error|WP_JSON_ResponseInterface|mixed $response Response to check
+ * @return WP_Error|WP_JSON_ResponseInterface
+ */
+function json_ensure_response( $response ) {
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	if ( $response instanceof WP_JSON_ResponseInterface ) {
+		return $response;
+	}
+
+	return new WP_JSON_Response( $response );
+}


### PR DESCRIPTION
This ensures that a value is either a WP_JSON_ResponseInterface object, or a WP_Error, by wrapping any other value in a WP_JSON_Response instance.

Fixes #151.
