### PR TITLE
WP_JSON_Posts::get_post_types() should return array, not hash/object

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -546,7 +546,7 @@ class WP_JSON_Posts {
 				continue;
 			}
 
-			$types[ $name ] = $type;
+			$types[] = $type;
 		}
 
 		return $types;


### PR DESCRIPTION
`WP_JSON_Posts::get_post_types()` may have had some old code around. it was returning an object whose keys were the Posttype names, rather than an array of objects. Discovered this while exploring the client-js repo.