### PR TITLE
Add discussion object to include count and open fields

### DIFF
--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -386,8 +386,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			'status' => $post->ping_status,
 		);
 
-		$discussion = new stdClass();
-		$discussion->count = (int) get_comments_number( $post->ID );
+		$discussion = (object) array( 'comment' => (int) get_comments_number( $post->ID ) );
 		$discussion->comments = (object) $comments;
 		$discussion->pings = (object) $pings;
 

--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -371,6 +371,30 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 	}
 
 	/**
+	 * Build discussion object for single post output.
+	 *
+	 * @param  object $post WP_Post object.
+	 * @return object $discussion
+	 */
+	protected function prepare_discussion_response( $post ) {
+		$comments = array(
+			'open'   => comments_open( $post->ID ),
+			'status' => $post->comment_status,
+		);
+		$pings = array(
+			'open'   => pings_open( $post->ID ),
+			'status' => $post->ping_status,
+		);
+
+		$discussion = new stdClass();
+		$discussion->count = (int) get_comments_number( $post->ID );
+		$discussion->comments = (object) $comments;
+		$discussion->pings = (object) $pings;
+
+		return $discussion;
+	}
+
+	/**
 	 * Prepare a single post for create or update
 	 *
 	 * @param WP_JSON_Request $request Request object
@@ -849,8 +873,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		if ( post_type_supports( $post->post_type, 'comments' ) ) {
-			$data['comment_status'] = $post->comment_status;
-			$data['ping_status'] = $post->ping_status;
+			$data['discussion'] = $this->prepare_discussion_response( $post );
 		}
 
 		if ( 'post' === $post->post_type ) {

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -817,7 +817,6 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 
 		// Comments
 		if ( post_type_supports( $post->post_type, 'comments' ) ) {
-			// echo var_dump( $data['discussion']->pings );
 			$this->assertEquals( get_comments_number( $post->ID ), $data['discussion']->count );
 			$this->assertEquals( $post->comment_status, $data['discussion']->comments->status );
 			$this->assertEquals( comments_open( $post->ID ), $data['discussion']->comments->open );

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -817,11 +817,14 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 
 		// Comments
 		if ( post_type_supports( $post->post_type, 'comments' ) ) {
-			$this->assertEquals( $post->comment_status, $data['comment_status'] );
-			$this->assertEquals( $post->ping_status, $data['ping_status'] );
+			// echo var_dump( $data['discussion']->pings );
+			$this->assertEquals( get_comments_number( $post->ID ), $data['discussion']->count );
+			$this->assertEquals( $post->comment_status, $data['discussion']->comments->status );
+			$this->assertEquals( comments_open( $post->ID ), $data['discussion']->comments->open );
+			$this->assertEquals( $post->ping_status, $data['discussion']->pings->status );
+			$this->assertEquals( pings_open( $post->ID ), $data['discussion']->pings->open );
 		} else {
-			$this->assertFalse( isset( $data['comment_status'] ) );
-			$this->assertFalse( isset( $data['ping_status'] ) );
+			$this->assertFalse( isset( $data['discussion'] ) );
 		}
 
 		if ( 'post' === $post->post_type ) {


### PR DESCRIPTION
Comment and ping fields are wrapped in a discussion object as discussed in #747 

```
"discussion": {
            "count": 0,
            "comments": {
                "open": false,
                "status": "closed"
            },
            "pings": {
                "open": false,
                "status": "closed"
            }
        },
```