### PR TITLE
Add the path as a parameter on posts.

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -550,6 +550,7 @@ class WP_JSON_Posts {
 			'parent'          => (int) $post['post_parent'],
 			#'post_mime_type' => $post['post_mime_type'],
 			'link'            => get_permalink( $post['ID'] ),
+			'path'            => wp_make_link_relative( get_permalink( $post['ID'] ) ),
 		);
 
 		$post_fields_extended = array(


### PR DESCRIPTION
What if we added the path to posts object? I know this isn't totally flushed out, but I think that working with remote data, you don't necessarily want the whole URL as the only option. The ID is an option, but this is handy...
