### PR TITLE
Return correct response code from wp_insert_post() error

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -215,7 +215,14 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 
 		$post->post_type = $this->post_type;
 		$post_id = wp_insert_post( $post, true );
+
 		if ( is_wp_error( $post_id ) ) {
+
+			if ( in_array( $post_id->get_error_code(), array( 'db_insert_error' ) ) ) {
+				$post_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$post_id->add_data( array( 'status' => 400 ) );
+			}
 			return $post_id;
 		}
 		$post->ID = $post_id;
@@ -282,6 +289,11 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 
 		$post_id = wp_update_post( $post, true );
 		if ( is_wp_error( $post_id ) ) {
+			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ) ) ) {
+				$post_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$post_id->add_data( array( 'status' => 400 ) );
+			}
 			return $post_id;
 		}
 

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -555,11 +555,11 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		 * trigger a DB error.
 		 */
 		global $wpdb;
-		$wpdb->show_errors = false;
-		add_filter( 'query', array( $this, 'disable_insert_query' ) );
+		$wpdb->suppress_errors = true;
+		add_filter( 'query', array( $this, 'error_insert_query' ) );
 		
 		$response = $this->server->dispatch( $request );
-		remove_filter( 'query', array( $this, 'disable_insert_query' ) );
+		remove_filter( 'query', array( $this, 'error_insert_query' ) );
 		$wpdb->show_errors = true;
 
 		$this->assertErrorResponse( 'db_insert_error', $response, 500 );
@@ -927,9 +927,9 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 	 * Internal function used to disable an insert query which
 	 * will trigger a wpdb error for testing purposes.
 	 */
-	public function disable_insert_query( $query ) {
+	public function error_insert_query( $query ) {
 		if ( strpos( $query, 'INSERT' ) === 0 ) {
-			$query = '';
+			$query = '],';
 		}
 		return $query;
 	}


### PR DESCRIPTION
From #961 we always trigger a 500 error is wp_insert_post() / wp_update_post() fails, however it's not neccesarily a problem with "us" it ould also be a problem with the request data.

I went through wp_insert_post() and put a check in for the only one which should be considered a 500 - which is a DB insert / update error. Also I made a tricky unit test to test this scenario.