### PR TITLE
Do not require type parameter to be set when updating a Post

### DIFF
--- a/lib/class-wp-json-base-posts-controller.php
+++ b/lib/class-wp-json-base-posts-controller.php
@@ -199,7 +199,7 @@ abstract class WP_JSON_Base_Posts_Controller extends WP_JSON_Controller {
 			return new WP_Error( 'json_post_cannot_edit', __( 'Sorry, you are not allowed to edit this post.' ), array( 'status' => 403 ) );
 		}
 
-		if ( $request['type'] != $post->post_type ) {
+		if ( isset( $request['type'] ) && $request['type'] != $post->post_type ) {
 			return new WP_Error( 'json_cannot_change_post_type', __( 'The post type may not be changed.' ), array( 'status' => 400 ) );
 		}
 

--- a/lib/class-wp-json-base-posts-controller.php
+++ b/lib/class-wp-json-base-posts-controller.php
@@ -416,6 +416,9 @@ abstract class WP_JSON_Base_Posts_Controller extends WP_JSON_Controller {
 		} elseif ( empty( $request['id'] ) ) {
 			// Creating new post, use default type
 			$prepared_post->post_type = apply_filters( 'json_insert_default_post_type', 'post' );
+		} else {
+			// Updating a post, use previous type.
+			$prepared_post->post_type = get_post_type( $request['id'] );
 		}
 		$post_type = get_post_type_object( $prepared_post->post_type );
 

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -586,6 +586,21 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( $params['excerpt']['raw'], $post->post_excerpt );
 	}
 
+	public function test_update_post_without_extra_params() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data();
+		unset( $params['type'] );
+		unset( $params['name'] );
+		unset( $params['author'] );
+		unset( $params['status'] );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$this->check_create_update_post_response( $response );
+	}
+
 	public function test_update_post_without_permisson() {
 		wp_set_current_user( $this->editor_id );
 		$user = wp_get_current_user();


### PR DESCRIPTION
Fixes #760

Only check if a post_type is being changed if the type parameter is set.
Fallback to the post_type of the post being updated when doing permission checks.
Includes unit test.