### PR TITLE
If post type doesn't match controller post type, throw 404

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -55,7 +55,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		$id = (int) $request['id'];
 		$post = get_post( $id );
 
-		if ( empty( $id ) || empty( $post->ID ) ) {
+		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
 			return new WP_Error( 'json_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
 		}
 

--- a/tests/test-json-pages-controller.php
+++ b/tests/test-json-pages-controller.php
@@ -32,6 +32,13 @@ class WP_Test_JSON_Pages_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		
 	}
 
+	public function test_get_item_invalid_post_type() {
+		$post_id = $this->factory->post->create();
+		$request = new WP_JSON_Request( 'GET', '/wp/pages/' . $post_id );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
 	public function test_create_item() {
 		
 	}


### PR DESCRIPTION
Posts should only be accessible through `/wp/posts`. Pages should only be accessible through `/wp/pages`. Otherwise we're mixing up our data.

See #884