### PR TITLE
Include taxonomy description in prepared data object

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -80,6 +80,7 @@ class WP_JSON_Taxonomies {
 			'name' => $taxonomy->label,
 			'slug' => $taxonomy->name,
 			'labels' => $taxonomy->labels,
+			'description' => $taxonomy->description,
 			'types' => array(),
 			'show_cloud' => $taxonomy->show_tagcloud,
 			'hierarchical' => $taxonomy->hierarchical,


### PR DESCRIPTION
While many sites do not use them, both `post_tag` and `category` taxonomy objects can include arbitrary text in the term's "description" field. Since this data can be used by theme developers if it is present, I feel it should be exposed by the API as well.

More pertinently, I'm building a project on top of the API that _depends_ on this data being exposed :)
