### PR TITLE
Add backwards compatibility for ACCEPT_RAW, ACCEPT_JSON, and HIDDEN_ENDPOINT

### DIFF
--- a/lib/class-wp-json-request.php
+++ b/lib/class-wp-json-request.php
@@ -44,6 +44,13 @@ class WP_JSON_Request implements ArrayAccess {
 	protected $body = null;
 
 	/**
+	 * JSON Decoded data
+	 *
+	 * @var array Decoded array of JSON data
+	 */
+	protected $json_body = null;
+
+	/**
 	 * Route matched for the request
 	 *
 	 * @var string
@@ -430,5 +437,41 @@ class WP_JSON_Request implements ArrayAccess {
 				unset( $this->params['GET'][ $offset ] );
 				break;
 		}
+	}
+
+	public function set_raw_data( $data = null ) {
+		if ( ! empty( $data ) ) {
+			$this->body = $data;
+			return true;
+		}
+		return false;
+	}
+
+	public function get_json() {
+		if ( null !== $this->json_body ) {
+			return $this->json_body;
+		}
+		if ( ! empty( $this->body ) ) {
+			$data = json_decode( $this->body, true );
+
+			// @todo Make get_json_last_error accessible
+			/*
+			// test for json_decode() error
+			$json_error_message = $this->get_json_last_error();
+			if ( $json_error_message ) {
+
+				$data = array();
+				parse_str( $raw_data, $data );
+
+				if ( empty( $data ) ) {
+					return new WP_Error( 'json_decode_error', $json_error_message, array( 'status' => 500 ) );
+				}
+			}
+			*/
+			$this->json_body = $data;
+
+			return $data;
+		}
+		return false;
 	}
 }

--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -29,14 +29,17 @@ class WP_JSON_Server {
 
 	/**
 	 * Does the endpoint accept raw JSON entities?
+	 * For v1 backwards compatibility
 	 */
-	const ACCEPT_RAW = 64;
-	const ACCEPT_JSON = 128;
+	const ACCEPT_RAW = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0, ACCEPT_RAW";
+	const ACCEPT_JSON = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0, ACCEPT_JSON";
+	//const ACCEPT_RAW = 64;
+	//const ACCEPT_JSON = 128;
 
 	/**
 	 * Should we hide this endpoint from the index?
 	 */
-	const HIDDEN_ENDPOINT = 256;
+	const HIDDEN_ENDPOINT = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0, HIDDEN_ENDPOINT";
 
 	/**
 	 * Map of HTTP verbs to constants
@@ -210,6 +213,7 @@ class WP_JSON_Server {
 		if ( isset( $_GET['_method'] ) ) {
 			$request->set_method( strtoupper( $_GET['_method'] ) );
 		}
+		$request->set_raw_data( $this->get_raw_data() );
 
 		$result = $this->check_authentication();
 
@@ -472,36 +476,6 @@ class WP_JSON_Server {
 				if ( ! is_callable( $callback ) ) {
 					return new WP_Error( 'json_invalid_handler', __( 'The handler for the route is invalid' ), array( 'status' => 500 ) );
 				}
-
-				/*
-				if ( ! empty( $handler['accept_json'] ) ) {
-					$raw_data = $this->get_raw_data();
-					$data = json_decode( $raw_data, true );
-
-					// test for json_decode() error
-					$json_error_message = $this->get_json_last_error();
-					if ( $json_error_message ) {
-
-						$data = array();
-						parse_str( $raw_data, $data );
-
-						if ( empty( $data ) ) {
-
-							return new WP_Error( 'json_decode_error', $json_error_message, array( 'status' => 500 ) );
-						}
-					}
-
-					if ( $data !== null ) {
-						$args = array_merge( $args, array( 'data' => $data ) );
-					}
-				} elseif ( ! empty( $handler['accept_raw'] ) ) {
-					$data = $this->get_raw_data();
-
-					if ( ! empty( $data ) ) {
-						$args = array_merge( $args, array( 'data' => $data ) );
-					}
-				}
-				*/
 
 				$request->set_url_params( $args );
 				$request->set_attributes( $handler );


### PR DESCRIPTION
Still needs some docs and a bit more work, proof of concept to see if this is a reasonable way to handle it.

My thought is that endpoints using the new form will access the data with $request->get_body or $request->get_json instead of expecting it to be in $args['data'] based on accept_raw or accept_json