### PR TITLE
Issue #411: Getting child comment causes fatal error

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1580,7 +1580,7 @@ class WP_JSON_Posts {
 			if ( $context === 'single' ) {
 				$parent_fields[] = 'comment';
 			}
-			$parent = get_comment( $post['post_parent'] );
+			$parent = get_comment( $comment->comment_parent );
 
 			$fields['parent'] = $this->prepare_comment( $parent, $parent_fields, 'single-parent' );
 		}


### PR DESCRIPTION
`get_comment()` with the post ID doesn't work, changed `get_comment()` call in the `WP_JSON_Posts` `prepare_comment()` function to use the `$comment->comment_parent` field. 

See [lib/class-wp-json-posts.php#L1583](https://github.com/WP-API/WP-API/blob/master/lib/class-wp-json-posts.php#L1583)
See Issue #411
