### PR TITLE
Revert "WP_JSON_Posts::get_post_types() should return array, not hash/ob...

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -399,7 +399,7 @@ class WP_JSON_Posts {
 				continue;
 			}
 
-			$types[] = $type;
+			$types[ $name ] = $type;
 		}
 
 		return $types;


### PR DESCRIPTION
Reverts WP-API/WP-API#524

This is a backwards compatibility break for 1.2.