### PR TITLE
Empty checks in Posts Controller make setting values to Falsy impossible

### DIFF
--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -391,21 +391,21 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		// Post content
-		if ( post_type_supports( $this->post_type, 'editor' ) && ! empty( $request['content'] ) ) {
+		if ( post_type_supports( $this->post_type, 'editor' ) && isset( $request['content'] ) ) {
 			if ( is_string( $request['content'] ) ) {
 				$prepared_post->post_content = wp_kses_post( $request['content'] );
 			}
-			elseif ( ! empty( $request['content']['raw'] ) ) {
+			elseif ( isset( $request['content']['raw'] ) ) {
 				$prepared_post->post_content = wp_kses_post( $request['content']['raw'] );
 			}
 		}
 
 		// Post excerpt
-		if ( post_type_supports( $this->post_type, 'excerpt' ) && ! empty( $request['excerpt'] ) ) {
+		if ( post_type_supports( $this->post_type, 'excerpt' ) && isset( $request['excerpt'] ) ) {
 			if ( is_string( $request['excerpt'] ) ) {
 				$prepared_post->post_excerpt = wp_kses_post( $request['excerpt'] );
 			}
-			elseif ( ! empty( $request['excerpt']['raw'] ) ) {
+			elseif ( isset( $request['excerpt']['raw'] ) ) {
 				$prepared_post->post_excerpt = wp_kses_post( $request['excerpt']['raw'] );
 			}
 		}

--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -488,7 +488,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		// Menu order
-		if ( post_type_supports( $this->post_type, 'page-attributes' ) && ! empty( $request['menu_order'] ) ) {
+		if ( post_type_supports( $this->post_type, 'page-attributes' ) && isset( $request['menu_order'] ) ) {
 			$prepared_post->menu_order = (int) $request['menu_order'];
 		}
 

--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -468,7 +468,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		// Post password
-		if ( ! empty( $request['password'] ) ) {
+		if ( isset( $request['password'] ) ) {
 			$prepared_post->post_password = $request['password'];
 
 			if ( ! current_user_can( $post_type->cap->publish_posts ) ) {

--- a/tests/test-json-pages-controller.php
+++ b/tests/test-json-pages-controller.php
@@ -114,4 +114,49 @@ class WP_Test_JSON_Pages_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		}
 	}
 
+	public function test_update_page_menu_order() {
+
+		$page_id = $this->factory->post->create( array(
+			'post_type' => 'page',
+		) );
+
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/pages/%d', $page_id ) );
+
+		$request->set_body_params( array(
+			'menu_order' => 1,
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertEquals( 1, $new_data['menu_order'] );
+	}
+
+	public function test_update_page_menu_order_to_zero() {
+
+		$page_id = $this->factory->post->create( array(
+			'post_type'  => 'page',
+			'menu_order' => 1
+		) );
+
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/pages/%d', $page_id ) );
+
+		$request->set_body_params(array(
+			'menu_order' => 0
+		));
+		$response = $this->server->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertEquals( 0, $new_data['menu_order'] );
+	}
+
+	protected function set_post_data( $args = array() ) {
+		$args = parent::set_post_data( $args );
+		$args['type'] = 'page';
+		return $args;
+	}
+
 }

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -442,8 +442,7 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
-		$new_post = get_post( $data['id'] );
-		$this->assertEquals( $new_post->post_password, $data['password'] );
+		$this->assertEquals( 'testing', $data['password'] );
 	}
 
 	public function test_create_post_with_password_without_permisson() {
@@ -464,6 +463,21 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'json_cannot_create_password_protected', $response, 401 );
+	}
+
+	public function test_create_post_with_falsy_password() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'POST', '/wp/posts' );
+		$params = $this->set_post_data( array(
+			'password' => '0',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( '0', $data['password'] );
 	}
 
 	public function test_create_post_custom_date() {

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -678,6 +678,58 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$this->assertEquals( true, is_sticky( $post->ID ) );
 	}
 
+	public function test_update_post_excerpt() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request->set_body_params( array(
+			'excerpt' => 'An Excerpt'
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( 'An Excerpt', $new_data['excerpt']['raw'] );
+	}
+
+	public function test_update_post_empty_excerpt() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request->set_body_params( array(
+			'excerpt' => ''
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( '', $new_data['excerpt']['raw'] );
+	}
+
+	public function test_update_post_content() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request->set_body_params( array(
+			'content' => 'Some Content'
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( 'Some Content', $new_data['content']['raw'] );
+	}
+
+	public function test_update_post_empty_content() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request->set_body_params( array(
+			'content' => ''
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( '', $new_data['content']['raw'] );
+	}
+
 	public function test_delete_item() {
 		$post_id = $this->factory->post->create();
 		wp_set_current_user( $this->editor_id );


### PR DESCRIPTION
Currently we are relying on a lot of `! empty( $var )` checks which fail on setting `0` or `""` for valid values. I fixed up `menu_order`, `contnet`, `password` and `excerpt`