### PR TITLE
allow periods in jsonp callback function name

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -203,7 +203,7 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 			}
 
 			// Check for invalid characters (only alphanumeric allowed)
-			if ( ! is_string( $_GET['_jsonp'] ) || preg_match( '/\W/', $_GET['_jsonp'] ) ) {
+			if ( ! is_string( $_GET['_jsonp'] ) || preg_match( '/\W\./', $_GET['_jsonp'] ) ) {
 				echo $this->json_error( 'json_callback_invalid', __( 'The JSONP callback function is invalid.' ), 400 );
 				return false;
 			}
@@ -613,7 +613,7 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 	 */
 	public function parse_date( $date, $force_utc = false ) {
 		_deprecated_function( __CLASS__ . '::' . __METHOD__, 'WPAPI-1.1', 'json_parse_date' );
-		
+
 		return json_parse_date( $date, $force_utc );
 	}
 

--- a/tests/test-json-server.php
+++ b/tests/test-json-server.php
@@ -37,7 +37,8 @@ class WP_Test_JSON_Server extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the format of errors encoded to json.
+	 * Test the format of errors encoded to json. Include
+	 * a test with periods to be sure it's allowed.
 	 */
 	function test_json_error() {
 		$this->markTestIncomplete('Missing test implementation.');


### PR DESCRIPTION
- now it plays nice with angularjs jsonp calls
- Reference: https://github.com/WP-API/WP-API/issues/144#issuecomment-46325232

rmccue responded with "Interesting; it was actually intentional to leave out . (not _) to avoid the possibility of side effects, but I guess I'm OK with adding it." but nothing has been added yet, at least I couldn't find a branch with the changes.

I am currently using WP-API with an Angular frontend, and I needed to make this fix, so I thought I would contribute it back as well.
