### PR TITLE
Make json_pre_dispatch and json_post_dispatch consistent

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -245,7 +245,7 @@ class WP_JSON_Server {
 		 * @param WP_JSON_Response $result
 		 * @param WP_JSON_Request $request
 		 */
-		$result = apply_filters( 'json_post_dispatch', json_ensure_response( $result ), $request );
+		$result = apply_filters( 'json_post_dispatch', json_ensure_response( $result ), $this, $request );
 
 		// Wrap the response in an envelope if asked for
 		if ( isset( $_GET['_envelope'] ) ) {


### PR DESCRIPTION
Currently `json_post_dispatch` passes the response data and the request
object, whereas the `json_pre_dispatch` passes the response data (null), the
server and the request object.

These filters should be consistent.