### PR TITLE
Change project name to WP REST API in plugin name and Readme title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSON REST API (WP-API)
+# WP REST API (WP-API)
 
 Access your WordPress site's data through an easy-to-use HTTP REST API.
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP REST API
  * Description: JSON-based REST API for WordPress, developed as part of GSoC 2013.
- * Author: Ryan McCue, WP REST API Team
+ * Author: WP REST API Team
  * Author URI: http://wp-api.org
  * Version: 1.1.1
  * Plugin URI: https://github.com/WP-API/WP-API

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: JSON REST API
+ * Plugin Name: WP REST API
  * Description: JSON-based REST API for WordPress, developed as part of GSoC 2013.
  * Author: Ryan McCue, WP REST API Team
  * Author URI: http://wp-api.org


### PR DESCRIPTION
Changes the project name in the Plugin name and the Readme title.

Part of #850 
