### PR TITLE
Third pass at handling post meta

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -798,11 +798,6 @@ class WP_JSON_Posts {
 			return new WP_Error( 'json_post_invalid_action', __( 'Invalid provided meta data for action.' ), array( 'status' => 400 ) );
 		}
 
-		$old_data = get_post_meta( $post_id, $meta_key );
-		if ( ! empty( $old_data ) ) {
-			return new WP_Error( 'json_post_invalid_action', __( 'Invalid action provided for meta data.' ), array( 'status' => 400 ) );
-		}
-
 		$meta_key = wp_slash( $meta_key );
 		$data = wp_slash( $data );
 		if ( ! add_post_meta( $post_id, $meta_key, $data ) ) {


### PR DESCRIPTION
This pass at post meta builds off the previous (#168, #188), but changes the format around.

When retrieving meta:

``` json
{
    "ID": 13,
    "post_meta": [
        {
            "ID": 33,
            "key": "my_meta_key",
            "value": "My value!"
        }
    ]
}
```

To update, you just change the value and send it back:

``` json
{
    "ID": 13,
    "post_meta": [
        {
            "ID": 33,
            "key": "my_meta_key",
            "value": "My new value!"
        }
    ]
}
```

To add a new value, you add an object to the array without an ID:

``` json
{
    "ID": 13,
    "post_meta": [
        {
            "key": "another_key",
            "value": "Another value"
        }
    ]
}
```

To delete a value, you set the key and value to `null`:

``` json
{
    "ID": 13,
    "post_meta": [
        {
            "ID": 33,
            "key": null,
            "value": null
        }
    ]
}
```

Side-effect: you can rename meta keys by changing the `key` when updating, as it's no longer used as the primary key.

Disadvantages: This cannot be read from the meta cache. I don't see this being a huge issue, as it's only exposed on `context=edit`.

Fixes #68.
