### PR TITLE
Allow Pretty Printing of JSON Responses on PHP 5.4+

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -151,7 +151,7 @@ class WP_JSON_Server {
 		}
 		$error = compact( 'code', 'message' );
 
-		return json_encode( array( $error ) );
+		return $this->json_encode( array( $error ) );
 	}
 
 	/**
@@ -282,13 +282,13 @@ class WP_JSON_Server {
 			// Embed links inside the request
 			$result = $this->response_to_data( $result, isset( $_GET['_embed'] ) );
 
-			$result = json_encode( $result );
+			$result = $this->json_encode( $this->prepare_response( $result ) );
 
 			$json_error_message = $this->get_json_last_error();
 			if ( $json_error_message ) {
 				$json_error_obj = new WP_Error( 'json_encode_error', $json_error_message, array( 'status' => 500 ) );
 				$result = $this->error_to_response( $json_error_obj );
-				$result = json_encode( $result->data[0] );
+				$result = $this->json_encode( $result->data[0] );
 			}
 
 			if ( isset( $_GET['_jsonp'] ) ) {
@@ -839,5 +839,16 @@ class WP_JSON_Server {
 		}
 
 		return $headers;
+	}
+
+	/**
+	 * JSON encode a value. This is a wrapper around `json_encode` so argument
+	 * flags and such can be set in a single place.
+	 *
+	 * @param array|object $data The value to encode
+	 * @return string The json encoded value
+	 */
+	protected function json_encode( $data ) {
+		return json_encode( $data );
 	}
 }

--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -871,6 +871,9 @@ class WP_JSON_Server {
 		 *
 		 * @param int $flags
 		 */
-		return apply_filters( 'json_encode_flags', 0 );
+		return apply_filters(
+			'json_encode_flags',
+			isset( $_GET['pretty'] ) && defined( 'JSON_PRETTY_PRINT' ) ? JSON_PRETTY_PRINT : 0
+		);
 	}
 }

--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -848,7 +848,29 @@ class WP_JSON_Server {
 	 * @param array|object $data The value to encode
 	 * @return string The json encoded value
 	 */
-	protected function json_encode( $data ) {
-		return json_encode( $data );
+	public function json_encode( $data ) {
+		return json_encode( $data, $this->get_json_encode_flags() );
+	}
+
+	/**
+	 * Get the options flags to be passed to `json_encode`.
+	 *
+	 * @return int
+	 */
+	public function get_json_encode_flags() {
+		/**
+		 * Modify the flags passed to `json_encode` for every request.
+		 *
+		 * Users should hook in and complete release the flags or do a bitwise
+		 * or to add flags. For instance if you wanted your API implementation
+		 * to use unescaped slashes:
+		 *
+		 *    add_filter( 'json_encode_flags', function ( $flags ) {
+		 *        return $flags | JSON_UNESCAPED_SLASHES;
+		 *    });
+		 *
+		 * @param int $flags
+		 */
+		return apply_filters( 'json_encode_flags', 0 );
 	}
 }


### PR DESCRIPTION
This changes two big things

1. Moves all calls to `json_encode` into a wrapper method so flags and such can be set in one place
2. Looks for the `pretty` query string param so you can get human-readable JSON with PHP 5.4+

Even if the second one isn't okay, I do think the first item is worth a look. I stole this idea from Elasticsearch, which sends non-pretty JSON by default and has all endpoints supporting a `pretty` query string argument.

Normal:

![screen shot 2015-02-04 at 12 50 55 pm](https://cloud.githubusercontent.com/assets/1010392/6046053/c17aa524-ac6c-11e4-84be-92b507e38723.png)

Pretty Printed:

![screen shot 2015-02-04 at 12 51 07 pm](https://cloud.githubusercontent.com/assets/1010392/6046061/cfb3dbce-ac6c-11e4-84c4-f304f9caa264.png)
