### PR TITLE
`prepare_post()` can return `WP_Error`

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -194,6 +194,9 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	 */
 	protected function prepare_post( $post, $context = 'view' ) {
 		$_post = parent::prepare_post( $post, $context );
+		if ( is_wp_error( $_post ) ) {
+			return $_post;
+		}
 
 		// Override entity meta keys with the correct links
 		$_post['meta'] = array(


### PR DESCRIPTION
Catch before we try to use it as an array
