### PR TITLE
Parse URL-encoded body with PUT requests

### DIFF
--- a/lib/class-wp-json-request.php
+++ b/lib/class-wp-json-request.php
@@ -348,6 +348,26 @@ class WP_JSON_Request implements ArrayAccess {
 	}
 
 	/**
+	 * Get merged parameters from the request
+	 *
+	 * The equivalent of {@see get_param}, but returns all parameters for the
+	 * request. Handles merging all the available values into a single array.
+	 *
+	 * @return array Map of key to value
+	 */
+	public function get_params() {
+		$order = $this->get_parameter_order();
+		$order = array_reverse( $order, true );
+
+		$params = array();
+		foreach ( $order as $type ) {
+			$params = array_merge( $params, $this->params[ $type ] );
+		}
+
+		return $params;
+	}
+
+	/**
 	 * Get parameters from the route itself
 	 *
 	 * These are parsed from the URL using the regex.

--- a/tests/test-json-request.php
+++ b/tests/test-json-request.php
@@ -212,4 +212,18 @@ class WP_Test_JSON_Request extends WP_UnitTestCase {
 			$this->assertEquals( $expected_value, $this->request->get_param( $key ) );
 		}
 	}
+
+	public function test_parameter_merging() {
+		$this->request_with_parameters();
+
+		$this->request->set_method( 'POST' );
+
+		$expected = array(
+			'source' => 'body',
+			'has_url_params' => true,
+			'has_query_params' => true,
+			'has_body_params' => true,
+		);
+		$this->assertEquals( $expected, $this->request->get_params() );
+	}
 }


### PR DESCRIPTION
Also parses for PATCH requests, but it's unlikely those will ever be sent as URL-encoded.

Fixes #671.
