### PR TITLE
Create new method to do WP_Query and format as JSON

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -166,8 +166,23 @@ class WP_JSON_Posts {
 		// Special parameter handling
 		$query['paged'] = absint( $page );
 
+		$response = $this->do_query( $query, $context );
+
+		return $response;
+
+	}
+
+	/**
+	 * Creates a proper JSON response from a WP_QUERY arguments array.
+	 *
+	 * @param array $query_args An array of args to pass to WP_Query
+	 * @param string $context Optional. The context; 'view' (default) or 'edit'.
+	 *
+	 * @return WP_JSON_Response
+	 */
+	public function do_query( $query_args, $context = 'view' ) {
 		$post_query = new WP_Query();
-		$posts_list = $post_query->query( $query );
+		$posts_list = $post_query->query( $query_args );
 		$response   = new WP_JSON_Response();
 		$response->query_navigation_headers( $post_query );
 
@@ -200,6 +215,7 @@ class WP_JSON_Posts {
 		$response->set_data( $struct );
 
 		return $response;
+
 	}
 
 	/**


### PR DESCRIPTION
This pull request on its own, effectively does nothing, but it opens up a lot of options for developers. It splits the get_posts() method of the posts endpoint class into two methods. The first, get_posts(), does all the preparation work to do WP_Query. The second, do_query(), builds the WP_Query object and then formats it as a proper JSON response.

I'm working on a plugin, where I want to add a custom endpoint do some things for a plugin I'm working on that I can't do with the existing posts endpoint. In order to do it, I created a class with over 400 lines of code, about 375 of which are pasted from WP_JSON_Posts. I needed all that code to do permissions checks, and format the JSON. Instead of all of that redundant, hard to maintain code, this PR would allow me to just build my own WP_Query args and pass them into the new method.