### PR TITLE
Added 'offset' to $json_valid array

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -157,7 +157,7 @@ class WP_JSON_Posts {
 		}
 
 		// Define our own in addition to WP's normal vars
-		$json_valid = array( 'posts_per_page' );
+		$json_valid = array( 'posts_per_page', 'offset' );
 		$valid_vars = array_merge( $valid_vars, $json_valid );
 
 		// Filter and flip for querying


### PR DESCRIPTION
Added 'offset' to $json_valid array to define the custom offset filter for get_posts function. 
This fixed the issue with offset not working in the GET posts request. 