### PR TITLE
Fix BC Break with Post Meta Handling in Post Routes

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1085,6 +1085,14 @@ class WP_JSON_Posts {
 			$post['ID'] = $post_ID;
 		}
 
+		// Post meta
+		if ( ! empty( $data['post_meta'] ) ) {
+			$result = $this->handle_post_meta_action( $post_ID, $data );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
 		// Sticky
 		if ( isset( $data['sticky'] ) ) {
 			if ( $data['sticky'] ) {

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -714,6 +714,7 @@ class WP_JSON_Posts {
 			'content_raw' => $post['post_content'],
 			'excerpt_raw' => $post['post_excerpt'],
 			'guid_raw'    => $post['guid'],
+			'post_meta'   => $this->handle_get_post_meta( $post['ID'] ),
 		);
 
 		// Dates

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -290,7 +290,7 @@ class WP_JSON_Posts {
 			return $result;
 		}
 
-		$response = json_ensure_response( $this->get_post( $result ) );
+		$response = json_ensure_response( $this->get_post( $result, 'edit' ) );
 		$response->set_status( 201 );
 		$response->header( 'Location', json_url( '/posts/' . $result ) );
 
@@ -403,7 +403,7 @@ class WP_JSON_Posts {
 			return $retval;
 		}
 
-		return $this->get_post( $id );
+		return $this->get_post( $id, 'edit' );
 	}
 
 	/**

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1335,22 +1335,6 @@ class WP_JSON_Posts {
 	}
 
 	/**
-	 * Update/add/delete meta for an object
-	 *
-	 * @deprecated WPAPI-1.2
-	 *
-	 * @param array $data
-	 * @param int $parent_id
-	 * @return bool|WP_Error
-	 */
-	protected function handle_post_meta_action( $post_id, $data ) {
-		_deprecated_function( 'WP_JSON_Posts::handle_post_meta_action', 'WPAPI-1.2', 'WP_JSON_Meta_Posts::handle_inline_meta' );
-
-		$handler = new WP_JSON_Meta_Posts( $this->server );
-		return $handler->_deprecated_call( 'handle_inline_meta', array( $post, $data, $is_raw ) );
-	}
-
-	/**
 	 * Check if the data provided is valid data
 	 *
 	 * @deprecated WPAPI-1.2

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1206,6 +1206,31 @@ class WP_JSON_Posts {
 	}
 
 	/**
+	 * Update/add/delete meta for a post.
+	 *
+	 * @param int $post_id
+	 * @param array $data
+	 * @return bool|WP_Error
+	 */
+	protected function handle_post_meta_action( $post_id, $data ) {
+		$handler = new WP_JSON_Meta_Posts( $this->server );
+
+		return $handler->handle_inline_meta( $post_id, $data['post_meta'] );
+	}
+
+	/**
+	 * Retrieve all meta for a post.
+	 *
+	 * @param int $post_id Post ID
+	 * @return (array[]|WP_Error) List of meta object data on success, WP_Error otherwise
+	 */
+	protected function handle_get_post_meta( $post_id ) {
+		$handler = new WP_JSON_Meta_Posts( $this->server );
+
+		return $handler->get_all_meta( $post_id );
+	}
+
+	/**
 	 * Retrieve custom fields for object
 	 *
 	 * @deprecated WPAPI-1.2

--- a/tests/test-json-posts.php
+++ b/tests/test-json-posts.php
@@ -539,10 +539,37 @@ class WP_Test_JSON_Posts extends WP_Test_JSON_TestCase {
 
 		$response = $this->endpoint->create_post( $data );
 		$response = json_ensure_response( $response );
+		$this->check_create_response( $response );
 
 		$response_data = $response->get_data();
 		$post_meta_value = get_post_meta( $response_data['ID'], 'testkey', true );
 		$this->assertEquals( 'testvalue', $post_meta_value );
+	}
+
+	function test_create_post_with_multiple_meta() {
+		$data = $this->set_data( array(
+			'post_meta' => array(
+				array(
+					'key' => 'some_meta',
+					'value' => 'some_value',
+				),
+				array(
+					'key' => 'some_other_meta',
+					'value' => 'some_other_value',
+				),
+		) ) );
+
+		$response = $this->endpoint->create_post( $data );
+		$response = json_ensure_response( $response );
+		$this->check_create_response( $response );
+
+		$response_data = $response->get_data();
+		$this->assertEquals( 2, count( $response_data['post_meta'] ) );
+
+		$post_meta_first_value = get_post_meta( $response_data['ID'], 'some_meta', true );
+		$post_meta_second_value = get_post_meta( $response_data['ID'], 'some_other_meta', true );
+		$this->assertEquals( 'some_value', $post_meta_first_value );
+		$this->assertEquals( 'some_other_value', $post_meta_second_value );
 	}
 
 	function test_get_post() {

--- a/tests/test-json-posts.php
+++ b/tests/test-json-posts.php
@@ -542,6 +542,8 @@ class WP_Test_JSON_Posts extends WP_Test_JSON_TestCase {
 		$this->check_create_response( $response );
 
 		$response_data = $response->get_data();
+		$this->assertEquals( 1, count( $response_data['post_meta'] ) );
+
 		$post_meta_value = get_post_meta( $response_data['ID'], 'testkey', true );
 		$this->assertEquals( 'testvalue', $post_meta_value );
 	}
@@ -584,6 +586,24 @@ class WP_Test_JSON_Posts extends WP_Test_JSON_TestCase {
 		$this->assertArrayHasKey( 'Last-Modified', $headers );
 
 		$this->check_get_post_response( $response, $this->post_obj );
+	}
+
+	function test_get_post_edit_context() {
+		add_post_meta( $this->post_id, 'some_meta', 'some_value', true );
+		add_post_meta( $this->post_id, 'some_other_meta', 'some_other_value', true );
+
+		$response = $this->endpoint->get_post( $this->post_id, 'edit' );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$response = json_ensure_response( $response );
+		$this->check_get_post_response( $response, $this->post_obj );
+
+		$headers = $response->get_headers();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'Last-Modified', $headers );
+
+		$response_data = $response->get_data();
+		$this->assertEquals( 2, count( $response_data['post_meta'] ) );
 	}
 
 	function test_get_revisions() {

--- a/tests/test-json-posts.php
+++ b/tests/test-json-posts.php
@@ -528,6 +528,23 @@ class WP_Test_JSON_Posts extends WP_Test_JSON_TestCase {
 		$this->assertFalse( is_sticky( $response_data['ID'] ) );
 	}
 
+	function test_create_post_with_meta() {
+		$data = $this->set_data( array(
+			'post_meta' => array(
+				array(
+					'key' => 'testkey',
+					'value' => 'testvalue',
+				),
+		) ) );
+
+		$response = $this->endpoint->create_post( $data );
+		$response = json_ensure_response( $response );
+
+		$response_data = $response->get_data();
+		$post_meta_value = get_post_meta( $response_data['ID'], 'testkey', true );
+		$this->assertEquals( 'testvalue', $post_meta_value );
+	}
+
 	function test_get_post() {
 		$response = $this->endpoint->get_post( $this->post_id );
 


### PR DESCRIPTION
During the split of the meta handling into it's own classes (#358) we broke documented functionality, including:

1. Allowing post_meta creation when creating a new post.
2. Allowing post_meta actions (add/edit/delete) when editing an existing post.
3. Returning post_meta values within the response for a post.

Additional unit tests needed here to make sure all edge cases are working as expected.

Originally identified by @tlovett1.