### PR TITLE
 Allow customization of the API resources prefix (v2)

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -202,7 +202,7 @@ register_deactivation_hook( __FILE__, 'json_api_deactivation' );
 function json_register_scripts() {
 	wp_register_script( 'wp-api', 'http://wp-api.github.io/client-js/build/js/wp-api.js', array( 'jquery', 'backbone', 'underscore' ), '1.1', true );
 
-	$settings = array( 'root' => esc_url_raw( home_url( 'wp-json' ) ), 'nonce' => wp_create_nonce( 'wp_json' ) );
+	$settings = array( 'root' => esc_url_raw( get_json_url() ), 'nonce' => wp_create_nonce( 'wp_json' ) );
 	wp_localize_script( 'wp-api', 'WP_API_Settings', $settings );
 }
 add_action( 'wp_enqueue_scripts', 'json_register_scripts', -100 );


### PR DESCRIPTION
From #244. Fixes #104, fixes #244. Also uses the prefix in the JS settings.
