### PR TITLE
Pagination headers missing on /users or terms collections

### DIFF
--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -70,10 +70,7 @@ class WP_JSON_Users {
 		$args['offset'] = ( $page - 1 ) * $args['number'];
 
 		$user_query = new WP_User_Query( $args );
-		// try to set paged query var for users.
-		$user_query->set( 'paged', $page );
-
-		$response = new WP_JSON_Response();
+		$response   = new WP_JSON_Response();
 		$response->query_navigation_headers( $user_query, 'user' );
 
 		if ( empty( $user_query->results ) ) {

--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -58,7 +58,7 @@ class WP_JSON_Users {
 
 		$args = array(
 			'orderby' => 'user_login',
-			'order'   => 'ASC'
+			'order'   => 'ASC',
 		);
 		$args = array_merge( $args, $filter );
 
@@ -70,18 +70,26 @@ class WP_JSON_Users {
 		$args['offset'] = ( $page - 1 ) * $args['number'];
 
 		$user_query = new WP_User_Query( $args );
+		// try to set paged query var for users.
+		$user_query->set( 'paged', $page );
+
+		$response = new WP_JSON_Response();
+		$response->query_navigation_headers( $user_query, 'user' );
 
 		if ( empty( $user_query->results ) ) {
-			return array();
+			$response->set_data( array() );
+
+			return $response;
 		}
 
 		$struct = array();
-
 		foreach ( $user_query->results as $user ) {
 			$struct[] = $this->prepare_user( $user, $context );
 		}
 
-		return $struct;
+		$response->set_data( $struct );
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
The pagination headers are only getting set for `WP_JSON_Response` objects within the `get_posts` method. This means that there is no way to request a subset of users, or of terms. Users is the critical one, for me at least: the default wp-json/users endpoint returns a default collection of 10 posts (filterable via `number`), and the `page` query param works, but without the headers it is impossible to easily traverse the collection.