### PR TITLE
Add permalink settings step to Quick Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,19 @@ testing environment in a few easy steps:
    vagrant up
    ```
 
-5. Browse to http://vagrant.local/wp/wp-admin/plugins.php and activate the WP API plugin
+5. Browse to http://vagrant.local/wp/wp-admin/plugins.php and activate the WP
+API plugin
 
    ```
    Username: admin
    Password: password
    ```
 
-6. Browse to http://vagrant.local/wp/wp-admin/options-permalink.php and set the permalink structure to anything other than "Default"
+6. Browse to http://vagrant.local/wp/wp-admin/options-permalink.php and set
+the permalink structure to anything other than "Default"
 
-7. Browse to http://vagrant.local/wp-json/
+7. Browse to http://vagrant.local/wp-json/ (or if the permalink structure is
+still "Default," to http://vagrant.local/?json_route=/)
 
 
 ### Testing


### PR DESCRIPTION
The `/wp-json/` endpoint is not accessible when following the Quick Setup instructions as they are written now, because the rewrite rule for the endpoint is not triggered with the default permalink structure.

Including a step in the setup instructions to explicitly set a compatible permalink structure should reduce confusion.

(Since I included a direct link to the permalink options page, I updated the plugin activation step link to a direct URL as well.)
