### PR TITLE
Ignore npm and composer vendor directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules
+vendor


### PR DESCRIPTION
They don't need to be tracked in version control