### PR TITLE
Register multiple routes for users correctly

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -225,11 +225,13 @@ function create_initial_json_routes() {
 	) );
 
 	register_json_route( 'wp', '/users/(?P<id>[\d]+)', array(
-		'methods'         => 'GET',
-		'callback'        => array( $controller, 'get_item' ),
-		'args'            => array(
-			'context'          => array(
-				'required'         => false,
+		array(
+			'methods'         => 'GET',
+			'callback'        => array( $controller, 'get_item' ),
+			'args'            => array(
+				'context'          => array(
+					'required'         => false,
+				),
 			),
 		),
 		array(


### PR DESCRIPTION
Right now, this is only registering the GET route, as the PUT one is embedded underneath it. This puts them on equal standing.
