### PR TITLE
Alter installation steps to use wp-cli for plugin and permanlink setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,30 @@ testing environment in a few easy steps:
    vagrant up
    ```
 
-5. Browse to http://vagrant.local/wp/wp-admin/plugins.php and activate the WP
-API plugin
+5. Activate the plugin:
+
+   ```bash
+   vagrant ssh -c 'cd /vagrant && wp plugin activate json-rest-api'
+   ```
+
+6. Set the permalink structure to something other than the default, in order to
+   enable the http://vagrant.local/wp-json/ endpoint URL (if you skip this
+   step, it can be accessed at http://vagrant.local/?json_route=/):
+
+   ```bash
+   vagrant ssh -c "cd /vagrant && wp rewrite structure '/%postname%/'"
+   ```
+
+You're done! You should now have a WordPress site available at
+http://vagrant.local; you can access the API via http://vagrant.local/wp-json/
+
+To access the admin interface, visit http://vagrant.local/wp/wp-admin and log
+in with the credentials below:
 
    ```
    Username: admin
    Password: password
    ```
-
-6. Browse to http://vagrant.local/wp/wp-admin/options-permalink.php and set
-the permalink structure to anything other than "Default"
-
-7. Browse to http://vagrant.local/wp-json/ (or if the permalink structure is
-still "Default," to http://vagrant.local/?json_route=/)
-
 
 ### Testing
 


### PR DESCRIPTION
WP-CLI is available in Chassis, so we can take advantage of it to make the setup steps slightly more straightforward by activating the plugin and setting a custom permalink structure. Commands are invoked via `vagrant ssh -c`, to permit them to be pasted from the same terminal instance used in the previous steps.
