### PR TITLE
Allow 'ignore_sticky_posts' filter #415

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -229,7 +229,7 @@ class WP_JSON_Posts {
 		}
 
 		// Define our own in addition to WP's normal vars
-		$json_valid = array( 'posts_per_page' );
+		$json_valid = array( 'posts_per_page', 'ignore_sticky_posts' );
 		$valid_vars = array_merge( $valid_vars, $json_valid );
 
 		// Filter and flip for querying


### PR DESCRIPTION
In #415 @rmccue says "We should allow the ignore_sticky_posts" this makes it so.
