### PR TITLE
post 'parent' value should be null rather than zero if unset

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -786,6 +786,10 @@ class WP_JSON_Posts {
 		if ( empty( $post_fields['format'] ) ) {
 			$post_fields['format'] = 'standard';
 		}
+		
+		if ( 0 === $post['post_parent'] ) {
+			$post_fields['parent'] = null;
+		}
 
 		if ( ( 'view' === $context || 'view-revision' == $context ) && 0 !== $post['post_parent'] ) {
 			// Avoid nesting too deeply


### PR DESCRIPTION
Having a field be either an integer or a nested object makes parsing more complicated. Furthermore, knowing that a parent ID of "0" means that a post has no parent is WordPress inside knowledge that should not leak through the API.
