### PR TITLE
Use the user fields from the item schema as the request args in route registration

### DIFF
--- a/lib/endpoints/class-wp-json-controller.php
+++ b/lib/endpoints/class-wp-json-controller.php
@@ -171,7 +171,7 @@ abstract class WP_JSON_Controller {
 			$post_type_fields_args[$field_id] = array();
 
 			if ( $add_required_flag && ! empty( $params['required'] ) ) {
-				$post_type_fields_args[$field_id]['required'] = true				
+				$post_type_fields_args[$field_id]['required'] = true;			
 			}
 		}
 

--- a/lib/endpoints/class-wp-json-controller.php
+++ b/lib/endpoints/class-wp-json-controller.php
@@ -119,7 +119,7 @@ abstract class WP_JSON_Controller {
 	public function filter_response_by_context( $data, $context ) {
 
 		$schema = $this->get_item_schema();
-		foreach( $data as $key => $value ) {
+		foreach ( $data as $key => $value ) {
 			if ( empty( $schema['properties'][ $key ] ) || empty( $schema['properties'][ $key ]['context'] ) ) {
 				continue;
 			}
@@ -129,7 +129,7 @@ abstract class WP_JSON_Controller {
 			}
 
 			if ( 'object' === $schema['properties'][ $key ]['type'] && ! empty( $schema['properties'][ $key ]['properties'] ) ) {
-				foreach( $schema['properties'][ $key ]['properties'] as $attribute => $details ) {
+				foreach ( $schema['properties'][ $key ]['properties'] as $attribute => $details ) {
 					if ( empty( $details['context'] ) ) {
 						continue;
 					}
@@ -138,7 +138,6 @@ abstract class WP_JSON_Controller {
 					}
 				}
 			}
-
 		}
 
 		return $data;

--- a/lib/endpoints/class-wp-json-controller.php
+++ b/lib/endpoints/class-wp-json-controller.php
@@ -155,10 +155,13 @@ abstract class WP_JSON_Controller {
 
 	/**
 	 * Get an array of endpoint arguments from the item schema for the controller.
-	 * 
+	 *
+	 * @param $add_required_flag Whether to use the 'required' flag from the schema proprties.
+	 *                           This is because update requests will not have any required params
+	 *                           Where as create requests will.
 	 * @return array
 	 */
-	public function get_endpoint_args_for_item_schema() {
+	public function get_endpoint_args_for_item_schema( $add_required_flag = true ) {
 
 		$schema                = $this->get_item_schema();
 		$post_type_fields      = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
@@ -166,6 +169,10 @@ abstract class WP_JSON_Controller {
 
 		foreach ( $post_type_fields as $field_id => $params ) {
 			$post_type_fields_args[$field_id] = array();
+
+			if ( $add_required_flag && ! empty( $params['required'] ) ) {
+				$post_type_fields_args[$field_id]['required'] = true				
+			}
 		}
 
 		return $post_type_fields_args;

--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -9,7 +9,9 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {
-		
+			
+		$user_fields = $this->get_endpoint_args_for_item_schema();
+
 		register_json_route( 'wp', '/users', array(
 			array(
 				'methods'         => WP_JSON_Server::READABLE,
@@ -27,25 +29,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'methods'         => WP_JSON_Server::CREATABLE,
 				'callback'        => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'            => array(
-					'email'           => array(
-						'required'        => true,
-					),
-					'username'        => array(
-						'required'        => true,
-					),
-					'password'        => array(
-						'required'        => true,
-					),
-					'name'            => array(),
-					'first_name'      => array(),
-					'last_name'       => array(),
-					'nickname'        => array(),
-					'slug'            => array(),
-					'description'     => array(),
-					'role'            => array(),
-					'url'             => array(),
-				),
+				'args'            => $user_fields,
 			),
 		) );
 		register_json_route( 'wp', '/users/(?P<id>[\d]+)', array(
@@ -56,26 +40,14 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'args'            => array(
 					'context'          => array(
 						'default'      => 'embed',
-						),
+					),
 				),
 			),
 			array(
 				'methods'         => WP_JSON_Server::EDITABLE,
 				'callback'        => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'            => array(
-					'email'           => array(),
-					'username'        => array(),
-					'password'        => array(),
-					'name'            => array(),
-					'first_name'      => array(),
-					'last_name'       => array(),
-					'nickname'        => array(),
-					'slug'            => array(),
-					'description'     => array(),
-					'role'            => array(),
-					'url'             => array(),
-				),
+				'args'            => $user_fields,
 			),
 			array(
 				'methods' => WP_JSON_Server::DELETABLE,

--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -29,7 +29,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( true ), array(
 					'password'    => array(
-						'required' => true
+						'required' => true,
 					)
 				) ),
 			),
@@ -528,7 +528,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'type'        => 'string',
 					'format'      => 'email',
 					'context'     => array( 'view', 'edit' ),
-					'required'    => true
+					'required'    => true,
 				),
 				'extra_capabilities' => array(
 					'description' => 'Any extra capabilities assigned to the user.',
@@ -591,7 +591,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Login name for the user.',
 					'type'        => 'string',
 					'context'     => array( 'edit' ),
-					'required'    => true
+					'required'    => true,
 				),
 			)
 		);

--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -29,7 +29,11 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'methods'         => WP_JSON_Server::CREATABLE,
 				'callback'        => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'            => $user_fields,
+				'args'            => array_merge( $user_fields, array(
+					'password'    => array(
+						'required' => true
+					)
+				) ),
 			),
 		) );
 		register_json_route( 'wp', '/users/(?P<id>[\d]+)', array(
@@ -47,7 +51,9 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'methods'         => WP_JSON_Server::EDITABLE,
 				'callback'        => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'            => $user_fields,
+				'args'            => array_merge( $user_fields, array(
+					'password'    => array()
+				) ),
 			),
 			array(
 				'methods' => WP_JSON_Server::DELETABLE,

--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -10,7 +10,6 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 	 */
 	public function register_routes() {
 			
-		$user_fields = $this->get_endpoint_args_for_item_schema();
 
 		register_json_route( 'wp', '/users', array(
 			array(
@@ -29,7 +28,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'methods'         => WP_JSON_Server::CREATABLE,
 				'callback'        => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'            => array_merge( $user_fields, array(
+				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( true ), array(
 					'password'    => array(
 						'required' => true
 					)
@@ -51,7 +50,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 				'methods'         => WP_JSON_Server::EDITABLE,
 				'callback'        => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'            => array_merge( $user_fields, array(
+				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( false ), array(
 					'password'    => array()
 				) ),
 			),
@@ -514,6 +513,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'type'        => 'string',
 					'format'      => 'email',
 					'context'     => array( 'view', 'edit' ),
+					'required'    => true
 				),
 				'extra_capabilities' => array(
 					'description' => 'Any extra capabilities assigned to the user.',
@@ -555,12 +555,12 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Registration date for the user.',
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
-					),
+				),
 				'roles'           => array(
 					'description' => 'Roles assigned to the user.',
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					),
+				),
 				'slug'        => array(
 					'description' => 'An alphanumeric identifier for the object unique to its type.',
 					'type'        => 'string',
@@ -576,7 +576,8 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Login name for the user.',
 					'type'        => 'string',
 					'context'     => array( 'edit' ),
-					),
+					'required'    => true
+				),
 			)
 		);
 


### PR DESCRIPTION
More DRY and rebust as the args are hardlinked to the schema