### PR TITLE
Add post_class to posts endpoint

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -710,6 +710,7 @@ class WP_JSON_Posts {
 			'comment_status' => $post['comment_status'],
 			'ping_status'    => $post['ping_status'],
 			'sticky'         => ( $post['post_type'] === 'post' && is_sticky( $post['ID'] ) ),
+			'post_class'     => get_post_class( $post['ID'] ),
 		);
 
 		$post_fields_raw = array(


### PR DESCRIPTION
I'm currently building a theme with WP-API and it would definitely be helpful if posts also returned the post_class.
