### PR TITLE
Include the taxonomy in the term response

### DIFF
--- a/lib/class-wp-json-terms-controller.php
+++ b/lib/class-wp-json-terms-controller.php
@@ -182,6 +182,7 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 			'description'  => $item->description,
 			'name'         => $item->name,
 			'slug'         => $item->slug,
+			'taxonomy'     => $item->taxonomy,
 			'parent_id'    => (int) $parent_id,
 		);
 

--- a/tests/test-json-terms-controller.php
+++ b/tests/test-json-terms-controller.php
@@ -257,6 +257,7 @@ class WP_Test_JSON_Terms_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertEquals( $categories[0]->term_id, $data[0]['id'] );
 		$this->assertEquals( $categories[0]->name, $data[0]['name'] );
 		$this->assertEquals( $categories[0]->slug, $data[0]['slug'] );
+		$this->assertEquals( $categories[0]->taxonomy, $data[0]['taxonomy'] );
 		$this->assertEquals( $categories[0]->description, $data[0]['description'] );
 		$this->assertEquals( $categories[0]->count, $data[0]['count'] );
 	}


### PR DESCRIPTION
It's useful data that should always be included

I could've sworn there was an issue for this, but can't find it :/