### PR TITLE
When `context=edit`, confirm user can `manage_comments`

### DIFF
--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -298,15 +298,17 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 
-		// If the post id isn't specified, presume we can create
-		if ( ! isset( $request['post'] ) ) {
-			return true;
+		// If the post id is specified, check that we can read the post
+		if ( isset( $request['post'] ) ) {
+			$post = get_post( (int) $request['post'] );
+
+			if ( $post && ! $this->check_read_post_permission( $post ) ) {
+				return false;
+			}
 		}
 
-		$post = get_post( (int) $request['post'] );
-
-		if ( $post && ! $this->check_read_post_permission( $post ) ) {
-			return false;
+		if ( ! empty( $request['context'] ) && 'edit' == $request['context'] && ! current_user_can( 'manage_comments' ) ) {
+			return new WP_Error( 'json_forbidden', __( 'Sorry, you cannot view comments with edit context' ), array( 'status' => 403 ) );
 		}
 
 		return true;

--- a/tests/test-json-comments-controller.php
+++ b/tests/test-json-comments-controller.php
@@ -70,6 +70,14 @@ class WP_Test_JSON_Comments_Controller extends WP_Test_JSON_Controller_Testcase 
 		$this->assertCount( 7, $comments );
 	}
 
+	public function test_get_items_no_permission() {
+		wp_set_current_user( 0 );
+		$request = new WP_JSON_Request( 'GET', '/wp/comments' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'json_forbidden', $response, 403 );
+	}
+
 	public function test_get_items_for_post() {
 		$second_post_id = $this->factory->post->create();
 		$this->factory->comment->create_post_comments( $second_post_id, 2 );


### PR DESCRIPTION
Otherwise supplying `context=edit` grants unauthorized access to comment secrets