### PR TITLE
Remove `_id` suffix from field names

### DIFF
--- a/lib/endpoints/class-wp-json-attachments-controller.php
+++ b/lib/endpoints/class-wp-json-attachments-controller.php
@@ -17,10 +17,10 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 		}
 
 		// If a user is trying to attach to a post make sure they have permissions. Bail early if post_id is not being passed
-		if ( ! empty( $request['post_id'] ) ) {
-			$parent = get_post( (int) $request['post_id'] );
+		if ( ! empty( $request['post'] ) ) {
+			$parent = get_post( (int) $request['post'] );
 			$post_parent_type = get_post_type_object( $parent->post_type );
-			if ( ! current_user_can( $post_parent_type->cap->edit_post, $request['post_id'] ) ) {
+			if ( ! current_user_can( $post_parent_type->cap->edit_post, $request['post'] ) ) {
 				return new WP_Error( 'json_cannot_edit', __( 'Sorry, you are not allowed to edit this post.' ), array( 'status' => 401 ) );
 			}
 		}
@@ -128,7 +128,7 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 			$prepared_attachment->post_excerpt = wp_filter_post_kses( $request['description'] );
 		}
 
-		if ( isset( $request['post_id'] ) ) {
+		if ( isset( $request['post'] ) ) {
 			$prepared_attachment->post_parent = (int) $request['post_parent'];
 		}
 
@@ -150,7 +150,7 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 		$response['description']   = $post->post_excerpt;
 		$response['media_type']    = wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
 		$response['media_details'] = wp_get_attachment_metadata( $post->ID );
-		$response['post_id']       = ! empty( $post->post_parent ) ? (int) $post->post_parent : null;
+		$response['post']          = ! empty( $post->post_parent ) ? (int) $post->post_parent : null;
 		$response['source_url']    = wp_get_attachment_url( $post->ID );
 
 		// Ensure empty details is an empty object
@@ -200,7 +200,7 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 			'description'     => 'Details about the attachment file, specific to its type.',
 			'type'            => 'object',
 			);
-		$schema['properties']['post_id'] = array(
+		$schema['properties']['post'] = array(
 			'description'     => 'The ID for the associated post of the attachment.',
 			'type'            => 'integer',
 			);

--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -69,7 +69,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			return new WP_Error( 'json_comment_exists', __( 'Cannot create existing comment.' ), array( 'status' => 400 ) );
 		}
 
-		$post = get_post( (int) $request['post_id'] );
+		$post = get_post( (int) $request['post'] );
 		if ( empty( $post ) ) {
 			return new WP_Error( 'json_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
 		}
@@ -177,11 +177,11 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	public function get_items_permissions_check( $request ) {
 
 		// If the post id isn't specified, presume we can create
-		if ( ! isset( $request['post_id'] ) ) {
+		if ( ! isset( $request['post'] ) ) {
 			return true;
 		}
 
-		$post = get_post( (int) $request['post_id'] );
+		$post = get_post( (int) $request['post'] );
 
 		if ( $post && ! $this->check_read_post_permission( $post ) ) {
 			return false;
@@ -227,11 +227,11 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	public function create_item_permissions_check( $request ) {
 
 		// If the post id isn't specified, presume we can create
-		if ( ! isset( $request['post_id'] ) ) {
+		if ( ! isset( $request['post'] ) ) {
 			return true;
 		}
 
-		$post = get_post( (int) $request['post_id'] );
+		$post = get_post( (int) $request['post'] );
 
 		if ( $post ) {
 
@@ -286,9 +286,9 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	public function prepare_item_for_response( $comment, $request ) {
 		$fields = array(
 			'id'           => (int) $comment->comment_ID,
-			'post_id'      => (int) $comment->comment_post_ID,
-			'parent_id'    => (int) $comment->comment_parent,
-			'user_id'      => (int) $comment->user_id,
+			'post'         => (int) $comment->comment_post_ID,
+			'parent'       => (int) $comment->comment_parent,
+			'user'         => (int) $comment->user_id,
 			'author'       => $comment->comment_author,
 			'author_email' => $comment->comment_author_email,
 			'author_url'   => $comment->comment_author_url,
@@ -344,8 +344,8 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 
 		$prepared_args = array(
 			'number'  => absint( $request['per_page'] ),
-			'post_id' => isset( $request['post_id'] ) ? absint( $request['post_id'] ) : '',
-			'parent'  => isset( $request['parent_id'] ) ? intval( $request['parent_id'] ) : '',
+			'post_id' => isset( $request['post'] ) ? absint( $request['post'] ) : '',
+			'parent'  => isset( $request['parent'] ) ? intval( $request['parent'] ) : '',
 			'search'  => $request['search'] ? sanitize_text_field( $request['search'] ) : '',
 			'orderby' => $this->normalize_query_param( $order_by ),
 			'order'   => sanitize_key( $request['order'] ),
@@ -357,7 +357,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 
 		if ( current_user_can( 'edit_posts' ) ) {
 			$protected_args = array(
-				'user_id'      => $request['user_id'] ? absint( $request['user_id'] ) : '',
+				'user'         => $request['user'] ? absint( $request['user'] ) : '',
 				'status'       => sanitize_key( $request['status'] ),
 				'type'         => isset( $request['type'] ) ? sanitize_key( $request['type'] ) : '',
 				'author_email' => isset( $request['author_email'] ) ? sanitize_email( $request['author_email'] ) : '',
@@ -388,10 +388,10 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			case 'id':
 				$normalized = $prefix . 'ID';
 				break;
-			case 'post_id':
+			case 'post':
 				$normalized = $prefix . 'post_ID';
 				break;
-			case 'parent_id':
+			case 'parent':
 				$normalized = $prefix . 'parent';
 				break;
 			default:
@@ -439,10 +439,10 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_comment = array(
-			'comment_post_ID'      => (int) $request['post_id'],
+			'comment_post_ID'      => (int) $request['post'],
 			'comment_type'         => sanitize_key( $request['type'] ),
-			'comment_parent'       => (int) $request['parent_id'],
-			'user_id'              => isset( $request['user_id'] ) ? (int) $request['user_id'] : get_current_user_id(),
+			'comment_parent'       => (int) $request['parent'],
+			'user_id'              => isset( $request['user'] ) ? (int) $request['user'] : get_current_user_id(),
 			'comment_content'      => isset( $request['content'] ) ? $request['content'] : '',
 			'comment_author'       => isset( $request['author'] ) ? sanitize_text_field( $request['author'] ) : '',
 			'comment_author_email' => isset( $request['author_email'] ) ? sanitize_email( $request['author_email'] ) : '',
@@ -544,11 +544,11 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'type'         => 'string',
 					'format'       => 'uri',
 					),
-				'parent_id'        => array(
+				'parent'           => array(
 					'description'  => 'The ID for the parent of the object.',
 					'type'         => 'integer',
 					),
-				'post_id'          => array(
+				'post'             => array(
 					'description'  => 'The ID of the associated post object.',
 					'type'         => 'integer',
 					),
@@ -560,7 +560,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'description'  => 'Type of Comment for the object.',
 					'type'         => 'string',
 					),
-				'user_id'          => array(
+				'user'             => array(
 					'description'  => 'The ID of the user object, if author was a user.',
 					'type'         => 'integer',
 					),

--- a/lib/endpoints/class-wp-json-terms-controller.php
+++ b/lib/endpoints/class-wp-json-terms-controller.php
@@ -184,7 +184,7 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 			'name'         => $item->name,
 			'slug'         => $item->slug,
 			'taxonomy'     => $item->taxonomy,
-			'parent_id'    => (int) $parent_id,
+			'parent'       => (int) $parent_id,
 		);
 
 		if ( ! empty( $parent_term ) ) {
@@ -228,7 +228,7 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 					'description'  => 'The title for the object.',
 					'type'         => 'string',
 					),
-				'parent_id'        => array(
+				'parent'           => array(
 					'description'  => 'The ID for the parent of the object.',
 					'type'         => 'integer',
 					),

--- a/plugin.php
+++ b/plugin.php
@@ -242,7 +242,7 @@ function create_initial_json_routes() {
 				),
 				'description' => array(),
 				'slug'        => array(),
-				'parent_id'   => array(),
+				'parent'      => array(),
 			),
 		),
 	));
@@ -258,7 +258,7 @@ function create_initial_json_routes() {
 				'name'           => array(),
 				'description'    => array(),
 				'slug'           => array(),
-				'parent_id'      => array(),
+				'parent'         => array(),
 			),
 		),
 		array(
@@ -368,10 +368,10 @@ function create_initial_json_routes() {
 			'callback'  => array( $controller, 'get_items' ),
 			'permission_callback' => array( $controller, 'get_items_permissions_check' ),
 			'args'      => array(
-				'post_id'      => array(
+				'post'         => array(
 					'default'      => null,
 				),
-				'user_id'      => array(
+				'user'         => array(
 					'default'      => 0,
 				),
 				'per_page'     => array(
@@ -386,7 +386,7 @@ function create_initial_json_routes() {
 				'type'         => array(
 					'default'      => 'comment',
 				),
-				'parent_id'    => array(),
+				'parent'       => array(),
 				'search'       => array(),
 				'order'        => array(
 					'default'      => 'DESC',
@@ -408,16 +408,16 @@ function create_initial_json_routes() {
 			'callback' => array( $controller, 'create_item' ),
 			'permission_callback' => array( $controller, 'create_item_permissions_check' ),
 			'args'     => array(
-				'post_id'      => array(
+				'post'         => array(
 					'required'     => true,
 				),
 				'type'         => array(
 					'default'      => 'comment',
 				),
-				'user_id'      => array(
+				'user'         => array(
 					'default'      => 0,
 				),
-				'parent_id'    => array(
+				'parent'       => array(
 					'default'      => 0,
 				),
 				'content'      => array(),
@@ -446,7 +446,7 @@ function create_initial_json_routes() {
 			'callback' => array( $controller, 'update_item' ),
 			'permission_callback' => array( $controller, 'update_item_permissions_check' ),
 			'args'     => array(
-				'post_id'      => array(),
+				'post'         => array(),
 				'status'       => array(),
 				'content'      => array(),
 				'author'       => array(),

--- a/tests/test-json-attachments-controller.php
+++ b/tests/test-json-attachments-controller.php
@@ -147,7 +147,7 @@ class WP_Test_JSON_Attachments_Controller extends WP_Test_JSON_Post_Type_Control
 		$post_id = $this->factory->post->create( array( 'post_author' => $this->editor_id ) );
 		wp_set_current_user( $this->author_id );
 		$request = new WP_JSON_Request( 'POST', '/wp/media' );
-		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'json_cannot_edit', $response, 401 );
 	}
@@ -246,7 +246,7 @@ class WP_Test_JSON_Attachments_Controller extends WP_Test_JSON_Post_Type_Control
 		$this->assertArrayHasKey( 'media_type', $properties );
 		$this->assertArrayHasKey( 'media_details', $properties );
 		$this->assertArrayHasKey( 'modified', $properties );
-		$this->assertArrayHasKey( 'post_id', $properties );
+		$this->assertArrayHasKey( 'post', $properties );
 		$this->assertArrayHasKey( 'ping_status', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'source_url', $properties );
@@ -269,9 +269,9 @@ class WP_Test_JSON_Attachments_Controller extends WP_Test_JSON_Post_Type_Control
 		$this->assertEquals( $attachment->post_excerpt, $data['description'] );
 
 		if ( $attachment->post_parent ) {
-			$this->assertEquals( $attachment->post_parent, $data['post_id'] );
+			$this->assertEquals( $attachment->post_parent, $data['post'] );
 		} else {
-			$this->assertNull( $data['post_id'] );
+			$this->assertNull( $data['post'] );
 		}
 
 		$this->assertEquals( wp_get_attachment_url( $attachment->ID ), $data['source_url']  );

--- a/tests/test-json-comments-controller.php
+++ b/tests/test-json-comments-controller.php
@@ -76,7 +76,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 
 		$request = new WP_JSON_Request( 'GET', '/wp/comments' );
 		$request->set_query_params( array(
-			'post_id' => $second_post_id,
+			'post' => $second_post_id,
 		) );
 
 		$response = $this->server->dispatch( $request );
@@ -149,7 +149,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( 0 );
 
 		$params = array(
-			'post_id'      => $this->post_id,
+			'post'         => $this->post_id,
 			'author'       => 'Comic Book Guy',
 			'author_email' => 'cbg@androidsdungeon.com',
 			'author_url'   => 'http://androidsdungeon.com',
@@ -175,12 +175,12 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( $this->admin_id );
 
 		$params = array(
-			'post_id'      => $this->post_id,
+			'post'         => $this->post_id,
 			'author'       => 'Homer Jay Simpson',
 			'author_email' => 'chunkylover53@aol.com',
 			'author_url'   => 'http://compuglobalhypermeganet.com',
 			'content'      => 'Here’s to alcohol: the cause of, and solution to, all of life’s problems.',
-			'user_id'      => 0,
+			'user'         => 0,
 		);
 
 		$request = new WP_JSON_Request( 'POST', '/wp/comments' );
@@ -191,7 +191,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$response = json_ensure_response( $response );
 		$this->assertEquals( 201, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 0, $data['user_id'] );
+		$this->assertEquals( 0, $data['user'] );
 	}
 
 	public function test_create_item_duplicate() {
@@ -207,7 +207,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( 0 );
 
 		$params = array(
-			'post_id'      => $this->post_id,
+			'post'         => $this->post_id,
 			'author'       => 'Guy N. Cognito',
 			'author_email' => 'chunkylover53@aol.co.uk',
 			'content'      => 'Homer? Who is Homer? My name is Guy N. Cognito.',
@@ -229,7 +229,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( 0 );
 
 		$params = array(
-			'post_id'      => $post_id,
+			'post'      => $post_id,
 		);
 
 		$request = new WP_JSON_Request( 'POST', '/wp/comments' );
@@ -370,20 +370,20 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$this->assertArrayHasKey( 'content', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
 		$this->assertArrayHasKey( 'link', $properties );
-		$this->assertArrayHasKey( 'parent_id', $properties );
-		$this->assertArrayHasKey( 'post_id', $properties );
+		$this->assertArrayHasKey( 'parent', $properties );
+		$this->assertArrayHasKey( 'post', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'type', $properties );
-		$this->assertArrayHasKey( 'user_id', $properties );
+		$this->assertArrayHasKey( 'user', $properties );
 	}
 
 	protected function check_comment_data( $data, $context ) {
 		$comment = get_comment( $data['id'] );
 
 		$this->assertEquals( $comment->comment_ID, $data['id'] );
-		$this->assertEquals( $comment->comment_post_ID, $data['post_id'] );
-		$this->assertEquals( $comment->comment_parent, $data['parent_id'] );
-		$this->assertEquals( $comment->user_id, $data['user_id' ] );
+		$this->assertEquals( $comment->comment_post_ID, $data['post'] );
+		$this->assertEquals( $comment->comment_parent, $data['parent'] );
+		$this->assertEquals( $comment->user_id, $data['user' ] );
 		$this->assertEquals( $comment->comment_author, $data['author'] );
 		$this->assertEquals( $comment->comment_author_email, $data['author_email'] );
 		$this->assertEquals( $comment->comment_author_url, $data['author_url'] );

--- a/tests/test-json-terms-controller.php
+++ b/tests/test-json-terms-controller.php
@@ -237,7 +237,7 @@ class WP_Test_JSON_Terms_Controller extends WP_Test_JSON_Controller_Testcase {
 		$data = $endpoint->prepare_item_for_response( $term, $request );
 		$this->check_taxonomy_term( $term, $data );
 
-		$this->assertEquals( 1, $data['parent_id'] );
+		$this->assertEquals( 1, $data['parent'] );
 		$this->assertEquals( json_url( 'wp/terms/category/1' ), $data['_links']['parent'] );
 	}
 
@@ -252,7 +252,7 @@ class WP_Test_JSON_Terms_Controller extends WP_Test_JSON_Controller_Testcase {
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'link', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
-		$this->assertArrayHasKey( 'parent_id', $properties );
+		$this->assertArrayHasKey( 'parent', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'taxonomy', $properties );
 		$this->assertEquals( array_keys( get_taxonomies() ), $properties['taxonomy']['enum'] );


### PR DESCRIPTION
Affects:
* `Attachment->post_id` => `Attachment->post`
* `Comment->post_id` => `Comment->post`
* `Comment->parent_id` => `Comment->parent`
* `Comment->user_id` => `Comment->user`
* `Terms->parent_id` => `Terms->parent`

See #605