### PR TITLE
Fix bug in check_required_parameters where JSON params were missed

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -472,13 +472,14 @@ class WP_JSON_Server {
 		}
 
 		foreach ( $attributes['args'] as $key => $arg ) {
-			if ( true === $arg['required'] && ! isset( $request[ $key ] ) ) {
+			$param = $request->get_param( $key );
+			if ( true === $arg['required'] && ! empty( $param ) ) {
 				$required[] = $key;
 			}
 		}
 
 		if ( ! empty( $required ) ) {
-			return new WP_Error( 'json_missing_callback_param', sprintf( __( 'Missing parameter(s) %s' ), implode( ', ', $required) ), array( 'status' => 400 ) );
+			return new WP_Error( 'json_missing_callback_param', sprintf( __( 'Missing parameter(s) %s' ), implode( ', ', $required ) ), array( 'status' => 400 ) );
 		}
 
 		return true;


### PR DESCRIPTION
Request parameters can be in the form of URL, POST, FILE, or JSON, we need to make sure we are checking all request parameters before determining if required parameters are missing from the request.
