### PR TITLE
Build JSON URL off site_url instead of home_url

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -568,12 +568,12 @@ function json_get_url_prefix() {
  */
 function get_json_url( $blog_id = null, $path = '', $scheme = 'json' ) {
 	if ( get_option( 'permalink_structure' ) ) {
-		$url = get_home_url( $blog_id, json_get_url_prefix(), $scheme );
+		$url = get_site_url( $blog_id, json_get_url_prefix(), $scheme );
 
 		if ( ! empty( $path ) && is_string( $path ) && strpos( $path, '..' ) === false )
 			$url .= '/' . ltrim( $path, '/' );
 	} else {
-		$url = trailingslashit( get_home_url( $blog_id, '', $scheme ) );
+		$url = trailingslashit( get_site_url( $blog_id, '', $scheme ) );
 
 		if ( empty( $path ) ) {
 			$path = '/';


### PR DESCRIPTION
I am using the API on a site with `FORCE_SSL_ADMIN` set to `true`. The site_url and home_url are both http URLs. I am using the API to make requests within the admin (forced to https). `get_home_url` does not obey `FORCE_SSL_ADMIN` so `get_json_url()` is returning a non-https link resulting in a mixed content warning.