### PR TITLE
Add missing response fields to the user schema.

### DIFF
--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -500,31 +500,61 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 	public function get_item_schema() {
 
 		$schema = array(
-			'$schema'              => 'http://json-schema.org/draft-04/schema#',
-			'title'                => 'user',
-			'type'                 => 'object',
-			'properties'           => array(
-				'id'               => array(
-					'description'  => 'Unique identifier for the object.',
-					'type'         => 'integer',
-					),
-				'name'             => array(
-					'description'  => 'Display name for the object.',
-					'type'         => 'string',
-					),
-				'email'            => array(
-					'description'  => 'The email address for the object.',
-					'type'         => 'string',
-					'format'       => 'email',
-					),
-				'link'             => array(
-					'description'  => 'URL to the object.',
-					'type'         => 'string',
-					'format'       => 'uri',
-					),
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'user',
+			'type'       => 'object',
+			'properties' => array(
+				'id'          => array(
+					'description' => 'Unique identifier for the object.',
+					'type'        => 'integer',
 				),
-			);
-		return $schema;
+				'name'        => array(
+					'description' => 'Display name for the object.',
+					'type'        => 'string',
+				),
+				'first_name'  => array(
+					'description' => 'First name for the object.',
+					'type'        => 'string',
+				),
+				'last_name'   => array(
+					'description' => 'Last name for the object.',
+					'type'        => 'string',
+				),
+				'email'       => array(
+					'description' => 'The email address for the object.',
+					'type'        => 'string',
+					'format'      => 'email',
+				),
+				'link'        => array(
+					'description' => 'Author URL to the object.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'nickname'    => array(
+					'description' => 'The nickname for the object.',
+					'type'        => 'string',
+				),
+				'slug'        => array(
+					'description' => 'An alphanumeric identifier for the object unique to its type.',
+					'type'        => 'string',
+				),
+				'url'         => array(
+					'description' => 'URL of the object.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'avatar_url'  => array(
+					'description' => 'Avatar URL for the object.',
+					'type'        => 'string',
+					'format'      => 'uri',
+				),
+				'description' => array(
+					'description' => 'Description of the object.',
+					'type'        => 'string',
+				),
+			)
+		);
 
+		return $schema;
 	}
 }

--- a/tests/test-json-users-controller.php
+++ b/tests/test-json-users-controller.php
@@ -459,11 +459,19 @@ class WP_Test_JSON_Users_Controller extends WP_Test_JSON_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];
-		$this->assertEquals( 4, count( $properties ) );
+
+		$this->assertEquals( 11, count( $properties ) );
+		$this->assertArrayHasKey( 'avatar_url', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'email', $properties );
+		$this->assertArrayHasKey( 'first_name', $properties );
 		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'last_name', $properties );
 		$this->assertArrayHasKey( 'link', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'nickname', $properties );
+		$this->assertArrayHasKey( 'slug', $properties );
+		$this->assertArrayHasKey( 'url', $properties );
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
The existing schema returned from `wp/users/schema` only included the following properties:

  - id
  - name
  - email
  - link

This adds the following missing properties to the schema:

  - first_name
  - last_name
  - nickname
  - slug
  - url
  - avatar_url
  - description

