### PR TITLE
Changes to class-wp-json-posts.php for documentation and error handling.

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -344,8 +344,11 @@ class WP_JSON_Posts {
 			return $post;
 		}
 
-		foreach ( $post['meta']['links'] as $rel => $url ) {
-			$response->link_header( $rel, $url );
+		// We don't need to iterate on the "meta" element if it doesnt exist.
+		if ( isset( $post['meta'] )) {
+			foreach ( $post['meta']['links'] as $rel => $url ) {
+				$response->link_header( $rel, $url );
+			}
 		}
 
 		$response->link_header( 'alternate',  get_permalink( $id ), array( 'type' => 'text/html' ) );


### PR DESCRIPTION
The "number" argument returns an error when called through the filter, but "posts_per_page" works. This change simply updates the documentation.
