### PR TITLE
The Getting Started edit and create posts examples are incorrect

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -400,7 +400,7 @@ posts. For example, to edit the title, content, and the date:
 ```json
 {
     "title": "Hello Updated World!",
-    "content_raw": "<p>Howdy updated content<\/p>",
+    "content_raw": "<p>Howdy updated content.<\/p>",
     "date": "2013-04-01T14:00:00+10:00"
 }
 ```


### PR DESCRIPTION
The `updated-post.json` from the Editing Posts example is re-used in the Create Posts example.  That should be changed since there are required parameters when creating a post.  Also the `modified` parameter is no longer available when creating OR editing a post.

In summary:
- [x]  Update new post example to include `content_raw` as a parameter.
- [x]  Change new and edit posts examples to use `date` parameter instead of `modified` parameter.
