### PR TITLE
Update class-wp-json-media.php

### DIFF
--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -457,7 +457,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 			// Already verified in preinsert_check()
 			$thumbnail = $this->get_post( $data['featured_image'], 'child' );
 
-			set_post_thumbnail( $post['ID'], $thumbnail['ID'] );
+			set_post_thumbnail( $post['ID'], $thumbnail->data['ID'] );
 		}
 	}
 


### PR DESCRIPTION
$thumbnail is a WP_JSON_Posts
ID is a dimension to data.

For your interest :
The post property "post_thumbnail" mentionned into the documentation (http://wp-api.org/#entities_post_post-thumbnail) is replaced by "featured_image" into the code.
