### PR TITLE
Only use if it's not WP_Error, and get data from Response object

### DIFF
--- a/lib/class-wp-json-media.php
+++ b/lib/class-wp-json-media.php
@@ -433,8 +433,10 @@ class WP_JSON_Media extends WP_JSON_Posts {
 		if ( ! empty( $data['featured_image'] ) ) {
 			// Already verified in preinsert_check()
 			$thumbnail = $this->get_post( $data['featured_image'], 'child' );
-
-			set_post_thumbnail( $post['ID'], $thumbnail->data['ID'] );
+			if ( ! is_wp_error( $thumbnail ) ) {
+				$data = $thumbnail->get_data();
+				set_post_thumbnail( $post['ID'], $data['ID'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1099