### PR TITLE
Fix attachment caption and description fields

### DIFF
--- a/lib/endpoints/class-wp-json-attachments-controller.php
+++ b/lib/endpoints/class-wp-json-attachments-controller.php
@@ -121,11 +121,11 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 		$prepared_attachment = parent::prepare_item_for_database( $request );
 
 		if ( isset( $request['caption'] ) ) {
-			$prepared_attachment->post_content = wp_filter_post_kses( $request['caption'] );
+			$prepared_attachment->post_excerpt = wp_filter_post_kses( $request['caption'] );
 		}
 
 		if ( isset( $request['description'] ) ) {
-			$prepared_attachment->post_excerpt = wp_filter_post_kses( $request['description'] );
+			$prepared_attachment->post_content = wp_filter_post_kses( $request['description'] );
 		}
 
 		if ( isset( $request['post'] ) ) {
@@ -146,8 +146,8 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 		$response = parent::prepare_item_for_response( $post, $request );
 
 		$response['alt_text']      = get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
-		$response['caption']       = $post->post_content;
-		$response['description']   = $post->post_excerpt;
+		$response['caption']       = $post->post_excerpt;
+		$response['description']   = $post->post_content;
 		$response['media_type']    = wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
 		$response['media_details'] = wp_get_attachment_metadata( $post->ID );
 		$response['post']          = ! empty( $post->post_parent ) ? (int) $post->post_parent : null;

--- a/tests/test-json-attachments-controller.php
+++ b/tests/test-json-attachments-controller.php
@@ -170,9 +170,9 @@ class WP_Test_JSON_Attachments_Controller extends WP_Test_JSON_Post_Type_Control
 		$this->assertEquals( 'My title is very cool', $data['title']['raw'] );
 		$this->assertEquals( 'My title is very cool', $attachment->post_title );
 		$this->assertEquals( 'This is a better caption.', $data['caption'] );
-		$this->assertEquals( 'This is a better caption.', $attachment->post_content );
+		$this->assertEquals( 'This is a better caption.', $attachment->post_excerpt );
 		$this->assertEquals( 'Without a description, my attachment is descriptionless.', $data['description'] );
-		$this->assertEquals( 'Without a description, my attachment is descriptionless.', $attachment->post_excerpt );
+		$this->assertEquals( 'Without a description, my attachment is descriptionless.', $attachment->post_content );
 		$this->assertEquals( 'Alt text is stored outside post schema.', $data['alt_text'] );
 		$this->assertEquals( 'Alt text is stored outside post schema.', get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ) );
 	}
@@ -265,8 +265,8 @@ class WP_Test_JSON_Attachments_Controller extends WP_Test_JSON_Post_Type_Control
 		parent::check_post_data( $attachment, $data, $context );
 
 		$this->assertEquals( get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ), $data['alt_text'] );
-		$this->assertEquals( $attachment->post_content, $data['caption'] );
-		$this->assertEquals( $attachment->post_excerpt, $data['description'] );
+		$this->assertEquals( $attachment->post_excerpt, $data['caption'] );
+		$this->assertEquals( $attachment->post_content, $data['description'] );
 
 		if ( $attachment->post_parent ) {
 			$this->assertEquals( $attachment->post_parent, $data['post'] );


### PR DESCRIPTION
`caption` is stored in `post_excerpt`, `description` is stored in
`post_content`. They were switched.

See
https://core.trac.wordpress.org/browser/trunk/src/wp-includes/media.php#L2701