### PR TITLE
Dates for new or updated posts should honor date parameters passed

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1185,13 +1185,13 @@ class WP_JSON_Posts {
 		if ( ! empty( $data['date'] ) ) {
 			$date_data = $this->server->get_date_with_gmt( $data['date'] );
 			if ( ! empty( $date_data ) ) {
-				list( $post['post_date'], $post['post_date_gmt'] ) = $data;
+				list( $post['post_date'], $post['post_date_gmt'] ) = $date_data;
 			}
 		}
 		elseif ( ! empty( $data['date_gmt'] ) ) {
 			$date_data = $this->server->get_date_with_gmt( $data['date_gmt'], true );
 			if ( ! empty( $date_data ) ) {
-				list( $post['post_date'], $post['post_date_gmt'] ) = $data;
+				list( $post['post_date'], $post['post_date_gmt'] ) = $date_data;
 			}
 		}
 
@@ -1199,13 +1199,13 @@ class WP_JSON_Posts {
 		if ( ! empty( $data['modified'] ) ) {
 			$date_data = $this->server->get_date_with_gmt( $data['modified'] );
 			if ( ! empty( $date_data ) ) {
-				list( $post['post_modified'], $post['post_modified_gmt'] ) = $data;
+				list( $post['post_modified'], $post['post_modified_gmt'] ) = $date_data;
 			}
 		}
 		elseif ( ! empty( $data['modified_gmt'] ) ) {
 			$date_data = $this->server->get_date_with_gmt( $data['modified_gmt'], true );
 			if ( ! empty( $date_data ) ) {
-				list( $post['post_modified'], $post['post_modified_gmt'] ) = $data;
+				list( $post['post_modified'], $post['post_modified_gmt'] ) = $date_data;
 			}
 		}
 


### PR DESCRIPTION
There is a bug in the logic of WP_JSON_Posts->insert_post() where even if the `$data['date']`, `$data['date_gmt']`, `$data['modified']`, or  `$data['modified_gmt']` are not empty the values are populated with the current time in GMT.

This appears to be a blocker for the 1.0 release, if this bug is confirmed by @rmccue.

See current logic here: https://github.com/WP-API/WP-API/blob/master/lib/class-wp-json-posts.php#L1185
