### PR TITLE
Fix test_root when using WordPress.org developer checkout.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,7 +13,7 @@
 if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = getenv( 'WP_DEVELOP_DIR' );
 } else if ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
-	$test_root = '../../../..';
+	$test_root = '../../../../tests/phpunit';
 } else if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }


### PR DESCRIPTION
The test_root is missing tests/phpunit so you can't run it when using the WordPress.org developer checkout.
