### PR TITLE
Add support for passing the role parameter to insert_user() method. #335

### DIFF
--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -307,6 +307,11 @@ class WP_JSON_Users {
 			$user->user_email = $data['email'];
 		}
 
+		// Role
+		if ( ! empty( $data['role'] ) ) {
+			$user->role = $data['role'];
+		}
+
 		// Pre-flight check
 		$user = apply_filters( 'json_pre_insert_user', $user, $data );
 


### PR DESCRIPTION
Add support for passing the role parameter to insert_user() method.

This allows users to be created and/or updated with a specific role.

Fixes #335 
