### PR TITLE
Remove references to removed $fields parameter

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -189,7 +189,7 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	 * Prepare post data
 	 *
 	 * @param array $post The unprepared post data
-	 * @param string $context
+	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
 	protected function prepare_post( $post, $context = 'view' ) {

--- a/lib/class-wp-json-pages.php
+++ b/lib/class-wp-json-pages.php
@@ -103,7 +103,7 @@ class WP_JSON_Pages extends WP_JSON_CustomPostType {
 	 * Prepare post data
 	 *
 	 * @param array $post The unprepared post data
-	 * @param string $context
+	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
 	protected function prepare_post( $post, $context = 'view' ) {

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -120,7 +120,7 @@ class WP_JSON_Posts {
 	 * @see get_posts() for more on $filter values
 	 *
 	 * @param array $filter Parameters to pass through to `WP_Query`
-	 * @param string $context
+	 * @param string $context The context; 'view' (default) or 'edit'.
 	 * @param string|array $type Post type slug, or array of slugs
 	 * @param int $page Page number (1-indexed)
 	 * @return stdClass[] Collection of Post entities
@@ -313,7 +313,7 @@ class WP_JSON_Posts {
 	 *
 	 * @uses get_post()
 	 * @param int $id Post ID
-	 * @param string $context
+	 * @param string $context The context; 'view' (default) or 'edit'.
 	 * @return array Post entity
 	 */
 	public function get_post( $id, $context = 'view' ) {
@@ -659,7 +659,7 @@ class WP_JSON_Posts {
 	 * @access protected
 	 *
 	 * @param array $post The unprepared post data
-	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed)
+	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
 	protected function prepare_post( $post, $context = 'view' ) {


### PR DESCRIPTION
The `get_post()` and `prepare_post()` methods apparently had a
`$fields` parameter at one time. This has been replaced by the
`$context` parameter.

When the `$fields` parameter was removed, some of the inline docs
stayed behind. This removes them.

Incidentally, the inline docs could probably use lots of tweaks. I assume maybe some of this is being put off while the code is still churning.
