### PR TITLE
Speed up builds by only running against MS once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,13 @@ language: php
 php:
     - 5.2
     - 5.3
-    - 5.4
     - 5.5
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=latest WP_MULTISITE=1
 
 matrix:
-  exclude:
-    - php: 5.2
-      env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+  include:
     - php: 5.4
       env: WP_VERSION=latest WP_MULTISITE=1
 


### PR DESCRIPTION
Ends up like this:

![image](https://cloud.githubusercontent.com/assets/36432/5174130/69c4de9c-73e3-11e4-9459-50e8ef109d7a.png)

I'd argue we really need one build per PHP version, and we could probably skip 5.4.

@WP-API/amigos opinions?
