### PR TITLE
Fields cleanup for User controller

### DIFF
--- a/lib/class-wp-json-users-controller.php
+++ b/lib/class-wp-json-users-controller.php
@@ -222,7 +222,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 			'nickname'    => $user->nickname,
 			'slug'        => $user->user_nicename,
 			'url'         => $user->user_url,
-			'avatar'      => json_get_avatar_url( $user->user_email ),
+			'avatar_url'  => json_get_avatar_url( $user->user_email ),
 			'description' => $user->description,
 		);
 

--- a/tests/test-json-users-controller.php
+++ b/tests/test-json-users-controller.php
@@ -241,7 +241,7 @@ class WP_Test_JSON_Users_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( $user->nickname, $data['nickname'] );
 		$this->assertEquals( $user->user_nicename, $data['slug'] );
 		$this->assertEquals( $user->user_url, $data['url'] );
-		$this->assertEquals( json_get_avatar_url( $user->user_email ), $data['avatar'] );
+		$this->assertEquals( json_get_avatar_url( $user->user_email ), $data['avatar_url'] );
 		$this->assertEquals( $user->description, $data['description'] );
 
 		if ( 'view' == $context ) {


### PR DESCRIPTION
- Only expose `username` in `edit` context.
- Rename `registered` to `registered_date`, and only expose in `view` context.
- Rename `avatar` to `avatar_url`.
- Some test coverage to address potential data leakage.

See #605
