### PR TITLE
Change comment author to structured data

### DIFF
--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -289,9 +289,11 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			'post'         => (int) $comment->comment_post_ID,
 			'parent'       => (int) $comment->comment_parent,
 			'user'         => (int) $comment->user_id,
-			'author'       => $comment->comment_author,
-			'author_email' => $comment->comment_author_email,
-			'author_url'   => $comment->comment_author_url,
+			'author'       => array(
+				'name'  => $comment->comment_author,
+				'email' => false,
+				'url'   => $comment->comment_author_url,
+			),
 			'date'         => json_mysql_to_rfc3339( $comment->comment_date ),
 			'content'      => array(
 				'rendered'     => apply_filters( 'comment_text', $comment->comment_content, $comment ),
@@ -302,11 +304,12 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 		);
 
 		if ( 'edit' == $request['context'] ) {
-			$fields['author_ip']           = $comment->comment_author_IP;
-			$fields['author_user_agent']   = $comment->comment_agent;
-			$fields['date_gmt']            = json_mysql_to_rfc3339( $comment->comment_date_gmt );
-			$fields['content']['raw']      = $comment->comment_content;
-			$fields['karma']               = $comment->comment_karma;
+			$fields['author']['email']      = $comment->comment_author_email;
+			$fields['author']['ip']         = $comment->comment_author_IP;
+			$fields['author']['user_agent'] = $comment->comment_agent;
+			$fields['date_gmt']             = json_mysql_to_rfc3339( $comment->comment_date_gmt );
+			$fields['content']['raw']       = $comment->comment_content;
+			$fields['karma']                = $comment->comment_karma;
 		}
 
 		$links = array();

--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -450,9 +450,9 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			'comment_parent'       => (int) $request['parent'],
 			'user_id'              => isset( $request['user'] ) ? (int) $request['user'] : get_current_user_id(),
 			'comment_content'      => isset( $request['content'] ) ? $request['content'] : '',
-			'comment_author'       => isset( $request['author'] ) ? sanitize_text_field( $request['author'] ) : '',
-			'comment_author_email' => isset( $request['author_email'] ) ? sanitize_email( $request['author_email'] ) : '',
-			'comment_author_url'   => isset( $request['author_url'] ) ? esc_url_raw( $request['author_url'] ) : '',
+			'comment_author'       => isset( $request['author']['name'] ) ? sanitize_text_field( $request['author']['name'] ) : '',
+			'comment_author_email' => isset( $request['author']['email'] ) ? sanitize_email( $request['author']['email'] ) : '',
+			'comment_author_url'   => isset( $request['author']['url'] ) ? esc_url_raw( $request['author']['url'] ) : '',
 			'comment_date'         => isset( $request['date'] ) ? $request['date'] : current_time( 'mysql' ),
 			'comment_date_gmt'     => isset( $request['date_gmt'] ) ? $request['date_gmt'] : current_time( 'mysql', 1 ),
 			// Setting remaining values before wp_insert_comment so we can
@@ -477,16 +477,16 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			$prepared_comment['comment_content'] = $request['content'];
 		}
 
-		if ( isset( $request['author'] ) ) {
-			$prepared_comment['comment_author'] = sanitize_text_field( $request['author'] );
+		if ( isset( $request['author']['name'] ) ) {
+			$prepared_comment['comment_author'] = sanitize_text_field( $request['author']['name'] );
 		}
 
-		if ( isset( $request['author_email'] ) ) {
-			$prepared_comment['comment_author_email'] = sanitize_email( $request['author_email'] );
+		if ( isset( $request['author']['email'] ) ) {
+			$prepared_comment['comment_author_email'] = sanitize_email( $request['author']['email'] );
 		}
 
-		if ( isset( $request['author_url'] ) ) {
-			$prepared_comment['comment_author_url'] = esc_url_raw( $request['author_url'] );
+		if ( isset( $request['author']['url'] ) ) {
+			$prepared_comment['comment_author_url'] = esc_url_raw( $request['author']['url'] );
 		}
 
 		if ( ! empty( $request['date'] ) ) {

--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -288,8 +288,8 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 			'id'           => (int) $comment->comment_ID,
 			'post'         => (int) $comment->comment_post_ID,
 			'parent'       => (int) $comment->comment_parent,
-			'user'         => (int) $comment->user_id,
 			'author'       => array(
+				'id'    => (int) $comment->user_id,
 				'name'  => $comment->comment_author,
 				'email' => false,
 				'url'   => $comment->comment_author_url,

--- a/tests/test-json-comments-controller.php
+++ b/tests/test-json-comments-controller.php
@@ -149,12 +149,14 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( 0 );
 
 		$params = array(
-			'post'         => $this->post_id,
-			'author'       => 'Comic Book Guy',
-			'author_email' => 'cbg@androidsdungeon.com',
-			'author_url'   => 'http://androidsdungeon.com',
-			'content'      => 'Worst Comment Ever!',
-			'date'         => '2014-11-07T10:14:25',
+			'post'    => $this->post_id,
+			'author'  => array(
+				'name'  => 'Comic Book Guy',
+				'email' => 'cbg@androidsdungeon.com',
+				'url'   => 'http://androidsdungeon.com',
+			),
+			'content' => 'Worst Comment Ever!',
+			'date'    => '2014-11-07T10:14:25',
 		);
 
 		$request = new WP_JSON_Request( 'POST', '/wp/comments' );
@@ -175,12 +177,14 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( $this->admin_id );
 
 		$params = array(
-			'post'         => $this->post_id,
-			'author'       => 'Homer Jay Simpson',
-			'author_email' => 'chunkylover53@aol.com',
-			'author_url'   => 'http://compuglobalhypermeganet.com',
-			'content'      => 'Here’s to alcohol: the cause of, and solution to, all of life’s problems.',
-			'user'         => 0,
+			'post'    => $this->post_id,
+			'author'  => array(
+				'name'  => 'Homer Jay Simpson',
+				'email' => 'chunkylover53@aol.com',
+				'url'   => 'http://compuglobalhypermeganet.com',
+			),
+			'content' => 'Here’s to alcohol: the cause of, and solution to, all of life’s problems.',
+			'user'    => 0,
 		);
 
 		$request = new WP_JSON_Request( 'POST', '/wp/comments' );
@@ -191,7 +195,8 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$response = json_ensure_response( $response );
 		$this->assertEquals( 201, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 0, $data['user'] );
+		$this->assertInternalType( 'array', $data['author'] );
+		$this->assertEquals( 0, $data['author']['id'] );
 	}
 
 	public function test_create_item_duplicate() {
@@ -207,10 +212,12 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( 0 );
 
 		$params = array(
-			'post'         => $this->post_id,
-			'author'       => 'Guy N. Cognito',
-			'author_email' => 'chunkylover53@aol.co.uk',
-			'content'      => 'Homer? Who is Homer? My name is Guy N. Cognito.',
+			'post'    => $this->post_id,
+			'author'  => array(
+				'name'  => 'Guy N. Cognito',
+				'email' => 'chunkylover53@aol.co.uk',
+			),
+			'content' => 'Homer? Who is Homer? My name is Guy N. Cognito.',
 		);
 
 		$request = new WP_JSON_Request( 'POST', '/wp/comments' );
@@ -245,11 +252,13 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		wp_set_current_user( $this->admin_id );
 
 		$params = array(
-			'content'      => "Disco Stu doesn't advertise.",
-			'author'       => 'Disco Stu',
-			'author_url'   => 'http://stusdisco.com',
-			'author_email' => 'stu@stusdisco.com',
-			'date'         => '2014-11-07T10:14:25',
+			'content' => "Disco Stu doesn't advertise.",
+			'author'  => array(
+				'name'  => 'Disco Stu',
+				'url'   => 'http://stusdisco.com',
+				'email' => 'stu@stusdisco.com',
+			),
+			'date'    => '2014-11-07T10:14:25',
 		);
 		$request = new WP_JSON_Request( 'PUT', sprintf( '/wp/comments/%d', $this->approved_id ) );
 		$request->add_header( 'content-type', 'application/json' );
@@ -262,9 +271,10 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$comment = $response->get_data();
 		$updated = get_comment( $this->approved_id );
 		$this->assertEquals( $params['content'], $comment['content']['raw'] );
-		$this->assertEquals( $params['author'], $comment['author'] );
-		$this->assertEquals( $params['author_url'], $comment['author_url'] );
-		$this->assertEquals( $params['author_email'], $comment['author_email'] );
+		$this->assertInternalType( 'array', $comment['author'] );
+		$this->assertEquals( $params['author']['name'], $comment['author']['name'] );
+		$this->assertEquals( $params['author']['url'], $comment['author']['url'] );
+		$this->assertEquals( $params['author']['email'], $comment['author']['email'] );
 
 		$this->assertEquals( json_mysql_to_rfc3339( $updated->comment_date ), $comment['date'] );
 		$this->assertEquals( '2014-11-07T10:14:25', $comment['date'] );
@@ -383,25 +393,27 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$this->assertEquals( $comment->comment_ID, $data['id'] );
 		$this->assertEquals( $comment->comment_post_ID, $data['post'] );
 		$this->assertEquals( $comment->comment_parent, $data['parent'] );
-		$this->assertEquals( $comment->user_id, $data['user' ] );
-		$this->assertEquals( $comment->comment_author, $data['author'] );
-		$this->assertEquals( $comment->comment_author_email, $data['author_email'] );
-		$this->assertEquals( $comment->comment_author_url, $data['author_url'] );
+		$this->assertInternalType( 'array', $data['author'] );
+		$this->assertEquals( $comment->user_id, $data['author']['id' ] );
+		$this->assertEquals( $comment->comment_author, $data['author']['name'] );
+		$this->assertEquals( $comment->comment_author_url, $data['author']['url'] );
 		$this->assertEquals( wpautop( $comment->comment_content ), $data['content']['rendered'] );
 		$this->assertEquals( json_mysql_to_rfc3339( $comment->comment_date ), $data['date'] );
 		$this->assertEquals( get_comment_link( $comment ), $data['link'] );
 
 		if ( 'edit' === $context ) {
-			$this->assertEquals( $comment->comment_author_IP, $data['author_ip'] );
-			$this->assertEquals( $comment->comment_agent, $data['author_user_agent'] );
+			$this->assertEquals( $comment->comment_author_email, $data['author']['email'] );
+			$this->assertEquals( $comment->comment_author_IP, $data['author']['ip'] );
+			$this->assertEquals( $comment->comment_agent, $data['author']['user_agent'] );
 			$this->assertEquals( json_mysql_to_rfc3339( $comment->comment_date_gmt ), $data['date_gmt'] );
 			$this->assertEquals( $comment->comment_content, $data['content']['raw'] );
 			$this->assertEquals( $comment->comment_karma, $data['karma'] );
 		}
 
 		if ( 'edit' !== $context ) {
-			$this->assertArrayNotHasKey( 'author_ip', $data );
-			$this->assertArrayNotHasKey( 'author_user_agent', $data );
+			$this->assertFalse( $data['author']['email'] );
+			$this->assertArrayNotHasKey( 'ip', $data['author'] );
+			$this->assertArrayNotHasKey( 'user_agent', $data['author'] );
 			$this->assertArrayNotHasKey( 'date_gmt', $data );
 			$this->assertArrayNotHasKey( 'raw', $data['content'] );
 			$this->assertArrayNotHasKey( 'karma', $data );


### PR DESCRIPTION
For comments, we currently have destructured author data in the following form:

```json
{
    "author": "admin",
    "author_email": "admin@example.com",
    "author_url": ""
}
```

Why did we switch from structured data (`author: { ... }`) to destructured data in the first place? Is anyone opposed to changing that back?

Also fixes #893.