### PR TITLE
json_prepare_term filter application missing $context argument

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -338,6 +338,6 @@ class WP_JSON_Taxonomies {
 			$data['parent'] = null;
 		}
 
-		return apply_filters( 'json_prepare_term', $data, $term );
+		return apply_filters( 'json_prepare_term', $data, $term, $context );
 	}
 }


### PR DESCRIPTION
All other json_prepare_ filter applications include the $context switch, but this one seems to be missing. Is this simply an oversight?
