### PR TITLE
Fix jsonp content-type response header

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -180,7 +180,8 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 	 * @uses WP_JSON_Server::dispatch()
 	 */
 	public function serve_request( $path = null ) {
-		$this->send_header( 'Content-Type', 'application/json; charset=' . get_option( 'blog_charset' ), true );
+		$content_type = isset( $_GET['_jsonp'] ) ? 'application/javascript' : 'application/json';
+		$this->send_header( 'Content-Type', $content_type . '; charset=' . get_option( 'blog_charset' ), true );
 
 		// Mitigate possible JSONP Flash attacks
 		// http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/


### PR DESCRIPTION
Incorrectly sends application/json rather than application/javascript on a jsonp request which breaks strict mime handling. In response to error: Refused to execute script from '...url...' because its MIME type ('application/json') is not executable, and strict MIME type checking is enabled.
