### PR TITLE
Default `args` to an empty array

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -464,6 +464,7 @@ class WP_JSON_Server {
 			'accept_json'   => false,
 			'accept_raw'    => false,
 			'show_in_index' => true,
+			'args'          => array(),
 		);
 		foreach ( $endpoints as $route => &$handlers ) {
 			if ( isset( $handlers['callback'] ) ) {


### PR DESCRIPTION
It's always referred to in `dispatch()`, so it needs to be set.

Fixes #740