### PR TITLE
Remove endpoint placeholders

### DIFF
--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -279,7 +279,6 @@ hooking and more for you:
 
 		public function register_routes( $routes ) {
 			$routes = parent::register_routes( $routes );
-			// $routes = parent::register_revision_routes( $routes );
 			// $routes = parent::register_comment_routes( $routes );
 
 			// Add more custom routes here

--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -73,19 +73,6 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	}
 
 	/**
-	 * Register revision-related routes for the post type
-	 *
-	 * @param array $routes Routes for the post type
-	 * @return array Modified routes
-	 */
-	public function register_revision_routes( $routes ) {
-		$routes[ $this->base . '/(?P<id>\d+)/revisions' ] = array(
-			array( '__return_null', WP_JSON_Server::READABLE ),
-		);
-		return $routes;
-	}
-
-	/**
 	 * Register comment-related routes for the post type
 	 *
 	 * @param array $routes Routes for the post type
@@ -94,12 +81,9 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	public function register_comment_routes( $routes ) {
 		$routes[ $this->base . '/(?P<id>\d+)/comments'] = array(
 			array( array( $this, 'get_comments' ), WP_JSON_Server::READABLE ),
-			array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 		);
 		$routes[ $this->base . '/(?P<id>\d+)/comments/(?P<comment>\d+)' ] = array(
 			array( array( $this, 'get_comment' ), WP_JSON_Server::READABLE ),
-			array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
-			array( '__return_null', WP_JSON_Server::DELETABLE ),
 		);
 		return $routes;
 	}

--- a/lib/class-wp-json-pages.php
+++ b/lib/class-wp-json-pages.php
@@ -41,7 +41,6 @@ class WP_JSON_Pages extends WP_JSON_CustomPostType {
 	 */
 	public function register_routes( $routes ) {
 		$routes = parent::register_routes( $routes );
-		$routes = parent::register_revision_routes( $routes );
 		$routes = parent::register_comment_routes( $routes );
 
 		// Add post-by-path routes

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -36,17 +36,13 @@ class WP_JSON_Posts {
 				array( array( $this, 'edit_post' ),   WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
 				array( array( $this, 'delete_post' ), WP_JSON_Server::DELETABLE ),
 			),
-			'/posts/(?P<id>\d+)/revisions' => array( '__return_null', WP_JSON_Server::READABLE ),
 
 			// Comments
 			'/posts/(?P<id>\d+)/comments'                  => array(
 				array( array( $this, 'get_comments' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 			),
 			'/posts/(?P<id>\d+)/comments/(?P<comment>\d+)' => array(
 				array( array( $this, 'get_comment' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
-				array( '__return_null', WP_JSON_Server::DELETABLE ),
 			),
 
 			// Meta-post endpoints

--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -17,12 +17,9 @@ class WP_JSON_Taxonomies {
 			),
 			'/posts/types/(?P<type>\w+)/taxonomies/(?P<taxonomy>\w+)/terms' => array(
 				array( array( $this, 'get_terms' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 			),
 			'/posts/types/(?P<type>\w+)/taxonomies/(?P<taxonomy>\w+)/terms/(?P<term>\w+)' => array(
 				array( array( $this, 'get_term' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
-				array( '__return_null', WP_JSON_Server::DELETABLE ),
 			),
 		);
 		return array_merge( $routes, $tax_routes );


### PR DESCRIPTION
These were originally just to mock out all the routes, but we don't need that any more. :)

Fixes #161.
