### PR TITLE
Passing a value for the slug parameter should update the post_name.

### DIFF
--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -453,8 +453,8 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			}
 		}
 		// Post slug
-		if ( isset( $request['name'] ) ) {
-			$prepared_post->post_name = sanitize_title( $request['name'] );
+		if ( isset( $request['slug'] ) ) {
+			$prepared_post->post_name = sanitize_title( $request['slug'] );
 		}
 
 		// Author

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -698,6 +698,22 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( 'gallery', get_post_format( $new_post->ID ) );
 	}
 
+	public function test_update_post_slug() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data( array(
+			'slug' => 'sample-slug',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertEquals( 'sample-slug', $new_data['slug'] );
+		$post = get_post( $new_data['id'] );
+		$this->assertEquals( 'sample-slug', $post->post_name );
+	}
+
 	public function test_update_post_sticky() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
Fixes #856.

Correct request parameter conditional logic to look for the 'slug' parameter to update a Posts post_name property.
Includes unit test.