### PR TITLE
`->prepare_post()` should be public

### DIFF
--- a/lib/class-wp-json-customposttype.php
+++ b/lib/class-wp-json-customposttype.php
@@ -212,7 +212,7 @@ abstract class WP_JSON_CustomPostType extends WP_JSON_Posts {
 	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
-	protected function prepare_post( $post, $context = 'view' ) {
+	public function prepare_post( $post, $context = 'view' ) {
 		$_post = parent::prepare_post( $post, $context );
 
 		// Override entity meta keys with the correct links

--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -102,7 +102,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	 * @param array $post
 	 * @return array
 	 */
-	protected function prepare_post( $post, $context = 'single' ) {
+	public function prepare_post( $post, $context = 'single' ) {
 		$data = parent::prepare_post( $post, $context );
 
 		if ( is_wp_error( $data ) || $post['post_type'] !== 'attachment' ) {
@@ -216,7 +216,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	public function upload_attachment( $_files, $_headers, $data = null, $post_id = 0 ) {
 
 		$post_type = get_post_type_object( 'attachment' );
-		
+
 		if ( $post_id == 0 ) {
 			$post_parent_type = get_post_type_object( 'post' );
 		} else {

--- a/lib/class-wp-json-pages.php
+++ b/lib/class-wp-json-pages.php
@@ -119,7 +119,7 @@ class WP_JSON_Pages extends WP_JSON_CustomPostType {
 	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
-	protected function prepare_post( $post, $context = 'view' ) {
+	public function prepare_post( $post, $context = 'view' ) {
 		$_post = parent::prepare_post( $post, $context );
 
 		// Override entity meta keys with the correct links

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -649,7 +649,7 @@ class WP_JSON_Posts {
 	 * @param string $context The context for the prepared post. (view|view-revision|edit|embed|single-parent)
 	 * @return array The prepared post data
 	 */
-	protected function prepare_post( $post, $context = 'view' ) {
+	public function prepare_post( $post, $context = 'view' ) {
 		// Holds the data for this post.
 		$_post = array( 'id' => (int) $post['ID'] );
 


### PR DESCRIPTION
Plugins need to generate a compatible post structure at times.

Example:

```
$a = get_post( $post['ID'], ARRAY_A );
$p = $wp_json_posts->prepare_post( $a, 'view' );
```
