### PR TITLE
Allow HTTP method to be overwritten by HTTP_X_HTTP_METHOD_OVERRIDE

### DIFF
--- a/lib/class-wp-json-server.php
+++ b/lib/class-wp-json-server.php
@@ -224,9 +224,15 @@ class WP_JSON_Server implements WP_JSON_ResponseHandler {
 		$this->headers        = $this->get_headers( $_SERVER );
 		$this->files          = $_FILES;
 
-		// Compatibility for clients that can't use PUT/PATCH/DELETE
+		/**
+		 * HTTP method override for clients that can't use PUT/PATCH/DELETE. First, we check
+		 * $_GET['_method']. If that is not set, we check for the HTTP_X_HTTP_METHOD_OVERRIDE
+		 * header.
+		 */
 		if ( isset( $_GET['_method'] ) ) {
 			$this->method = strtoupper( $_GET['_method'] );
+		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
+			$this->method = strtoupper( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] );
 		}
 
 		$result = $this->check_authentication();


### PR DESCRIPTION
Title says it all. We did this in #967 for the `develop` branch.