### PR TITLE
Rename the `wp_json_server_before_serve` to `wp_json_init`

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -155,7 +155,7 @@ function create_initial_json_routes() {
 	$controller->register_routes();
 
 }
-add_action( 'wp_json_server_before_serve', 'create_initial_json_routes', 0 );
+add_action( 'wp_json_init', 'create_initial_json_routes', 0 );
 
 /**
  * Register rewrite rules for the API.
@@ -225,7 +225,7 @@ function json_api_default_filters( $server ) {
 	add_filter( 'json_pre_dispatch',  'json_handle_options_request', 10, 3 );
 
 }
-add_action( 'wp_json_server_before_serve', 'json_api_default_filters', 10, 1 );
+add_action( 'wp_json_init', 'json_api_default_filters', 10, 1 );
 
 /**
  * Load the JSON API.
@@ -269,7 +269,7 @@ function json_api_loaded() {
 	 *
 	 * @param WP_JSON_Server $wp_json_server Server object.
 	 */
-	do_action( 'wp_json_server_before_serve', $wp_json_server );
+	do_action( 'wp_json_init', $wp_json_server );
 
 	// Fire off the request.
 	$wp_json_server->serve_request( $GLOBALS['wp']->query_vars['json_route'] );

--- a/tests/class-wp-test-json-controller-testcase.php
+++ b/tests/class-wp-test-json-controller-testcase.php
@@ -8,7 +8,7 @@ abstract class WP_Test_JSON_Controller_Testcase extends WP_Test_JSON_TestCase {
 		parent::setUp();
 		global $wp_json_server;
 		$this->server = $wp_json_server = new WP_JSON_Server;
-		do_action( 'wp_json_server_before_serve' );
+		do_action( 'wp_json_init' );
 	}
 
 	public function tearDown() {

--- a/tests/test-json-server.php
+++ b/tests/test-json-server.php
@@ -13,7 +13,7 @@ class WP_Test_JSON_Server extends WP_Test_JSON_TestCase {
 		global $wp_json_server;
 		$this->server = $wp_json_server = new WP_Test_Spy_JSON_Server();
 
-		do_action( 'wp_json_server_before_serve', $this->server );
+		do_action( 'wp_json_init', $this->server );
 	}
 
 	public function test_envelope() {


### PR DESCRIPTION
Currently, developers must use the `wp_json_server_before_serve` hook to add
any new endpoints. This is very verbose and difficult to remember, I think it
would be better to have this named akin to `init` and `admin_init` hooks. In
the future, if the plugin switches to `wp_api` prefix, rather than `json` I
think we'd change this hook to `api_init` but for now I think it's best kept
inline with the rest of the naming conventions.