### PR TITLE
Fix copy pasta in the schema checks

### DIFF
--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -665,7 +665,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 		}
 
 		// Author
-		if ( ! empty( $schema['properties']['title'] ) && ! empty( $request['author'] ) ) {
+		if ( ! empty( $schema['properties']['author'] ) && ! empty( $request['author'] ) ) {
 			$author = $this->handle_author_param( $request['author'], $post_type );
 			if ( is_wp_error( $author ) ) {
 				return $author;


### PR DESCRIPTION
I'd add test coverage, but mocking variable schemas is out of scope at
the moment