### PR TITLE
Allow `title` to be set to empty string in request

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -417,7 +417,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		$schema = $this->get_item_schema();
 
 		// Post title
-		if ( ! empty( $schema['properties']['title'] ) && ! empty( $request['title'] ) ) {
+		if ( ! empty( $schema['properties']['title'] ) && isset( $request['title'] ) ) {
 			if ( is_string( $request['title'] ) ) {
 				$prepared_post->post_title = wp_kses_post( $request['title'] );
 			}


### PR DESCRIPTION
Fixes #745