### PR TITLE
Mssing Fields - add missing post meta

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -904,6 +904,11 @@ class WP_JSON_Posts {
 		if ( ! empty( $data['ping_status'] ) ) {
 			$post['ping_status'] = $data['ping_status'];
 		}
+		
+		// Tags input
+		if ( ! empty( $data['tags_input'] ) ) {
+		    $post['tags_input'] = $data['tags_input'];
+		}
 
 		// Post format
 		if ( ! empty( $data['post_format'] ) ) {


### PR DESCRIPTION
If you update/insert a post the API miss the "tags_input". So it is not possible to add missing "terms".
So content check extended add from "tags_input".
