### PR TITLE
enable getting users by slug OR id, not just ID

### DIFF
--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -30,7 +30,7 @@ class WP_JSON_Users {
 				array( array( $this, 'get_users' ),        WP_JSON_Server::READABLE ),
 				array( array( $this, 'create_user' ),      WP_JSON_Server::CREATABLE | WP_JSON_Server::ACCEPT_JSON ),
 			),
-			'/users/(?P<id>\d+)' => array(
+			'/users/(?P<id>\w+)' => array(
 				array( array( $this, 'get_user' ),         WP_JSON_Server::READABLE ),
 				array( array( $this, 'edit_user' ),        WP_JSON_Server::EDITABLE | WP_JSON_Server::ACCEPT_JSON ),
 				array( array( $this, 'delete_user' ),      WP_JSON_Server::DELETABLE ),
@@ -130,7 +130,13 @@ class WP_JSON_Users {
 			return new WP_Error( 'json_user_cannot_list', __( 'Sorry, you are not allowed to view this user.' ), array( 'status' => 403 ) );
 		}
 
-		$user = get_userdata( $id );
+		
+		if (is_numeric($id)){
+			$user = get_user_by('id', $id ); //Can also do get_userdata($id) but this is just an alias
+		} else {
+			$user = get_user_by('slug', $id );
+		}
+
 
 		if ( empty( $user->ID ) ) {
 			return new WP_Error( 'json_user_invalid_id', __( 'Invalid user ID.' ), array( 'status' => 400 ) );


### PR DESCRIPTION
As it doesn't seem possible to get a user by nicename / slug, and I needed this functionality, this pull req enables that. It only does 2 small changes:
- Enable /users/ID where ID can be non-numeric
- Check if ID is numeric. If numeric, it is treated as ID, otherwise as slug.
