### PR TITLE
Add a json_prepare_type-{post_type} filter on the /posts endpoint

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -210,7 +210,11 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 			$_post['meta']['links']['up'] = json_url( $this->base . '/' . $post['ID'] );
 		}
 
-		return apply_filters( "json_prepare_{$this->type}", $_post, $post, $context );
+		// json_prepare_{post_type} filters all objects requested via this endpoint
+		$_post = apply_filters( "json_prepare_{$this->type}", $_post, $post, $context );
+
+		// Run post type-specific filters
+		return apply_filters( "json_prepare_type-{$this->type}", $_post, $post, $context );
 	}
 
 	/**

--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -128,7 +128,11 @@ class WP_JSON_Media extends WP_JSON_Posts {
 			$data['meta']['links']['up'] = json_url( '/media/' . (int) $post['post_parent'] );
 		}
 
-		return apply_filters( 'json_prepare_attachment', $data, $post, $context );
+		// json_prepare_attachment filters all objects requested via this endpoint
+		$data = apply_filters( 'json_prepare_attachment', $data, $post, $context );
+
+		// Run post type-specific filters
+		return apply_filters( "json_prepare_type-attachment", $data, $post, $context );
 	}
 
 	/**
@@ -191,7 +195,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	public function upload_attachment( $_files, $_headers, $post_id = 0 ) {
 
 		$post_type = get_post_type_object( 'attachment' );
-		
+
 		if ( $post_id == 0 ) {
 			$post_parent_type = get_post_type_object( 'post' );
 		} else {

--- a/lib/class-wp-json-pages.php
+++ b/lib/class-wp-json-pages.php
@@ -116,6 +116,10 @@ class WP_JSON_Pages extends WP_JSON_CustomPostType {
 			$_post['meta']['links']['up'] = json_url( $this->base . '/' . get_page_uri( (int) $post['post_parent'] ) );
 		}
 
-		return apply_filters( 'json_prepare_page', $_post, $post, $context );
+		// json_prepare_post filters all objects requested via /posts
+		$_post = apply_filters( 'json_prepare_page', $_post, $post, $context );
+
+		// Run post type-specific filters
+		return apply_filters( 'json_prepare_type-page', $_post, $post, $context );
 	}
 }

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -786,7 +786,7 @@ class WP_JSON_Posts {
 		if ( empty( $post_fields['format'] ) ) {
 			$post_fields['format'] = 'standard';
 		}
-		
+
 		if ( 0 === $post['post_parent'] ) {
 			$post_fields['parent'] = null;
 		}
@@ -857,7 +857,12 @@ class WP_JSON_Posts {
 		if ( $previous_post ) {
 			setup_postdata( $previous_post );
 		}
-		return apply_filters( 'json_prepare_post', $_post, $post, $context );
+
+		// json_prepare_post filters all objects requested via /posts
+		$_post = apply_filters( 'json_prepare_post', $_post, $post, $context );
+
+		// Run post type-specific filters
+		return apply_filters( "json_prepare_type-{$post['post_type']}", $_post, $post, $context );
 	}
 
 	/**


### PR DESCRIPTION
This is intended mainly as the stimulus for a discussion. We currently have the following filters on posts:

- `json_prepare_post`: Runs on anything requested via /posts
- `json_prepare_{post_type}`: Runs on anything requested via and endpoint extending `WP_JSON_CustomPostType`

Right now, if you don't make a custom endpoint and request a CPT, you have to filter on `json_prepare_post` and conditionally check for the target post type.

Having the filters exist per-endpoint is fine (although I feel like I've seen a situation where another endpoint hit json_prepare_post, via a call to `WP_JSON_Posts`'s `prepare_post`, I cannot find it atm). However, I wanted to raise the question of whether we should be able to filter against CPT objects retrieved via /posts?type= separately from `json_prepare_posts`, and, if so, whether that filter should also be invoked/invokable from a custom endpoint.

This implementation is set up to add a new filter method:

- `json_prepare_type-{post_type}`

This method processes any request passed through the `/posts` endpoint.

My question:

Should this be applied to objects retrieved through custom endpoints? *i.e.*, should `json_prepare_type-{post_type}` be called from within `WP_JSON_CustomPostType`'s `prepare_post`? If so, this would mean that

- `json_prepare_post` would be called for anything on `/posts`
- `json_prepare_{post_type}` would be called for anything on a custom endpoint
- `json_prepare_type-{post_type}` would be called for any custom type returned from the system, regardless of through which endpoint it was requested.

I personally like this approach, because it lets you pick your level of specificity with a filter: whether it should handle all resources of a type, or whether it should handle all resources from a custom endpoint (or the default one). It makes things more consistent with the filter `json_prepare_attachment`, as well, since that's then effectively a `json_prepare_{post_type}` call, just as is `json_prepare_post` is for that endpoint. It de-couples filters for the type of object from filters for how it was retrieved. (Names may need to change; json_prepare_posts and json_prepare_media, *etc*, though that may be irrelevant if we go with an exclusively root-discoverable API).

Thoughts?