### PR TITLE
Change on the term id value

### DIFF
--- a/lib/class-wp-json-taxonomies.php
+++ b/lib/class-wp-json-taxonomies.php
@@ -125,7 +125,7 @@ class WP_JSON_Taxonomies {
 		$base_url = '/taxonomies/' . $term->taxonomy . '/terms';
 
 		$data = array(
-			'id'          => (int) $term->term_taxonomy_id,
+			'id'          => (int) $term->term_id,
 			'name'        => $term->name,
 			'slug'        => $term->slug,
 			'description' => $term->description,


### PR DESCRIPTION
The term_taxonomy_id is not the "real" ID and and is not the same as term_id. If we want to pass the ID through url in an app it's impossible to get the json with it. If you want maybe you could pass the two different ID.
