### PR TITLE
If an invalid date is supplied to create / update post, return an error

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -539,12 +539,16 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 
 			if ( ! empty( $date_data ) ) {
 				list( $prepared_post->post_date, $prepared_post->post_date_gmt ) = $date_data;
+			} else {
+				return new WP_Error( 'json_invalid_date', __( 'The date you provided is invalid.' ), array( 'status' => 400 ) );
 			}
 		} elseif ( ! empty( $request['date_gmt'] ) ) {
 			$date_data = json_get_date_with_gmt( $request['date_gmt'], true );
 
 			if ( ! empty( $date_data ) ) {
 				list( $prepared_post->post_date, $prepared_post->post_date_gmt ) = $date_data;
+			} else {
+				return new WP_Error( 'json_invalid_date', __( 'The date you provided is invalid.' ), array( 'status' => 400 ) );
 			}
 		}
 		// Post slug

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -525,6 +525,32 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$this->assertEquals( $time, strtotime( $new_post->post_date ) );
 	}
 
+	public function test_create_post_with_invalid_date() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'POST', '/wp/posts' );
+		$params = $this->set_post_data( array(
+			'date' => '2010-60-01T02:00:00Z',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'json_invalid_date', $response, 400 );
+	}
+
+	public function test_create_post_with_invalid_date_gmt() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_JSON_Request( 'POST', '/wp/posts' );
+		$params = $this->set_post_data( array(
+			'date_gmt' => '2010-60-01T02:00:00',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'json_invalid_date', $response, 400 );
+	}
+
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
Currently we silently fail to not updating the date.