### PR TITLE
Split permission checks

### DIFF
--- a/lib/class-wp-json-meta-posts.php
+++ b/lib/class-wp-json-meta-posts.php
@@ -30,7 +30,7 @@ class WP_JSON_Meta_Posts extends WP_JSON_Meta {
 			return new WP_Error( 'json_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
 		}
 
-		if ( ! json_check_edit_permission( $post ) ) {
+		if ( ! json_check_post_permission( $post, 'edit' ) ) {
 			return new WP_Error( 'json_cannot_edit', __( 'Sorry, you cannot edit this post' ), array( 'status' => 403 ) );
 		}
 


### PR DESCRIPTION
Began moving object permission checks into global functions.  This begins the process with the Post permission checks.  We will also need to do this for Users and Terms.

ef44a2d5988ef3973ae62f8d37ecd81c144b586f Changes my initial approach based on feedback from @rmccue 
