### PR TITLE
User's ID should alway be integer

### DIFF
--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -123,6 +123,7 @@ class WP_JSON_Users {
 	 * @return response
 	 */
 	public function get_user( $id, $context = 'view' ) {
+		$id = (int) $id;
 		$current_user_id = get_current_user_id();
 
 		if ( $current_user_id !== $id && ! current_user_can( 'list_users' ) ) {


### PR DESCRIPTION
When user that doesn't have `list_users` capability request its own data using `/users/me`, they are redirected to `/users/<ID>`, which means ID is passed as a string to `WP_JSON_Users::get_user()`. As `get_current_user_id()` returns integer, and there is strict comparison, this will fail.

User's ID should be converted to integer, or there shouldn't be strict comparison.
