### PR TITLE
Check that the JSONP callback is a string first

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -202,7 +202,7 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 			}
 
 			// Check for invalid characters (only alphanumeric allowed)
-			if ( preg_match( '/\W/', $_GET['_jsonp'] ) ) {
+			if ( ! is_string( $_GET['_jsonp'] ) || preg_match( '/\W/', $_GET['_jsonp'] ) ) {
 				echo $this->json_error( 'json_callback_invalid', __( 'The JSONP callback function is invalid.' ), 400 );
 				return false;
 			}


### PR DESCRIPTION
If you pass in an array, this would cause a warning.

Props @ircrash.

Fixes #404
