### PR TITLE
Updating another post field shouldn't change sticky status

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -215,7 +215,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			$this->handle_featured_image( $request['featured_image'], $post_id );
 		}
 
-		if ( 'post' === $post->post_type ) {
+		if ( 'post' === $post->post_type && isset( $request['sticky'] ) ) {
 			$sticky = isset( $request['sticky'] ) ? (bool) $request['sticky'] : false;
 			$this->handle_sticky_posts( $sticky, $post_id );
 		}

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -682,6 +682,19 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$this->assertEquals( true, $new_data['sticky'] );
 		$post = get_post( $new_data['id'] );
 		$this->assertEquals( true, is_sticky( $post->ID ) );
+
+		// Updating another field shouldn't change sticky status
+		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data( array(
+			'title'       => 'This should not reset sticky',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertEquals( true, $new_data['sticky'] );
+		$post = get_post( $new_data['id'] );
+		$this->assertEquals( true, is_sticky( $post->ID ) );
 	}
 
 	public function test_update_post_excerpt() {


### PR DESCRIPTION
It's been a bug for a while...

See https://github.com/WP-API/WP-API/commit/7d66dde663d6d405a43331f6d575517fc94f286e#diff-5330db7df8462cb82a5542bbacfce38bL221