### PR TITLE
Remove unused prepare_author method from WP_JSON_Posts class

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -647,35 +647,6 @@ class WP_JSON_Posts {
 		return apply_filters( 'json_prepare_meta', $custom_fields, $post_id );
 	}
 
-	protected function prepare_author( $author ) {
-		$user = get_user_by( 'id', $author );
-
-		if (! $author || ! is_object( $user ) ) {
-			return null;
-		}
-
-
-		$author = array(
-			'ID' => $user->ID,
-			'name' => $user->display_name,
-			'slug' => $user->user_nicename,
-			'URL' => $user->user_url,
-			'avatar' => $this->server->get_avatar_url( $user->user_email ),
-			'meta' => array(
-				'links' => array(
-					'self' => json_url( '/users/' . $user->ID ),
-					'archives' => json_url( '/users/' . $user->ID . '/posts' ),
-				),
-			),
-		);
-
-		if ( current_user_can( 'edit_user', $user->ID ) ) {
-			$author['first_name'] = $user->first_name;
-			$author['last_name'] = $user->last_name;
-		}
-		return $author;
-	}
-
 	/**
 	 * Helper method for wp_newPost and wp_editPost, containing shared logic.
 	 *


### PR DESCRIPTION
Remove unused method: https://github.com/WP-API/WP-API/blob/master/lib/class-wp-json-posts.php#L650  

Discussed with @rmccue and agreed that there is no need to depreciate the method since it is a protected, internal-only, method.
