### PR TITLE
Remove placeholder endpoints (v2)

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -94,11 +94,9 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	public function register_comment_routes( $routes ) {
 		$routes[ $this->base . '/(?P<id>\d+)/comments'] = array(
 			array( array( $this, 'get_comments' ), WP_JSON_Server::READABLE ),
-			array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 		);
 		$routes[ $this->base . '/(?P<id>\d+)/comments/(?P<comment>\d+)' ] = array(
 			array( array( $this, 'get_comment' ), WP_JSON_Server::READABLE ),
-			array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
 			array( array( $this, 'delete_comment' ), WP_JSON_Server::DELETABLE ),
 		);
 		return $routes;

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -41,11 +41,9 @@ class WP_JSON_Posts {
 			// Comments
 			'/posts/(?P<id>\d+)/comments'                  => array(
 				array( array( $this, 'get_comments' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 			),
 			'/posts/(?P<id>\d+)/comments/(?P<comment>\d+)' => array(
 				array( array( $this, 'get_comment' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
 				array( array( $this, 'delete_comment' ), WP_JSON_Server::DELETABLE ),
 			),
 

--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -17,12 +17,9 @@ class WP_JSON_Taxonomies {
 			),
 			'/posts/types/(?P<type>\w+)/taxonomies/(?P<taxonomy>\w+)/terms' => array(
 				array( array( $this, 'get_terms' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 			),
 			'/posts/types/(?P<type>\w+)/taxonomies/(?P<taxonomy>\w+)/terms/(?P<term>\w+)' => array(
 				array( array( $this, 'get_term' ), WP_JSON_Server::READABLE ),
-				array( '__return_null', WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
-				array( '__return_null', WP_JSON_Server::DELETABLE ),
 			),
 		);
 		return array_merge( $routes, $tax_routes );


### PR DESCRIPTION
Doesn't remove revision endpoints, as they'll be handled in #169.

Fixes #161.
