### PR TITLE
Don't set parent key in get_comment response to the Post parent

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1558,12 +1558,6 @@ class WP_JSON_Posts {
 			$fields['type'] = 'comment';
 		}
 
-		// Post
-		if ( 'single' === $context ) {
-			$parent = get_post( $post['post_parent'], ARRAY_A );
-			$fields['parent'] = $this->prepare_post( $parent, 'single-parent' );
-		}
-
 		// Parent
 		if ( ( 'single' === $context || 'single-parent' === $context ) && (int) $comment->comment_parent ) {
 			$parent_fields = array( 'meta' );


### PR DESCRIPTION
In `WP_JSON_Posts->prepare_comment()` if the $context parameter = single we set $fields['parent'] to the parent post (line 1564)....and then we set $fields['parent'] a few lines down to the parent comment (line 1576)? https://github.com/WP-API/WP-API/blob/master/lib/class-wp-json-posts.php#L1564

I don't think we should get the post_parent here at all.  The .com API only gives the comment parent: http://developer.wordpress.com/docs/api/1/get/sites/%24site/comments/%24comment_ID/

@rmccue any reason for this bizarre logic?
