### PR TITLE
Ensure post deletion is idempotent

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -59,7 +59,9 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 				'callback' => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 				'args'     => array(
-					'force'    => array(),
+					'force'    => array(
+						'default'      => false,
+					),
 				),
 			),
 		) );
@@ -289,7 +291,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 	 */
 	public function delete_item( $request ) {
 		$id = (int) $request['id'];
-		$force = isset( $request['force'] ) ? (bool) $request['force']: false;
+		$force = (bool) $request['force'];
 
 		$post = get_post( $id );
 

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -280,7 +280,10 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 		else {
 			// Otherwise, only trash if we haven't already
-			//
+			if ( EMPTY_TRASH_DAYS && $post->post_status == 'trash' ) {
+				return new WP_Error( 'json_already_deleted', __( 'The post has already been deleted.' ), array( 'status' => 410 ) );
+			}
+
 			// (Note that internally this falls through to `wp_delete_post` if
 			// the trash is disabled.)
 			$result = wp_trash_post( $id );

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -274,7 +274,17 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			return new WP_Error( 'json_user_cannot_delete_post', __( 'Sorry, you are not allowed to delete this post.' ), array( 'status' => 401 ) );
 		}
 
-		$result = wp_delete_post( $id, $force );
+		// If we're forcing, then delete permanently
+		if ( $force ) {
+			$result = wp_delete_post( $id, true );
+		}
+		else {
+			// Otherwise, only trash if we haven't already
+			//
+			// (Note that internally this falls through to `wp_delete_post` if
+			// the trash is disabled.)
+			$result = wp_trash_post( $id );
+		}
 
 		if ( ! $result ) {
 			return new WP_Error( 'json_cannot_delete', __( 'The post cannot be deleted.' ), array( 'status' => 500 ) );

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -183,7 +183,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			}
 		}
 
-		if ( ! empty( $schema['properties']['featured_image'] ) && isset( $request['featured_image' ] ) ) {
+		if ( ! empty( $schema['properties']['featured_image'] ) && isset( $request['featured_image'] ) ) {
 			$this->handle_featured_image( $request['featured_image'], $post->ID );
 		}
 
@@ -248,7 +248,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			$this->handle_format_param( $request['format'], $post );
 		}
 
-		if ( ! empty( $schema['properties']['featured_image'] ) && isset( $request['featured_image' ] ) ) {
+		if ( ! empty( $schema['properties']['featured_image'] ) && isset( $request['featured_image'] ) ) {
 			$this->handle_featured_image( $request['featured_image'], $post_id );
 		}
 
@@ -973,7 +973,6 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			if ( ! empty( $post->post_password ) ) {
 				$_COOKIE['wp-postpass_' . COOKIEHASH] = '';
 			}
-
 		}
 
 		if ( ! empty( $schema['properties']['excerpt'] ) ) {
@@ -1266,7 +1265,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 				continue;
 			}
 
-			switch( $attribute ) {
+			switch ( $attribute ) {
 
 				case 'title':
 					$schema['properties']['title'] = array(


### PR DESCRIPTION
Practically speaking: a DELETE request to a post resource will ensure the post is trashed. If the post is already trashed, no change will occur. To permanently delete, pass force=true, and it will be permanently deleted regardless of status.

This is a change from the previous behaviour of the first DELETE trashing the post, and the second DELETE permanently deleting it.

See #789.