### PR TITLE
Allow HTTP method to be overwritten by HTTP_X_HTTP_METHOD_OVERRIDE

### DIFF
--- a/lib/infrastructure/class-wp-json-server.php
+++ b/lib/infrastructure/class-wp-json-server.php
@@ -200,7 +200,12 @@ class WP_JSON_Server {
 			}
 		}
 
-		$request = new WP_JSON_Request( $_SERVER['REQUEST_METHOD'], $path );
+		$method = $_SERVER['REQUEST_METHOD'];
+		if ( ! empty( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
+			$method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
+		}
+
+		$request = new WP_JSON_Request( $method, $path );
 		$request->set_query_params( $_GET );
 		$request->set_body_params( $_POST );
 		$request->set_file_params( $_FILES );

--- a/lib/infrastructure/class-wp-json-server.php
+++ b/lib/infrastructure/class-wp-json-server.php
@@ -200,21 +200,22 @@ class WP_JSON_Server {
 			}
 		}
 
-		$method = $_SERVER['REQUEST_METHOD'];
-		if ( ! empty( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
-			$method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
-		}
-
-		$request = new WP_JSON_Request( $method, $path );
+		$request = new WP_JSON_Request( $_SERVER['REQUEST_METHOD'], $path );
 		$request->set_query_params( $_GET );
 		$request->set_body_params( $_POST );
 		$request->set_file_params( $_FILES );
 		$request->set_headers( $this->get_headers( $_SERVER ) );
 		$request->set_body( $this->get_raw_data() );
 
-		// Compatibility for clients that can't use PUT/PATCH/DELETE
+		/**
+		 * HTTP method override for clients that can't use PUT/PATCH/DELETE. First, we check
+		 * $_GET['_method']. If that is not set, we check for the HTTP_X_HTTP_METHOD_OVERRIDE
+		 * header.
+		 */
 		if ( isset( $_GET['_method'] ) ) {
 			$request->set_method( $_GET['_method'] );
+		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
+			$request->set_method( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] );
 		}
 
 		$result = $this->check_authentication();


### PR DESCRIPTION
Simply check `$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']` and if it is set, use it as the request method.