### PR TITLE
Give JSON API more flexibility as to where it's run from

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,17 +6,17 @@
  * @subpackage JSON API
  */
 
-// Activates this plugin in WordPress so it can be tested.
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( basename( dirname( dirname( __FILE__ ) ) ) . '/plugin.php' ),
-);
-
 // If the develop repo location is defined (as WP_DEVELOP_DIR), use that
 // location. Otherwise, we'll just assume that this plugin is installed in a
 // WordPress develop SVN checkout.
+$develop_dir = false !== getenv( 'WP_DEVELOP_DIR' ) ? getenv( 'WP_DEVELOP_DIR' ) : '../../../..';
 
-if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
-	require getenv( 'WP_DEVELOP_DIR' ) . '/tests/phpunit/includes/bootstrap.php';
-} else {
-	require '../../../../tests/phpunit/includes/bootstrap.php';
+require_once $develop_dir . '/tests/phpunit/includes/functions.php';
+
+// Activates this plugin in WordPress so it can be tested.
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/plugin.php';
 }
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require_once $develop_dir . '/tests/phpunit/includes/bootstrap.php';

--- a/tests/test_json_plugin.php
+++ b/tests/test_json_plugin.php
@@ -15,8 +15,7 @@ class WP_Test_JSON_Plugin extends WP_UnitTestCase {
 	 * The plugin should be installed and activated.
 	 */
 	function test_plugin_activated() {
-		$directory = basename( dirname( dirname( __FILE__ ) ) );
-		$this->assertTrue( is_plugin_active( $directory . '/plugin.php' ) );
+		$this->assertTrue( function_exists( 'json_url') );
 	}
 
 	/**


### PR DESCRIPTION
WordPress Trunk is in /srv/www/wordpress-trunk.dev but the test suite is somewhere else.
