### PR TITLE
Add taxonomy to term data list

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -321,6 +321,7 @@ class WP_JSON_Taxonomies {
 			'name'        => $term->name,
 			'slug'        => $term->slug,
 			'description' => $term->description,
+			'taxonomy'    => $term->taxonomy,
 			'parent'      => (int) $term->parent,
 			'count'       => (int) $term->count,
 			'link'        => get_term_link( $term, $term->taxonomy ),


### PR DESCRIPTION
I was working on getting a little extra information into the taxonomy terms using the 'json_prepare_term' filter. It's surprising how difficult it is to get any extra information without the taxonomy slug. Really simple fix though.