### PR TITLE
Bug fix: upload attachment error

### DIFF
--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -434,7 +434,7 @@ class WP_JSON_Media extends WP_JSON_Posts {
 			// Already verified in preinsert_check()
 			$thumbnail = $this->get_post( $data['featured_image'], 'child' );
 
-			set_post_thumbnail( $post['ID'], $thumbnail['ID'] );
+			set_post_thumbnail( $post['ID'], $thumbnail->data['ID'] );
 		}
 	}
 


### PR DESCRIPTION
The get_post method does not return an array, but a WP_JSON_Response object. Because of this, the ID of the thumbnail is only to be found in the data variable of the class.

This PR fixes issue : #1009.