### PR TITLE
Require `moderate_comments` capability to context=edit a Comment

### DIFF
--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -316,7 +316,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	 * Check if a given request has access to read the comment
 	 * 
 	 * @param  WP_JSON_Request $request Full details about the request.
-	 * @return bool
+	 * @return bool|WP_Error
 	 */
 	public function get_item_permissions_check( $request ) {
 		$id = (int) $request['id'];

--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -161,10 +161,6 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			return new WP_Error( 'json_comment_invalid_id', __( 'Invalid comment ID.' ), array( 'status' => 404 ) );
 		}
 
-		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( 'moderate_comments' ) ) {
-			return new WP_Error( 'json_comment_cannot_view', __( 'Sorry, you cannot view this comment with edit context' ), array( 'status' => 403 ) );
-		}
-
 		$post = get_post( $comment->comment_post_ID );
 		if ( empty( $post ) ) {
 			return new WP_Error( 'json_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
@@ -339,6 +335,10 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 
 		if ( $post && ! $this->check_read_post_permission( $post ) ) {
 			return false;
+		}
+
+		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( 'moderate_comments' ) ) {
+			return new WP_Error( 'json_forbidden', __( 'Sorry, you cannot view this comment with edit context' ), array( 'status' => 403 ) );
 		}
 
 		return true;

--- a/tests/test-json-comments-controller.php
+++ b/tests/test-json-comments-controller.php
@@ -97,6 +97,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 	}
 
 	public function test_prepare_item() {
+		wp_set_current_user( $this->admin_id );
 		$request = new WP_JSON_Request( 'GET', sprintf( '/wp/comments/%d', $this->approved_id ) );
 		$request->set_query_params( array(
 			'context' => 'edit',
@@ -114,6 +115,13 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'json_comment_invalid_id', $response, 404 );
+	}
+
+	public function test_get_comment_invalid_context() {
+		$request = new WP_JSON_Request( 'GET', sprintf( '/wp/comments/%s', $this->approved_id ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'json_comment_cannot_view', $response, 403 );
 	}
 
 	public function test_get_comment_invalid_post_id() {
@@ -166,7 +174,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$this->assertEquals( 201, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->check_comment_data( $data, 'edit' );
+		$this->check_comment_data( $data, 'view' );
 		$this->assertEquals( 'hold', $data['status'] );
 		$this->assertEquals( '2014-11-07T10:14:25', $data['date'] );
 	}

--- a/tests/test-json-comments-controller.php
+++ b/tests/test-json-comments-controller.php
@@ -121,7 +121,7 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$request = new WP_JSON_Request( 'GET', sprintf( '/wp/comments/%s', $this->approved_id ) );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'json_comment_cannot_view', $response, 403 );
+		$this->assertErrorResponse( 'json_forbidden', $response, 403 );
 	}
 
 	public function test_get_comment_invalid_post_id() {


### PR DESCRIPTION
If a comment author created a comment without the `moderate_comments`
capability, use context=view

Don't use `edit_comment` capability because `moderate_comments` can be
used to view the Comment list table without granting edit access

See #950, #702 