### PR TITLE
Add embeddable attachments to Post response _links

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -1124,7 +1124,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			);
 		}
 
-		if ( 'attachment' !== $post->post_type ) {
+		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
 			$attachments_url = json_url( 'wp/media' );
 			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
 			$links['attachments'] = array(

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -449,7 +449,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			$valid_vars = array_merge( $valid_vars, $private );
 		}
 		// Define our own in addition to WP's normal vars
-		$json_valid = array( 'posts_per_page', 'ignore_sticky_posts' );
+		$json_valid = array( 'posts_per_page', 'ignore_sticky_posts', 'post_parent' );
 		$valid_vars = array_merge( $valid_vars, $json_valid );
 
 		/**
@@ -1124,6 +1124,15 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 			);
 		}
 
+		if ( 'attachment' !== $post->post_type ) {
+			$attachments_url = json_url( 'wp/media' );
+			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
+			$links['attachments'] = array(
+				'href'       => $attachments_url,
+				'embeddable' => true,
+			);
+		}
+
 		return $links;
 	}
 
@@ -1337,7 +1346,6 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 					break;
 
 			}
-
 		}
 
 		if ( 'post' === $this->post_type ) {

--- a/tests/test-json-posts-controller.php
+++ b/tests/test-json-posts-controller.php
@@ -99,6 +99,10 @@ class WP_Test_JSON_Posts_Controller extends WP_Test_JSON_Post_Type_Controller_Te
 		$this->assertEquals( $replies_url, $links['replies'][0]['href'] );
 
 		$this->assertEquals( json_url( '/wp/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );
+
+		$attachments_url = json_url( 'wp/media' );
+		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
+		$this->assertEquals( $attachments_url, $links['attachments'][0]['href'] );
 	}
 
 	public function test_get_post_without_permission() {


### PR DESCRIPTION
Adds the `attachments` key to the `_links` object in a Post response for discoverability, which is also embeddable.  This does require allowing the `post_parent` query parameter to be public, which the WordPress.com API already allows: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/.  