### PR TITLE
Check get_post_type_object() returns an object before using it

### DIFF
--- a/lib/class-wp-json-meta-posts.php
+++ b/lib/class-wp-json-meta-posts.php
@@ -24,7 +24,7 @@ class WP_JSON_Meta_Posts extends WP_JSON_Meta {
 	protected function check_edit_permission( $post ) {
 		$post_type = get_post_type_object( $post['post_type'] );
 		
-		return current_user_can( $post_type->cap->edit_post, $post['ID'] );
+		return ! empty( $post_type ) && current_user_can( $post_type->cap->edit_post, $post['ID'] );
 	}
 
 	/**

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -365,7 +365,7 @@ class WP_JSON_Posts {
 
 		$post_type = get_post_type_object( $post['post_type'] );
 
-		if ( ! current_user_can( $post_type->cap->delete_post, $id ) ) {
+		if ( empty( $post_type ) || ! current_user_can( $post_type->cap->delete_post, $id ) ) {
 			return new WP_Error( 'json_user_cannot_delete_post', __( 'Sorry, you are not allowed to delete this post.' ), array( 'status' => 401 ) );
 		}
 
@@ -394,7 +394,7 @@ class WP_JSON_Posts {
 		$post_type = get_post_type_object( $post['post_type'] );
 
 		// Ensure the post type can be read
-		if ( ! $post_type->show_in_json ) {
+		if ( empty( $post_type ) || ! $post_type->show_in_json ) {
 			return false;
 		}
 
@@ -429,7 +429,7 @@ class WP_JSON_Posts {
 	protected function check_edit_permission( $post ) {
 		$post_type = get_post_type_object( $post['post_type'] );
 
-		return current_user_can( $post_type->cap->edit_post, $post['ID'] );
+		return ! empty( $post_type ) && current_user_can( $post_type->cap->edit_post, $post['ID'] );
 	}
 
 	/**
@@ -554,7 +554,7 @@ class WP_JSON_Posts {
 			$type = get_post_type_object( $type );
 		}
 
-		if ( $type->show_in_json === false ) {
+		if ( empty( $type ) || $type->show_in_json === false ) {
 			return new WP_Error( 'json_cannot_read_type', __( 'Cannot view post type' ), array( 'status' => 403 ) );
 		}
 


### PR DESCRIPTION
This PR checks the return of get_post_type_object() in a few places where the code assumes it will return a post type object. It will [return NULL](http://codex.wordpress.org/Function_Reference/get_post_type_object#Return_Values) if a post type for a requested post is no longer registered (for instance, if a plugin has been disabled).

![wp-api-php-notice](https://cloud.githubusercontent.com/assets/2306629/5218322/5323abfc-7643-11e4-95ce-96315ac01cb9.png)

I scanned the code for get_post_type_object() and fixed all those instances where no checks were in place, with two exceptions.
1. [/lib/class-wp-json-posts.php:652](https://github.com/WP-API/WP-API/blob/develop/lib/class-wp-json-posts.php#L652) - The next line calls WP_JSON_Posts::check_read_permissions(). In the event of an unregistered post type, it will return before the $post_type var is used anway. However, it seems like the check_read_permissions() call could be made at the top of that method, before the call to get_post_type_object().
2. [/lib/class-wp-json-posts.php:915](https://github.com/WP-API/WP-API/blob/develop/lib/class-wp-json-posts.php#L915) - get_post_type_object() is called on a post type that is pulled from the database while updating a post. I left this one without a check because I am not familiar enough with the API yet to know whether the API would have returned an error before this step anyway. Will it block an update to a post type that is not registered?

The use-case which led me to this issue involved securing non-public posts that still need to be exposed to the API (provided other authentication checks are passed). If a post can be updated via the API for a type that is no longer registered, how would WordPress know which user permissions to apply to that action?
