### PR TITLE
Allow empty titles to be set after initial title is set.

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -822,7 +822,7 @@ class WP_JSON_Posts {
 		}
 
 		// Post title
-		if ( ! empty( $data['title'] ) ) {
+		if ( isset( $data['title'] ) ) {
 			$post['post_title'] = $data['title'];
 		}
 

--- a/tests/test-json-posts.php
+++ b/tests/test-json-posts.php
@@ -647,6 +647,14 @@ class WP_Test_JSON_Posts extends WP_Test_JSON_TestCase {
 		$this->check_get_post_response( $response, $edited_post );
 	}
 
+	function test_edit_post_set_empty_title() {
+		$data = $this->set_data( array( 'ID' => $this->post_id, 'title' => '' ) ) ;
+		$this->endpoint->edit_post( $this->post_id, $data );
+
+		// Check that we have an empty title
+		$this->assertEquals( '', get_the_title( $this->post_id ) );
+	}
+
 	function test_edit_post_without_permission() {
 		$data = $this->set_data( array( 'ID' => $this->post_id ) ) ;
 


### PR DESCRIPTION
Once a title has been set as non-empty further edits cannot set the title as empty. This fixes the problem with an `isset` check instead of `! empty`.