### PR TITLE
Update class-wp-json-media.php  Missing argument 2 error

### DIFF
--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -213,7 +213,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 	 * @param array $_headers HTTP headers from the request
 	 * @return array|WP_Error Attachment data or error
 	 */
-	public function upload_attachment( $_files, $_headers, $data = null, $post_id = 0 ) {
+	public function upload_attachment( $_files, $_headers = array(), $data = null, $post_id = 0 ) {
 
 		$post_type = get_post_type_object( 'attachment' );
 


### PR DESCRIPTION
Warning: Missing argument 2 for WP_JSON_Media::upload_attachment() in E:\xampp\www\wordpress\wp-content\plugins\WP-API\lib\class-wp-json-media.php on line 216

and 
print_r($_files);
here
$_files is a WP_JSON_Request Object 

so line 247 upload_from_file function
line 392 $_files['file'] got nothing!
https://github.com/WP-API/WP-API/blob/develop/lib/class-wp-json-media.php#L392