### PR TITLE
Readonly attribute in schema to exclude from args array

### DIFF
--- a/lib/endpoints/class-wp-json-attachments-controller.php
+++ b/lib/endpoints/class-wp-json-attachments-controller.php
@@ -212,11 +212,13 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 			'type'            => 'string',
 			'enum'            => array( 'image', 'file' ),
 			'context'         => array( 'view', 'edit' ),
+			'readonly'        => true,
 			);
 		$schema['properties']['media_details'] = array(
 			'description'     => 'Details about the attachment file, specific to its type.',
 			'type'            => 'object',
 			'context'         => array( 'view', 'edit' ),
+			'readonly'        => true,
 			);
 		$schema['properties']['post'] = array(
 			'description'     => 'The ID for the associated post of the attachment.',
@@ -228,6 +230,7 @@ class WP_JSON_Attachments_Controller extends WP_JSON_Posts_Controller {
 			'type'            => 'string',
 			'format'          => 'uri',
 			'context'         => array( 'view', 'edit' ),
+			'readonly'        => true,
 			);
 		return $schema;
 	}

--- a/lib/endpoints/class-wp-json-comments-controller.php
+++ b/lib/endpoints/class-wp-json-comments-controller.php
@@ -708,6 +708,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'description'  => 'Unique identifier for the object.',
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'author'           => array(
 					'description'  => 'The ID of the user object, if author was a user.',
@@ -724,6 +725,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'description'  => 'IP address for the object author.',
 					'type'         => 'string',
 					'context'      => array( 'edit' ),
+					'readonly'     => true,
 					),
 				'author_name'     => array(
 					'description'  => 'Display name for the object author.',
@@ -740,6 +742,7 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'description'  => 'User agent for the object author.',
 					'type'         => 'string',
 					'context'      => array( 'edit' ),
+					'readonly'     => true,
 					),
 				'content'          => array(
 					'description'     => 'The content for the object.',
@@ -774,35 +777,37 @@ class WP_JSON_Comments_Controller extends WP_JSON_Controller {
 					'description'  => 'Karma for the object.',
 					'type'         => 'integer',
 					'context'      => array( 'edit' ),
-					),
+					'readonly'     => true,
+				),
 				'link'             => array(
 					'description'  => 'URL to the object.',
 					'type'         => 'string',
 					'format'       => 'uri',
 					'context'      => array( 'view', 'edit' ),
-					),
+					'readonly'     => true,
+				),
 				'parent'           => array(
 					'description'  => 'The ID for the parent of the object.',
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit' ),
-					),
+				),
 				'post'             => array(
 					'description'  => 'The ID of the associated post object.',
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit' ),
-					),
+				),
 				'status'           => array(
 					'description'  => 'State of the object.',
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
-					),
+				),
 				'type'             => array(
 					'description'  => 'Type of Comment for the object.',
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
-					),
 				),
-			);
+			),
+		);
 		return $schema;
 	}
 

--- a/lib/endpoints/class-wp-json-controller.php
+++ b/lib/endpoints/class-wp-json-controller.php
@@ -187,6 +187,12 @@ abstract class WP_JSON_Controller {
 		$post_type_fields_args = array();
 
 		foreach ( $post_type_fields as $field_id => $params ) {
+
+			// Anything marked as readonly should not be a arg
+			if ( ! empty( $params['readonly'] ) ) {
+				continue;
+			}
+
 			$post_type_fields_args[$field_id] = array();
 
 			if ( $add_required_flag && ! empty( $params['required'] ) ) {

--- a/lib/endpoints/class-wp-json-posts-controller.php
+++ b/lib/endpoints/class-wp-json-posts-controller.php
@@ -1175,6 +1175,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 					'description' => 'The globally unique identifier for the object.',
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
 							'description' => 'GUID for the object, as it exists in the database.',
@@ -1192,12 +1193,14 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 					'description' => 'Unique identifier for the object.',
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'link'            => array(
 					'description' => 'URL to the object.',
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'modified'        => array(
 					'description' => 'The date the object was last modified.',
@@ -1231,6 +1234,7 @@ class WP_JSON_Posts_Controller extends WP_JSON_Controller {
 					'description' => 'Type of Post for the object.',
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			)
 		);

--- a/lib/endpoints/class-wp-json-terms-controller.php
+++ b/lib/endpoints/class-wp-json-terms-controller.php
@@ -465,11 +465,13 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 					'description'  => 'Unique identifier for the object.',
 					'type'         => 'integer',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'count'            => array(
 					'description'  => 'Number of published posts for the object.',
 					'type'         => 'integer',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'description'      => array(
 					'description'  => 'A human-readable description of the object.',
@@ -481,6 +483,7 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 					'type'         => 'string',
 					'format'       => 'uri',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'name'             => array(
 					'description'  => 'The title for the object.',
@@ -502,6 +505,7 @@ class WP_JSON_Terms_Controller extends WP_JSON_Controller {
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				),
 			);

--- a/lib/endpoints/class-wp-json-users-controller.php
+++ b/lib/endpoints/class-wp-json-users-controller.php
@@ -526,6 +526,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'capabilities'    => array(
 					'description' => 'All capabilities assigned to the user.',
@@ -548,6 +549,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Any extra capabilities assigned to the user.',
 					'type'        => 'object',
 					'context'     => array( 'edit' ),
+					'readonly'    => true,
 					),
 				'first_name'  => array(
 					'description' => 'First name for the object.',
@@ -558,6 +560,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Unique identifier for the object.',
 					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'last_name'   => array(
 					'description' => 'Last name for the object.',
@@ -569,6 +572,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'name'        => array(
 					'description' => 'Display name for the object.',
@@ -584,6 +588,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'description' => 'Registration date for the user.',
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'roles'           => array(
 					'description' => 'Roles assigned to the user.',
@@ -600,6 +605,7 @@ class WP_JSON_Users_Controller extends WP_JSON_Controller {
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'username'    => array(
 					'description' => 'Login name for the user.',


### PR DESCRIPTION
Picking up from #892 - now the endpoint args are specified from the schema, it pays to declare the readonly attribute, as these are ignored in the route's arg registration.