### PR TITLE
Register post types for API based on `access_in_json` argument

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -76,16 +76,40 @@ function register_json_route( $namespace, $route, $args = array(), $override = f
 }
 
 /**
+ * Add the extra Post Type registration arguments we need
+ * These attributes will eventually be committed to core.
+ */
+function _add_extra_api_post_type_arguments() {
+	global $wp_post_types;
+
+	$wp_post_types['post']->access_in_json = true;
+	$wp_post_types['post']->json_base = 'posts';
+	$wp_post_types['post']->json_controller_class = 'WP_JSON_Posts_Controller';
+
+	$wp_post_types['page']->access_in_json = true;
+	$wp_post_types['page']->json_base = 'pages';
+	$wp_post_types['page']->json_controller_class = 'WP_JSON_Posts_Controller';
+
+	// $wp_post_types['attachment']->access_in_json = true;
+	// $wp_post_types['attachment']->json_base = 'media';
+	// $wp_post_types['attachment']->json_controller_class = 'WP_JSON_Attachments_Controller';
+
+}
+add_action( 'init', '_add_extra_api_post_type_arguments', 11 );
+
+/**
  * Register default JSON API routes
  */
 function create_initial_json_routes() {
 
 	/*
-	 * Posts
+	 * Post types
 	 */
-	foreach( get_post_types( array( 'public' => true ) ) as $post_type ) {
-		$controller = new WP_JSON_Posts_Controller( $post_type );
-		$base = $post_type . 's';
+	foreach( get_post_types( array( 'access_in_json' => true ), 'objects' ) as $post_type ) {
+
+		$class = ! empty( $post_type->json_controller_class ) ? $post_type->json_controller_class : 'WP_JSON_Posts_Controller';
+		$controller = new $class( $post_type->name );
+		$base = ! empty( $post_type->json_base ) ? $post_type->json_base : $post_type->name;
 		register_json_route( 'wp', '/' . $base, array(
 			array(
 				'methods'         => WP_JSON_Server::READABLE,


### PR DESCRIPTION
`json_base` specifies the base slug used for the post type. Like core's
existing behavior, it will use `name` as the default.

`json_controller_class` probably needs a better name. It specifies which
controller class to use, because more complex post types will break
outside the standard `WP_JSON_Posts_Controller` class.

See #759, #718