### PR TITLE
Remove Duplicate Logic for Post Type Attributes

### DIFF
--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -87,10 +87,6 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 	 * @return WP_Error|WP_HTTP_ResponseInterface
 	 */
 	public function get_item_revisions( $request ) {
-		$request->set_query_params( array(
-			'context' => 'view-revision',
-		) );
-
 		$id = (int) $request['id'];
 		$parent = get_post( $id );
 

--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -103,7 +103,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		// Todo: Query args filter for wp_get_post_revisions
-		$revisions = wp_get_post_revisions( $id );
+		$revisions = wp_get_post_revisions( $parent->ID );
 
 		$struct = array();
 		foreach ( $revisions as $revision ) {

--- a/plugin.php
+++ b/plugin.php
@@ -206,8 +206,12 @@ function create_initial_json_routes() {
 		register_json_route( 'wp', '/' . $base . '/(?P<id>\d+)/revisions', array(
 			'methods'         => WP_JSON_Server::READABLE,
 			'callback'        => array( $controller, 'get_item_revisions' ),
+			'args'            => array(
+				'context'          => array(
+					'default'      => 'view-revision',
+				),
+			),
 		) );
-
 	}
 
 	/*

--- a/plugin.php
+++ b/plugin.php
@@ -859,7 +859,7 @@ function json_handle_options_request( $response, $handler, $request ) {
 /**
  * Send the "Allow" header to state all methods that can be sen
  * to the current route
- * 
+ *
  * @param  WP_JSON_Response  $response
  * @param  WP_JSON_Server    $server ResponseHandler instance (usually WP_JSON_Server)
  * @param  WP_JSON_Request   $request
@@ -895,7 +895,7 @@ function json_send_allow_header( $response, $server, $request ) {
 	$allowed_methods = array_filter( $allowed_methods );
 
 	if ( $allowed_methods ) {
-		$response->header( 'Allow', implode( ', ', array_map( 'strtoupper', array_keys( $allowed_methods ) ) ) );	
+		$response->header( 'Allow', implode( ', ', array_map( 'strtoupper', array_keys( $allowed_methods ) ) ) );
 	}
 
 	return $response;

--- a/plugin.php
+++ b/plugin.php
@@ -175,7 +175,6 @@ function create_initial_json_routes() {
 			array(
 				'methods'         => WP_JSON_Server::CREATABLE,
 				'callback'        => array( $controller, 'create_item' ),
-				'accept_json'     => true,
 				'args'            => $post_type_fields,
 			),
 		) );

--- a/plugin.php
+++ b/plugin.php
@@ -645,40 +645,6 @@ function json_api_deactivation( $network_wide ) {
 register_deactivation_hook( __FILE__, 'json_api_deactivation' );
 
 /**
- * Add 'show_in_json' {@see register_post_type()} argument.
- *
- * Adds the 'show_in_json' post type argument to {@see register_post_type()}.
- * This value controls whether the post type is available via API endpoints,
- * and defaults to the value of $publicly_queryable.
- *
- * @global array $wp_post_types Post types list.
- *
- * @param string   $post_type Post type to register.
- * @param stdClass $args      Post type arguments.
- */
-function json_register_post_type( $post_type, $args ) {
-	global $wp_post_types;
-
-	$type = &$wp_post_types[ $post_type ];
-
-	// Exception for pages.
-	if ( $post_type === 'page' ) {
-		$type->show_in_json = true;
-	}
-
-	// Exception for revisions.
-	if ( $post_type === 'revision' ) {
-		$type->show_in_json = true;
-	}
-
-	// Default to the value of $publicly_queryable.
-	if ( ! isset( $type->show_in_json ) ) {
-		$type->show_in_json = $type->publicly_queryable;
-	}
-}
-add_action( 'registered_post_type', 'json_register_post_type', 10, 2 );
-
-/**
  * Get the URL prefix for any API resource.
  *
  * @return string Prefix.


### PR DESCRIPTION
Removes legacy `json_register_post_type()` that was modifying post_type attributes in conflict with #820.  The `json_register_post_type()` function was causing additional revision routes to be registered that are not supported.  

This PR also includes some minor code clean up.

