### PR TITLE
add a simple method get post by type and postname (no require authentica...

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -39,6 +39,10 @@ class WP_JSON_Posts {
 			'/posts/(?P<id>\d+)/revisions' => array(
 				array( $this, 'get_revisions' ),         WP_JSON_Server::READABLE
 			),
+			
+			'/posts/(?P<type>\w+)/(?P<path>[a-z\-]+)' => array(
+				array( $this, 'get_post_by_type_and_path'), WP_JSON_Server::READABLE
+			),
 
 			// Comments
 			'/posts/(?P<id>\d+)/comments' => array(
@@ -202,6 +206,21 @@ class WP_JSON_Posts {
 		return $response;
 	}
 
+	/**
+	 * Retrieve a simple post by path name
+	 * 
+	 * @param string $path
+	 */
+	public function get_post_by_type_and_path( $type, $path, $context = 'view' ) {
+
+		$post = get_page_by_path( $path, ARRAY_A, $type);		
+		if ( empty( $post ) ) {
+			return new WP_Error( 'json_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		}
+
+		return $this->get_post( $post['ID'], $context );
+	}
+	
 	/**
 	 * Check if we can read a post
 	 *


### PR DESCRIPTION
I have a java app running on tomcat that consumes the posts by WP-API and i would like to access posts by <b>Type and Postname/Path</b>.  However, if i understand the plugin just permits authenticated users by using filter params like a wp-query. Really is dangerous to leave this feature opened. So i created the route for posts/<type>/<postname> and the method to retrieve the post using wordpress native function (get_page_by_path)..  

I believe the change is not a invasive code, please, let me know if exists any concept distortion in my changeset.

Note:

In my case i have some codes in JSPs like..  for example: c:import url="wordpress/post/44888"
And in the case of a wodpress user recreate the post it would break my integration
