### PR TITLE
Fix the format of the args when building them from the Schema

### DIFF
--- a/lib/endpoints/class-wp-json-controller.php
+++ b/lib/endpoints/class-wp-json-controller.php
@@ -103,4 +103,21 @@ abstract class WP_JSON_Controller {
 		return array();
 	}
 
+	/**
+	 * Get an array of endpoint arguments from the item schema for the controller.
+	 * 
+	 * @return array
+	 */
+	public function get_endpoint_args_for_item_schema() {
+
+		$schema                = $this->get_item_schema();
+		$post_type_fields      = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
+		$post_type_fields_args = array();
+
+		foreach ( $post_type_fields as $field_id => $params ) {
+			$post_type_fields_args[$field_id] = array();
+		}
+
+		return $post_type_fields_args;
+	}
 }

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -15,8 +15,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 
 		$base = $this->get_post_type_base( $this->post_type );
 
-		$schema = $this->get_item_schema();
-		$post_type_fields = ! empty( $schema['properties'] ) ? array_keys( $schema['properties'] ) : array();
+		$post_type_fields = $this->get_endpoint_args_for_item_schema();
 
 		register_json_route( 'wp', '/' . $base, array(
 			array(


### PR DESCRIPTION
Currently we pass the args as `array( 'title', 'author', ... );` which is not
the correct format. This Pull Request changes that to be `array( 'title' =>
array( ... ), ... )` which can / will be extended to add arg validation per
the enums / datatype defines in the schema.