### PR TITLE
Allow WP_JSON_Server::send_header()/send_headers() to be accessed publicly

### DIFF
--- a/lib/infrastructure/class-wp-json-server.php
+++ b/lib/infrastructure/class-wp-json-server.php
@@ -727,7 +727,7 @@ class WP_JSON_Server {
 	 * @param string $key Header key
 	 * @param string $value Header value
 	 */
-	protected function send_header( $key, $value ) {
+	public function send_header( $key, $value ) {
 		// Sanitize as per RFC2616 (Section 4.2):
 		//   Any LWS that occurs between field-content MAY be replaced with a
 		//   single SP before interpreting the field value or forwarding the
@@ -741,7 +741,7 @@ class WP_JSON_Server {
 	 *
 	 * @param array Map of header name to header value
 	 */
-	protected function send_headers( $headers ) {
+	public function send_headers( $headers ) {
 		foreach ( $headers as $key => $value ) {
 			$this->send_header( $key, $value );
 		}


### PR DESCRIPTION
When using the `json_pre_serve_request` hook, it's not possible to call `$server->send_header()` or `$server->send_headers()` because they're protected methods.

Let's make them public so a callback on the `json_pre_serve_request` action can use these methods instead of using `header()` directly.