### PR TITLE
Return 200 and an empty array for valid queries with 0 results.

### DIFF
--- a/lib/class-wp-json-posts-controller.php
+++ b/lib/class-wp-json-posts-controller.php
@@ -27,7 +27,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		$posts_query = new WP_Query();
 		$query_result = $posts_query->query( $query_args );
 		if ( 0 === $posts_query->found_posts ) {
-			return new WP_Error( 'json_invalid_query', __( 'Invalid post query.' ), array( 'status' => 404 ) );
+			return json_ensure_response( array() );
 		}
 
 		$posts = array();

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -40,7 +40,12 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$this->check_get_posts_response( $response );
 	}
 
-	public function test_get_items_invalid_query() {
+	/**
+	 * A valid query that returns 0 results should return an empty JSON list.
+	 *
+	 * @issue 862
+	 */
+	public function test_get_items_empty_query() {
 		$request = new WP_JSON_Request( 'GET', '/wp/posts' );
 		$request->set_query_params( array(
 			'type'           => 'post',
@@ -48,7 +53,8 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'json_invalid_query', $response, 404 );
+		$this->assertEquals( array(), $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_get_items_status_without_permissons() {


### PR DESCRIPTION
Fixes #862. 

A post_type collection endpoint will no longer return a 404 status and a `json_invalid_query` WP_Error for valid queries that return 0 results.  

Now, valid queries that return 0 results will return a 200 status and an empty array.  