### PR TITLE
Second pass at handling post meta

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -740,6 +740,8 @@ class WP_JSON_Posts {
 			return new WP_Error( 'json_post_invalid_action', __( 'Invalid provided meta data for action.' ), array( 'status' => 400 ) );
 		}
 
+		$meta_key = wp_slash( $meta_key );
+		$data = wp_slash( $meta_key );
 		return update_post_meta( $post_id, $meta_key, $data );
 	}
 
@@ -782,6 +784,8 @@ class WP_JSON_Posts {
 			return new WP_Error( 'json_post_invalid_action', __( 'Invalid action provided for meta data.' ), array( 'status' => 400 ) );
 		}
 
+		$meta_key = wp_slash( $meta_key );
+		$data = wp_slash( $data );
 		return add_post_meta( $post_id, $meta_key, $data );
 	}
 


### PR DESCRIPTION
Based on #168.

Still not at a point where I like it. We're now outputting:

``` json
[
    {
        "key": "my_test_field",
        "value": [
            "Some value!"
        ]
    }
]
```

Whereas the input is:

``` json
[
    {
        "key": "my_test_field",
        "value": "Some value!",
        "action": "update"
    }
]
```
