### PR TITLE
Check edit permission for context before returning created post

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -234,7 +234,7 @@ class WP_JSON_Posts {
 
 		$context = 'edit';
 
-		if ( !json_check_post_permission( $post, 'edit' ) ) {
+		if ( !json_check_post_permission( get_post( $result, ARRAY_A ), 'edit' ) ) {
 			$context = 'view';
 		}
 

--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -232,7 +232,13 @@ class WP_JSON_Posts {
 			return $result;
 		}
 
-		$response = json_ensure_response( $this->get_post( $result, 'edit' ) );
+		$context = 'edit';
+
+		if ( !json_check_post_permission( $post, 'edit' ) ) {
+			$context = 'view';
+		}
+
+		$response = json_ensure_response( $this->get_post( $result, $context ) );
 		$response->set_status( 201 );
 		$response->header( 'Location', json_url( '/posts/' . $result ) );
 


### PR DESCRIPTION
After creating the post, the returned post object is always on "edit" context. In my project, the user can publish a post in a certain post type, but not edit afterwards. That causes a crash, since the returned object for `json_ensure_response( $this->get_post( $result, 'edit' ) )` is a WP_Error and it tries to `set_status` on this WP_Error.

The best solution, I figured, is to check the user permission to send the proper context as parameter.