### PR TITLE
Remove from docs the "post_type" filter parameter for /posts endpoint

### DIFF
--- a/docs/routes/routes.md
+++ b/docs/routes/routes.md
@@ -149,7 +149,6 @@ The following query variables are available to the API:
 * `taxonomy`
 * `term`
 * `cpage`
-* `post_type`
 * `posts_per_page`
 
 In addition, the following are available when authenticated as a user with


### PR DESCRIPTION
The post type must be passed as a ```type``` parameter with the GET request, not as a query variable for for the ```filter``` parameter.

Post types are pulled from ```type``` parameter [here](https://github.com/WP-API/WP-API/blob/develop/lib/class-wp-json-posts.php#L206-L214) and any ```post_type``` query variable in the ```filter``` parameter is discarded [here](https://github.com/WP-API/WP-API/blob/develop/lib/class-wp-json-posts.php#L241).

```type``` parameter is already documented a little farther down in the docs.