### PR TITLE
Update taxonomy collection to return indexed array

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -133,7 +133,7 @@ class WP_JSON_Taxonomies {
 
 		$data = array();
 		foreach ($terms as $term) {
-			$data[ $term->slug ] = $this->prepare_term( $term, $type );
+			$data[] = $this->prepare_term( $term, $type );
 		}
 		return $data;
 	}


### PR DESCRIPTION
Whilst testing some code in the backbone JS client (cc @tlovett1) I came accross an issue with the `/posts/types/post/taxonomies/` endpoint.

A taxonomies collection requres the response to be an array of taxonomies, however because this is an associative array (using taxonomy slug), `json_encode` converts it to an object - which backbone doesn't like.

An alternative would be to handle this with a custom parse method on the backbone collection (see code below) however I think that it should be fixed here - although feel free to tell me where to go...!

```
        // Correctly format response.
        parse: function (response) {
            return jQuery.map( response, function( value ) {
                return [value]
            } );
        }
```

If this should be fixed in WP-API then it will need changing elsewhere too - a quick glance it seems similar for the post types endpoint
