### PR TITLE
add handler for terms and term_names in insert_post method like it was in xml-rpc

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -1065,6 +1065,103 @@ class WP_JSON_Posts {
 			$post['post_format'] = $data['post_format'];
 		}
 
+		//====================================================================================================
+		// Post terms 
+		// http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.newPost
+		if ( isset( $data['terms'] ) || isset( $data['terms_names'] ) ) {
+			$post_type_taxonomies = get_object_taxonomies( $post['post_type'], 'objects' );
+
+			// accumulate term IDs from terms and terms_names
+			$terms = array();
+
+			// first validate the terms specified by ID
+			if ( isset( $data['terms'] ) && is_array( $data['terms'] ) ) {
+				$taxonomies = array_keys( $data['terms'] );
+
+				// validating term ids
+				foreach ( $taxonomies as $taxonomy ) {
+					if ( ! array_key_exists( $taxonomy , $post_type_taxonomies ) )
+						return new WP_Error( 'json_not_supported_taxonomy', __( 'One of the given taxonomies is not supported by the post type.' ), array( 'status' => 401 ) );
+
+					if ( ! current_user_can( $post_type_taxonomies[$taxonomy]->cap->assign_terms ) )
+						return new WP_Error( 'json_cannot_assign_taxonomy', __( 'You are not allowed to assign a term to one of the given taxonomies.' ), array( 'status' => 401 ) );
+
+					$term_ids = $data['terms'][$taxonomy];
+					$terms[ $taxonomy ] = array();
+					foreach ( $term_ids as $term_id ) {
+						$term = get_term_by( 'id', $term_id, $taxonomy );
+
+						if ( ! $term )
+						 	return new WP_Error( 'json_invalid_term_id', __( 'Invalid term ID' ), array( 'status' => 403 ) );
+							//return new IXR_Error( 403, __( 'Invalid term ID' ) );
+
+						$terms[$taxonomy][] = (int) $term_id;
+					}
+				}
+			}
+
+			// now validate terms specified by name
+			if ( isset( $data['terms_names'] ) && is_array( $data['terms_names'] ) ) {
+				$taxonomies = array_keys( $data['terms_names'] );
+
+				foreach ( $taxonomies as $taxonomy ) {
+					if ( ! array_key_exists( $taxonomy , $post_type_taxonomies ) ) {
+						return new WP_Error( 'json_not_supported_taxonomy', __( 'One of the given taxonomies is not supported by the post type.' ), array( 'status' => 401 ) );
+					}
+
+					if ( ! current_user_can( $post_type_taxonomies[$taxonomy]->cap->assign_terms ) ) {
+						return new WP_Error( 'json_cannot_assign_taxonomy', __( 'You are not allowed to assign a term to one of the given taxonomies.' ), array( 'status' => 401 ) );
+					}
+
+					// for hierarchical taxonomies, we can't assign a term when multiple terms in the hierarchy share the same name
+					$ambiguous_terms = array();
+					if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+						$tax_term_names = get_terms( $taxonomy, array( 'fields' => 'names', 'hide_empty' => false ) );
+
+						// count the number of terms with the same name
+						$tax_term_names_count = array_count_values( $tax_term_names );
+
+						// filter out non-ambiguous term names
+						$ambiguous_tax_term_counts = array_filter( $tax_term_names_count, array( $this, '_is_greater_than_one') );
+
+						$ambiguous_terms = array_keys( $ambiguous_tax_term_counts );
+					}
+
+					$term_names = $data['terms_names'][$taxonomy];
+					foreach ( $term_names as $term_name ) {
+						if ( in_array( $term_name, $ambiguous_terms ) ) {
+							return new WP_Error( 'json_invalid_term_name', __( 'Ambiguous term name used in a hierarchical taxonomy. Please use term ID instead.' ), array( 'status' => 401 ) );
+						}
+
+						$term = get_term_by( 'name', $term_name, $taxonomy );
+
+						if ( ! $term ) {
+							// term doesn't exist, so check that the user is allowed to create new terms
+							if ( ! current_user_can( $post_type_taxonomies[$taxonomy]->cap->edit_terms ) ) {
+								return new WP_Error( 'json_cannot_add_term_to_tax', __( 'You are not allowed to add a term to one of the given taxonomies.' ), array( 'status' => 401 ) );
+							}
+							// create the new term
+							$term_info = wp_insert_term( $term_name, $taxonomy );
+							if ( is_wp_error( $term_info ) ) {
+								return new WP_Error( 'json_insert_term_error', $term_info->get_error_message(), array( 'status' => 500 ) );
+							}
+
+							$terms[$taxonomy][] = (int) $term_info['term_id'];
+						} else {
+							$terms[$taxonomy][] = (int) $term->term_id;
+						}
+					}
+				}
+			}
+
+			$post['tax_input'] = $terms;
+			unset( $post['terms'], $post['terms_names'] );
+		} else {
+			// do not allow direct submission of 'tax_input', clients must use 'terms' and/or 'terms_names'
+			unset( $post['tax_input'], $post['post_category'], $post['tags_input'] );
+		}
+		//============================================================================================================
+
 		// Pre-insert hook
 		$can_insert = apply_filters( 'json_pre_insert_post', true, $post, $data, $update );
 


### PR DESCRIPTION
Here I tried to make the same logic as it was in wordpress xml-rpc plugin. There you can sent only term_names like { category: ['cat1', 'cat2', 'cat3'], post_tag: ['tag1', 'tag2', 'tag3'] } without any ids and api can add unexist terms automatically.@see http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.newPost 