### PR TITLE
Normalize our test classes setUP and tearDown methods

### DIFF
--- a/tests/class-wp-test-json-controller-testcase.php
+++ b/tests/class-wp-test-json-controller-testcase.php
@@ -2,11 +2,19 @@
 
 abstract class WP_Test_JSON_Controller_Testcase extends WP_Test_JSON_TestCase {
 
+	protected $server;
+
 	public function setUp() {
 		parent::setUp();
 		global $wp_json_server;
 		$this->server = $wp_json_server = new WP_JSON_Server;
 		do_action( 'wp_json_server_before_serve' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		global $wp_json_server;
+		$wp_json_server = null;
 	}
 
 	abstract public function test_register_routes();

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -21,15 +21,11 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 		) );
 
 		$this->endpoint = new WP_JSON_Posts_Controller;
-		$this->server = $GLOBALS['wp_json_server'];
 	}
 
 	public function test_register_routes() {
-		global $wp_json_server;
-		$wp_json_server = new WP_JSON_Server;
-		do_action( 'wp_json_server_before_serve' );
+		$routes = $this->server->get_routes();
 
-		$routes = $wp_json_server->get_routes();
 		$this->assertArrayHasKey( '/wp/posts', $routes );
 		$this->assertCount( 2, $routes['/wp/posts'] );
 		$this->assertArrayHasKey( '/wp/posts/(?P<id>[\d]+)', $routes );
@@ -730,10 +726,7 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 	}
 
 	public function tearDown() {
-		global $wp_json_server;
-
 		parent::tearDown();
-		$wp_json_server = null;
 	}
 
 	protected function check_post_data( $post, $data, $context ) {

--- a/tests/test-json-taxonomies-controller.php
+++ b/tests/test-json-taxonomies-controller.php
@@ -9,10 +9,8 @@ class WP_Test_JSON_Taxonomies_Controller extends WP_Test_JSON_Controller_Testcas
 	}
 
 	public function test_register_routes() {
-		global $wp_json_server;
-		$wp_json_server = new WP_JSON_Server;
-		do_action( 'wp_json_server_before_serve' );
-		$routes = $wp_json_server->get_routes();
+		$routes = $this->server->get_routes();
+
 		$this->assertArrayHasKey( '/wp/taxonomies', $routes );
 		$this->assertArrayHasKey( '/wp/taxonomies/(?P<taxonomy>[\w-]+)', $routes );
 	}
@@ -40,7 +38,7 @@ class WP_Test_JSON_Taxonomies_Controller extends WP_Test_JSON_Controller_Testcas
 	public function test_get_taxonomies_with_types() {
 		foreach ( get_post_types() as $type ) {
 			$request = new WP_JSON_Request;
-                	$request->set_method( 'GET' );
+			$request->set_method( 'GET' );
 			$request->set_param( 'post_type', $type );
 			$response = $this->endpoint->get_items( $request );
 			$this->check_taxonomies_for_type_response( $type, $response );
@@ -82,11 +80,7 @@ class WP_Test_JSON_Taxonomies_Controller extends WP_Test_JSON_Controller_Testcas
 	}
 
 	public function tearDown() {
-		global $wp_json_server;
-
 		parent::tearDown();
-
-		$wp_json_server = null;
 	}
 
 	/**
@@ -128,4 +122,4 @@ class WP_Test_JSON_Taxonomies_Controller extends WP_Test_JSON_Controller_Testcas
 		$this->assertEquals( count( $taxonomies ), count( $data ) );
 	}
 
-}	
+}

--- a/tests/test-json-terms-controller.php
+++ b/tests/test-json-terms-controller.php
@@ -240,6 +240,10 @@ class WP_Test_JSON_Terms_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( json_url( 'wp/terms/category/1' ), $data['_links']['parent'] );
 	}
 
+	public function tearDown() {
+		parent::tearDown();
+	}
+
 	protected function check_get_taxonomy_terms_response( $response ) {
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = json_ensure_response( $response );
@@ -252,9 +256,9 @@ class WP_Test_JSON_Terms_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( count( $categories ), count( $data ) );
 		$this->assertEquals( $categories[0]->term_id, $data[0]['id'] );
 		$this->assertEquals( $categories[0]->name, $data[0]['name'] );
-		$this->assertEquals( $categories[0]->slug, $data[0]['slug']);
-		$this->assertEquals( $categories[0]->description, $data[0]['description']);
-		$this->assertEquals( $categories[0]->count, $data[0]['count']);
+		$this->assertEquals( $categories[0]->slug, $data[0]['slug'] );
+		$this->assertEquals( $categories[0]->description, $data[0]['description'] );
+		$this->assertEquals( $categories[0]->count, $data[0]['count'] );
 	}
 
 	protected function check_taxonomy_term( $term, $data ) {

--- a/tests/test-json-users-controller.php
+++ b/tests/test-json-users-controller.php
@@ -22,15 +22,11 @@ class WP_Test_JSON_Users_Controller extends WP_Test_JSON_Controller_Testcase {
 		) );
 
 		$this->endpoint = new WP_JSON_Users_Controller();
-		$this->server = $GLOBALS['wp_json_server'];
 	}
 
 	public function test_register_routes() {
-		global $wp_json_server;
-		$wp_json_server = new WP_JSON_Server;
-		do_action( 'wp_json_server_before_serve' );
+		$routes = $this->server->get_routes();
 
-		$routes = $wp_json_server->get_routes();
 		$this->assertArrayHasKey( '/wp/users', $routes );
 		$this->assertCount( 2, $routes['/wp/users'] );
 		$this->assertArrayHasKey( '/wp/users/(?P<id>[\d]+)', $routes );
@@ -432,11 +428,15 @@ class WP_Test_JSON_Users_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertErrorResponse( 'json_user_invalid_reassign', $response, 400 );
 	}
 
+	public function tearDown() {
+		parent::tearDown();
+	}
+
 	protected function check_user_data( $user, $data, $context ) {
 		$this->assertEquals( $user->ID, $data['id'] );
 		$this->assertEquals( $user->display_name, $data['name'] );
 		$this->assertEquals( $user->first_name, $data['first_name'] );
-		$this->assertEquals( $user->last_name, $data['last_name' ] );
+		$this->assertEquals( $user->last_name, $data['last_name'] );
 		$this->assertEquals( $user->nickname, $data['nickname'] );
 		$this->assertEquals( $user->user_nicename, $data['slug'] );
 		$this->assertEquals( $user->user_url, $data['url'] );


### PR DESCRIPTION
Fixes #793 

Added tearDown method to WP_Test_JSON_Controller_Testcase.
Removed any duplicate setUp logic from the classes that extended WP_Test_JSON_Controller_Testcase.
Removed any duplicate tearDown logic from the classes that extended WP_Test_JSON_Controller_Testcase.