### PR TITLE
Move all core routes to v2 namespace.

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -76,7 +76,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		) );
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/' . $this->get_post_type_base( $attachment->post_type ) . '/' . $id ) );
+		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $attachment->post_type ) . '/' . $id ) );
 
 		return $response;
 
@@ -107,7 +107,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		));
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/' . $this->get_post_type_base( $this->post_type ) . '/' . $data['id'] ) );
+		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $data['id'] ) );
 		return $response;
 	}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -10,7 +10,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/comments', array(
+		register_rest_route( 'wp/v2', '/comments', array(
 			array(
 				'methods'   => WP_REST_Server::READABLE,
 				'callback'  => array( $this, 'get_items' ),
@@ -116,7 +116,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp', '/comments/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/comments/(?P<id>[\d]+)', array(
 			array(
 				'methods'  => WP_REST_Server::READABLE,
 				'callback' => array( $this, 'get_item' ),
@@ -151,7 +151,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp', '/comments/schema', array(
+		register_rest_route( 'wp/v2', '/comments/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
@@ -247,7 +247,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $response;
 		}
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/comments/' . $comment_id ) );
+		$response->header( 'Location', rest_url( '/wp/v2/comments/' . $comment_id ) );
 
 		return $response;
 	}
@@ -296,7 +296,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $response;
 		}
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/comments/' . $comment->comment_ID ) );
+		$response->header( 'Location', rest_url( '/wp/v2/comments/' . $comment->comment_ID ) );
 
 		return $response;
 	}
@@ -496,16 +496,16 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	protected function prepare_links( $comment ) {
 		$links = array(
 			'self' => array(
-				'href' => rest_url( '/wp/comments/' . $comment->comment_ID ),
+				'href' => rest_url( '/wp/v2/comments/' . $comment->comment_ID ),
 			),
 			'collection' => array(
-				'href' => rest_url( '/wp/comments' ),
+				'href' => rest_url( '/wp/v2/comments' ),
 			),
 		);
 
 		if ( 0 !== (int) $comment->user_id ) {
 			$links['author'] = array(
-				'href'       => rest_url( '/wp/users/' . $comment->user_id ),
+				'href'       => rest_url( '/wp/v2/users/' . $comment->user_id ),
 				'embeddable' => true,
 			);
 		}
@@ -517,7 +517,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				$base = $posts_controller->get_post_type_base( $post->post_type );
 
 				$links[ $post->post_type ] = array(
-					'href'       => rest_url( '/wp/' . $base . '/' . $comment->comment_post_ID ),
+					'href'       => rest_url( '/wp/v2/' . $base . '/' . $comment->comment_post_ID ),
 					'embeddable' => true,
 				);
 			}
@@ -525,7 +525,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		if ( 0 !== (int) $comment->comment_parent ) {
 			$links['in-reply-to'] = array(
-				'href'       => rest_url( sprintf( '/wp/comments/%d', (int) $comment->comment_parent ) ),
+				'href'       => rest_url( sprintf( '/wp/v2/comments/%d', (int) $comment->comment_parent ) ),
 				'embeddable' => true,
 			);
 		}

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -35,7 +35,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 	 * Register the meta-related routes.
 	 */
 	public function register_routes() {
-		register_rest_route( 'wp', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/meta', array(
+		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/meta', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -58,7 +58,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				),
 			),
 		) );
-		register_rest_route( 'wp', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -85,7 +85,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				'args'                => array(),
 			),
 		) );
-		register_rest_route( 'wp', $this->parent_base . '/meta/schema', array(
+		register_rest_route( 'wp/v2', $this->parent_base . '/meta/schema', array(
 			'methods'  => WP_REST_Server::READABLE,
 			'callback' => array( $this, 'get_item_schema' ),
 		) );

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -7,17 +7,17 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/statuses', array(
+		register_rest_route( 'wp/v2', '/statuses', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_items' ),
 		) );
 
-		register_rest_route( 'wp', '/statuses/schema', array(
+		register_rest_route( 'wp/v2', '/statuses/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
 
-		register_rest_route( 'wp', '/statuses/(?P<status>[\w-]+)', array(
+		register_rest_route( 'wp/v2', '/statuses/(?P<status>[\w-]+)', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item' ),
 		) );

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -7,7 +7,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/types', array(
+		register_rest_route( 'wp/v2', '/types', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_items' ),
 			'args'            => array(
@@ -17,12 +17,12 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp', '/types/schema', array(
+		register_rest_route( 'wp/v2', '/types/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
 
-		register_rest_route( 'wp', '/types/(?P<type>[\w-]+)', array(
+		register_rest_route( 'wp/v2', '/types/(?P<type>[\w-]+)', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item' ),
 		) );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1102,7 +1102,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
-			$attachments_url = rest_url( 'wp/media' );
+			$attachments_url = rest_url( 'wp/v2/media' );
 			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
 			$links['attachments'] = array(
 				'href'       => $attachments_url,
@@ -1120,9 +1120,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				}
 
 				if ( 'post_tag' === $tax ) {
-					$terms_url = rest_url( 'wp/terms/tag' );
+					$terms_url = rest_url( '/wp/v2/terms/tag' );
 				} else {
-					$terms_url = rest_url( 'wp/terms/' . $tax );
+					$terms_url = rest_url( '/wp/v2/terms/' . $tax );
 				}
 
 				$terms_url = add_query_arg( 'post', $post->ID, $terms_url );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -31,7 +31,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		register_rest_route( 'wp', '/' . $base, array(
+		register_rest_route( 'wp/v2', '/' . $base, array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
@@ -44,7 +44,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'args'            => $this->get_endpoint_args_for_item_schema( true ),
 			),
 		) );
-		register_rest_route( 'wp', '/' . $base . '/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/' . $base . '/(?P<id>[\d]+)', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
@@ -73,7 +73,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				),
 			),
 		) );
-		register_rest_route( 'wp', '/' . $base . '/schema', array(
+		register_rest_route( 'wp/v2', '/' . $base . '/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
@@ -212,7 +212,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		) );
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/' . $this->get_post_type_base( $post->post_type ) . '/' . $post_id ) );
+		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $post->post_type ) . '/' . $post_id ) );
 
 		return $response;
 	}
@@ -1060,7 +1060,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return array Links for the given post.
 	 */
 	protected function prepare_links( $post ) {
-		$base = '/wp/' . $this->get_post_type_base( $this->post_type );
+		$base = '/wp/v2/' . $this->get_post_type_base( $this->post_type );
 
 		// Entity meta
 		$links = array(
@@ -1074,13 +1074,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'author' ) ) {
 			$links['author'] = array(
-				'href'       => rest_url( '/wp/users/' . $post->post_author ),
+				'href'       => rest_url( '/wp/v2/users/' . $post->post_author ),
 				'embeddable' => true,
 			);
 		};
 
 		if ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'comments' ) ) {
-			$replies_url = rest_url( '/wp/comments' );
+			$replies_url = rest_url( '/wp/v2/comments' );
 			$replies_url = add_query_arg( 'post_id', $post->ID, $replies_url );
 			$links['replies'] = array(
 				'href'         => $replies_url,

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -17,7 +17,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions', array(
+		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_items' ),
 			'permission_callback' => array( $this, 'get_items_permissions_check' ),
@@ -28,7 +28,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
@@ -46,7 +46,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			))
 		);
 
-		register_rest_route( 'wp', '/' . $this->parent_base . '/revisions/schema', array(
+		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/revisions/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -7,7 +7,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/taxonomies', array(
+		register_rest_route( 'wp/v2', '/taxonomies', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_items' ),
 			'args'            => array(
@@ -16,11 +16,11 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				),
 			),
 		) );
-		register_rest_route( 'wp', '/taxonomies/schema', array(
+		register_rest_route( 'wp/v2', '/taxonomies/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
-		register_rest_route( 'wp', '/taxonomies/(?P<taxonomy>[\w-]+)', array(
+		register_rest_route( 'wp/v2', '/taxonomies/(?P<taxonomy>[\w-]+)', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item' ),
 			'permission_callback' => array( $this, 'get_item_permissions_check' ),

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -441,7 +441,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$parent_term = get_term_by( 'id', (int) $term->parent, $term->taxonomy );
 			if ( $parent_term ) {
 				$links['up'] = array(
-					'href'       => rest_url( sprintf( 'wp/terms/%s/%d', $this->get_taxonomy_base( $parent_term->taxonomy ), $parent_term->term_taxonomy_id ) ),
+					'href'       => rest_url( sprintf( 'wp/v2/terms/%s/%d', $this->get_taxonomy_base( $parent_term->taxonomy ), $parent_term->term_taxonomy_id ) ),
 					'embeddable' => true,
 				);
 			}

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -10,7 +10,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/terms/(?P<taxonomy>[\w-]+)', array(
+		register_rest_route( 'wp/v2', '/terms/(?P<taxonomy>[\w-]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -60,7 +60,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				),
 			),
 		));
-		register_rest_route( 'wp', '/terms/(?P<taxonomy>[\w-]+)/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/terms/(?P<taxonomy>[\w-]+)/(?P<id>[\d]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -90,7 +90,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 			),
 		) );
-		register_rest_route( 'wp', '/terms/(?P<taxonomy>[\w-]+)/schema', array(
+		register_rest_route( 'wp/v2', '/terms/(?P<taxonomy>[\w-]+)/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
@@ -427,7 +427,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return array Links for the given term.
 	 */
 	protected function prepare_links( $term ) {
-		$base = '/wp/terms/' . $this->get_taxonomy_base( $term->taxonomy );
+		$base = '/wp/v2/terms/' . $this->get_taxonomy_base( $term->taxonomy );
 		$links = array(
 			'self'       => array(
 				'href'       => rest_url( trailingslashit( $base ) . $term->term_taxonomy_id ),

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -10,7 +10,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp', '/users', array(
+		register_rest_route( 'wp/v2', '/users', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
@@ -48,7 +48,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				) ),
 			),
 		) );
-		register_rest_route( 'wp', '/users/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/users/(?P<id>[\d]+)', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
@@ -77,7 +77,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp', '/users/me', array(
+		register_rest_route( 'wp/v2', '/users/me', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_current_item' ),
 			'args'            => array(
@@ -85,7 +85,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			)
 		));
 
-		register_rest_route( 'wp', '/users/schema', array(
+		register_rest_route( 'wp/v2', '/users/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
@@ -164,7 +164,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $response );
-		$response->header( 'Location', rest_url( sprintf( '/wp/users/%d', $current_user_id ) ) );
+		$response->header( 'Location', rest_url( sprintf( '/wp/v2/users/%d', $current_user_id ) ) );
 		$response->set_status( 302 );
 
 		return $response;
@@ -216,7 +216,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		));
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/users/' . $user_id ) );
+		$response->header( 'Location', rest_url( '/wp/v2/users/' . $user_id ) );
 
 		return $response;
 	}
@@ -265,7 +265,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		));
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/users/' . $user_id ) );
+		$response->header( 'Location', rest_url( '/wp/v2/users/' . $user_id ) );
 
 		return $response;
 	}
@@ -447,10 +447,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	protected function prepare_links( $user ) {
 		$links = array(
 			'self' => array(
-				'href' => rest_url( sprintf( '/wp/users/%d', $user->ID ) ),
+				'href' => rest_url( sprintf( '/wp/v2/users/%d', $user->ID ) ),
 			),
 			'collection' => array(
-				'href' => rest_url( '/wp/users' ),
+				'href' => rest_url( '/wp/v2/users' ),
 			),
 		);
 

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -29,10 +29,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/media', $routes );
-		$this->assertCount( 2, $routes['/wp/media'] );
-		$this->assertArrayHasKey( '/wp/media/(?P<id>[\d]+)', $routes );
-		$this->assertCount( 3, $routes['/wp/media/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/media', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/media'] );
+		$this->assertArrayHasKey( '/wp/v2/media/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/media/(?P<id>[\d]+)'] );
 	}
 
 	public function test_get_items() {
@@ -40,7 +40,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_mime_type' => 'image/jpeg',
 			'post_excerpt'   => 'A sample caption',
 		) );
-		$request = new WP_REST_Request( 'GET', '/wp/media' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_get_posts_response( $response );
@@ -52,14 +52,14 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_excerpt'   => 'A sample caption',
 		) );
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'Sample alt text' );
-		$request = new WP_REST_Request( 'GET', '/wp/media/' . $attachment_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_post_response( $response );
 	}
 
 	public function test_create_item() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
@@ -71,7 +71,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_with_files() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_file_params( array(
 			'file'     => file_get_contents( $this->test_file ),
 			'name'     => 'canola.jpg',
@@ -87,14 +87,14 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_empty_body() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_upload_no_data', $response, 400 );
 	}
 
 	public function test_create_item_missing_content_type() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_upload_no_content_type', $response, 400 );
@@ -102,7 +102,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_missing_content_disposition() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$response = $this->server->dispatch( $request );
@@ -111,7 +111,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_bad_md5_header() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
 		$request->set_header( 'Content-MD5', 'abc123' );
@@ -122,7 +122,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_with_files_bad_md5_header() {
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_file_params( array(
 			'file'     => file_get_contents( $this->test_file ),
 			'name'     => 'canola.jpg',
@@ -138,7 +138,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_create_item_invalid_upload_files_capability() {
 		wp_set_current_user( $this->contributor_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -146,7 +146,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	public function test_create_item_invalid_edit_permissions() {
 		$post_id = $this->factory->post->create( array( 'post_author' => $this->editor_id ) );
 		wp_set_current_user( $this->author_id );
-		$request = new WP_REST_Request( 'POST', '/wp/media' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 401 );
@@ -159,7 +159,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_excerpt'   => 'A sample caption',
 			'post_author'    => $this->editor_id,
 		) );
-		$request = new WP_REST_Request( 'POST', '/wp/media/' . $attachment_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
 		$request->set_param( 'title', 'My title is very cool' );
 		$request->set_param( 'caption', 'This is a better caption.' );
 		$request->set_param( 'description', 'Without a description, my attachment is descriptionless.' );
@@ -184,7 +184,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_excerpt'   => 'A sample caption',
 			'post_author'    => $this->editor_id,
 		) );
-		$request = new WP_REST_Request( 'POST', '/wp/media/' . $attachment_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
 		$request->set_param( 'caption', 'This is a better caption.' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -196,7 +196,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_mime_type' => 'image/jpeg',
 			'post_excerpt'   => 'A sample caption',
 		) );
-		$request = new WP_REST_Request( 'DELETE', '/wp/media/' . $attachment_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/media/' . $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
@@ -210,7 +210,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_excerpt'   => 'A sample caption',
 			'post_author'    => $this->editor_id,
 		) );
-		$request = new WP_REST_Request( 'DELETE', '/wp/media/' . $attachment_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/media/' . $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}
@@ -223,14 +223,14 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		) );
 
 		$attachment = get_post( $attachment_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/media/%d', $attachment_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/media/%d', $attachment_id ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->check_post_data( $attachment, $data, 'view' );
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/media/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -51,16 +51,16 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/comments', $routes );
-		$this->assertCount( 2, $routes['/wp/comments'] );
-		$this->assertArrayHasKey( '/wp/comments/(?P<id>[\d]+)', $routes );
-		$this->assertCount( 3, $routes['/wp/comments/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/comments', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/comments'] );
+		$this->assertArrayHasKey( '/wp/v2/comments/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/comments/(?P<id>[\d]+)'] );
 	}
 
 	public function test_get_items() {
 		$this->factory->comment->create_post_comments( $this->post_id, 6 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/comments' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -72,7 +72,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', '/wp/comments' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
@@ -82,7 +82,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$second_post_id = $this->factory->post->create();
 		$this->factory->comment->create_post_comments( $second_post_id, 2 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/comments' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_query_params( array(
 			'post' => $second_post_id,
 		) );
@@ -95,7 +95,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/comments/%d', $this->approved_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $this->approved_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -106,7 +106,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 	public function test_prepare_item() {
 		wp_set_current_user( $this->admin_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/comments/%d', $this->approved_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $this->approved_id ) );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -119,14 +119,14 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_comment_invalid_id() {
-		$request = new WP_REST_Request( 'GET', '/wp/comments/' . 100 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . 100 );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_comment_invalid_id', $response, 404 );
 	}
 
 	public function test_get_comment_invalid_context() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/comments/%s', $this->approved_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%s', $this->approved_id ) );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
@@ -137,7 +137,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_approved' => 1,
 			'comment_post_ID'  => 100,
 		));
-		$request = new WP_REST_Request( 'GET', '/wp/comments/' . $comment_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . $comment_id );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -146,7 +146,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_comment_not_approved() {
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/comments/%d', $this->hold_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $this->hold_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
@@ -155,7 +155,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_comment_not_approved_same_user() {
 		wp_set_current_user( $this->subscriber_id );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/comments/%d', $this->hold_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $this->hold_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -173,7 +173,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'date'    => '2014-11-07T10:14:25',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -189,7 +189,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 	public function create_item_assign_different_user() {
 		wp_set_current_user( $this->admin_id );
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$params = array(
 			'post'    => $this->post_id,
 			'author_name'  => 'Comic Book Guy',
@@ -199,7 +199,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'content' => 'Worst Comment Ever!',
 			'date'    => '2014-11-07T10:14:25',
 		);
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
@@ -220,7 +220,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'author'    => 0,
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
@@ -250,7 +250,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'content' => 'Homer? Who is Homer? My name is Guy N. Cognito.',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
@@ -269,7 +269,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'post'      => $post_id,
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/comments' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 		$response = $this->server->dispatch( $request );
@@ -288,7 +288,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'author_email' => 'stu@stusdisco.com',
 			'date'    => '2014-11-07T10:14:25',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/comments/%d', $this->approved_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $this->approved_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -318,7 +318,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$params = array(
 			'status' => 'approve',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/comments/%d', $comment_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -338,7 +338,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$params = array(
 			'content' => 'Oh, they have the internet on computers now!',
 		);
-		$request = new WP_REST_Request( 'PUT', '/wp/comments/' . 100 );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . 100 );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -352,7 +352,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$params = array(
 			'content' => 'Disco Stu likes disco music.',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/comments/%d', $this->hold_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $this->hold_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -368,7 +368,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => $this->post_id,
 			'user_id'          => $this->subscriber_id,
 		));
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/comments/%d', $comment_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/comments/%d', $comment_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
@@ -378,7 +378,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_comment_invalid_id() {
 		wp_set_current_user( $this->admin_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/comments/%d', 100 ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/comments/%d', 100 ) );
 
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
@@ -388,14 +388,14 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_comment_without_permission() {
 		wp_set_current_user( $this->subscriber_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/comments/%d', $this->approved_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/comments/%d', $this->approved_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/comments/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-meta-posts-controller.php
+++ b/tests/test-rest-meta-posts-controller.php
@@ -19,10 +19,10 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/posts/(?P<parent_id>[\d]+)/meta', $routes );
-		$this->assertCount( 2, $routes['/wp/posts/(?P<parent_id>[\d]+)/meta'] );
-		$this->assertArrayHasKey( '/wp/posts/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)', $routes );
-		$this->assertCount( 3, $routes['/wp/posts/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<parent_id>[\d]+)/meta', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/posts/(?P<parent_id>[\d]+)/meta'] );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/posts/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)'] );
 	}
 
 	public function test_get_items() {
@@ -42,7 +42,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		// protected
 		add_post_meta( $post_id, '_testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
@@ -86,7 +86,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
 
@@ -100,7 +100,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -119,7 +119,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
 		// Use the real URL to ensure routing succeeds
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		// Override the id parameter to ensure meta is checking it
 		$request['parent_id'] = 0;
 
@@ -132,7 +132,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
 		// Use the real URL to ensure routing succeeds
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		// Override the id parameter to ensure meta is checking it
 		$request['parent_id'] = -1;
 
@@ -145,7 +145,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
 		// Override the mid parameter to ensure meta is checking it
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', 0, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', 0, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -156,7 +156,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
 		// Use the real URL to ensure routing succeeds
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		// Override the mid parameter to ensure meta is checking it
 		$request['id'] = -1;
 
@@ -168,7 +168,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, '_testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
 	}
@@ -177,7 +177,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', array( 'testvalue' => 'test' ) );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
 	}
@@ -186,7 +186,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', (object) array( 'testvalue' => 'test' ) );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );
 	}
@@ -197,7 +197,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -209,11 +209,11 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id_two = $this->factory->post->create();
 		$meta_id_two = add_post_meta( $post_id_two, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id_two, $meta_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id_two, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_post_mismatch', $response, 400 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id_two ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id_two ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_post_mismatch', $response, 400 );
 	}
@@ -222,7 +222,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request['parent_id'] = 0;
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response );
@@ -232,7 +232,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request['parent_id'] = -1;
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response );
@@ -244,7 +244,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response );
 	}
@@ -255,7 +255,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testkey',
 			'value' => 'testvalue',
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -280,7 +280,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => 'testvalue',
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$request['parent_id'] = 0;
@@ -296,7 +296,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => 'testvalue',
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$request['parent_id'] = -1;
@@ -310,7 +310,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'key' => 'testkey',
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -328,7 +328,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => 'testvalue',
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -341,7 +341,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => false,
 			'value' => 'testvalue',
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -357,7 +357,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -372,7 +372,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => array( 'testvalue1', 'testvalue2' ),
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -387,7 +387,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ),
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -402,7 +402,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ),
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -435,7 +435,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'value' => 'testvalue',
 		);
 
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -452,7 +452,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testkey',
 			'value' => "test unslashed ' value",
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -473,7 +473,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testkey',
 			'value' => "test slashed \\' value",
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta', $post_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -492,7 +492,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -519,7 +519,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'key' => 'testnewkey',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -551,7 +551,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -580,7 +580,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
 		$data = array();
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -595,7 +595,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', 0, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', 0, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -610,7 +610,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', 99999, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', 99999, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -625,7 +625,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, 0 ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, 0 ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -641,7 +641,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request['id'] = -1;
 		$request->set_body_params( $data );
 
@@ -660,7 +660,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -679,14 +679,14 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id_two, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id_two, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_post_mismatch', $response, 400 );
 		$this->assertEquals( array( 'testvalue' ), get_post_meta( $post_id_two, 'testkey' ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id_two ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id_two ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -701,7 +701,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => array( 'testvalue1', 'testvalue2' ),
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -716,7 +716,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ),
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -731,7 +731,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) ),
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -746,7 +746,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -761,7 +761,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$data = array(
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -777,7 +777,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => '_testnewkey',
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -794,7 +794,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => false,
 			'value' => 'testnewvalue',
 		);
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -813,7 +813,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testkey',
 			'value' => "test unslashed ' value",
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -836,7 +836,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 			'key' => 'testkey',
 			'value' => "test slashed \\' value",
 		);
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
@@ -852,7 +852,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
@@ -871,7 +871,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request['parent_id'] = 0;
 
 		$response = $this->server->dispatch( $request );
@@ -884,7 +884,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request['parent_id'] = -1;
 
 		$response = $this->server->dispatch( $request );
@@ -897,7 +897,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request['id'] = 0;
 
 		$response = $this->server->dispatch( $request );
@@ -910,7 +910,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 		$request['id'] = -1;
 
 		$response = $this->server->dispatch( $request );
@@ -925,7 +925,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -940,13 +940,13 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id_two = $this->factory->post->create();
 		$meta_id_two = add_post_meta( $post_id_two, 'testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id_two, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id_two, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_post_mismatch', $response, 400 );
 		$this->assertEquals( array( 'testvalue' ), get_post_meta( $post_id_two, 'testkey' ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id_two ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id_two ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_post_mismatch', $response, 400 );
@@ -958,7 +958,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$value = array( 'testvalue1', 'testvalue2' );
 		$meta_id = add_post_meta( $post_id, 'testkey', $value );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
@@ -970,7 +970,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$value = (object) array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' );
 		$meta_id = add_post_meta( $post_id, 'testkey', $value );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
@@ -982,7 +982,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$value = serialize( array( 'testkey1' => 'testvalue1', 'testkey2' => 'testvalue2' ) );
 		$meta_id = add_post_meta( $post_id, 'testkey', $value );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
@@ -993,7 +993,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$post_id = $this->factory->post->create();
 		$meta_id = add_post_meta( $post_id, '_testkey', 'testvalue' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d/meta/%d', $post_id, $meta_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/meta/%d', $post_id, $meta_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_meta_protected', $response, 403 );

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -37,7 +37,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_item_invalid_post_type() {
 		$post_id = $this->factory->post->create();
-		$request = new WP_REST_Request( 'GET', '/wp/pages/' . $post_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages/' . $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -50,7 +50,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		wp_set_current_user( $this->editor_id );
 		$this->setup_test_template();
 
-		$request = new WP_REST_Request( 'POST', '/wp/pages' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/pages' );
 		$params = $this->set_post_data( array(
 			'template'       => 'page-my-test-template.php',
 		) );
@@ -69,7 +69,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		) );
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/pages' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/pages' );
 		$params = $this->set_post_data( array(
 			'parent' => $page_id,
 		) );
@@ -92,7 +92,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_page_with_invalid_parent() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/pages' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/pages' );
 		$params = $this->set_post_data( array(
 			'parent' => -1,
 		) );
@@ -119,7 +119,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'post_type' => 'page',
 		) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/pages' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
 		$request->set_query_params( array(
 			'page'           => 2,
 			'posts_per_page' => 4,
@@ -149,7 +149,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/pages/%d', $page_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/pages/%d', $page_id ) );
 
 		$request->set_body_params( array(
 			'menu_order' => 1,
@@ -169,7 +169,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/pages/%d', $page_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/pages/%d', $page_id ) );
 
 		$request->set_body_params(array(
 			'menu_order' => 0
@@ -181,7 +181,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/pages/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -4,12 +4,12 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/statuses', $routes );
-		$this->assertArrayHasKey( '/wp/statuses/(?P<status>[\w-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/statuses', $routes );
+		$this->assertArrayHasKey( '/wp/v2/statuses/(?P<status>[\w-]+)', $routes );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/statuses' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses' );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
@@ -26,7 +26,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $user_id );
 
-		$request = new WP_REST_Request( 'GET', '/wp/statuses' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses' );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
@@ -39,19 +39,19 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', '/wp/statuses/publish' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/publish' );
 		$response = $this->server->dispatch( $request );
 		$this->check_post_status_object_response( $response );
 	}
 
 	public function test_get_item_invalid_status() {
-		$request = new WP_REST_Request( 'GET', '/wp/statuses/invalid' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/invalid' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_status_invalid', $response, 404 );
 	}
 
 	public function test_get_item_invalid_access() {
-		$request = new WP_REST_Request( 'GET', '/wp/statuses/draft' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/draft' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read_status', $response, 403 );
 	}
@@ -60,7 +60,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $user_id );
 
-		$request = new WP_REST_Request( 'GET', '/wp/statuses/inherit' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/inherit' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read_status', $response, 403 );
 	}
@@ -85,7 +85,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/statuses/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -4,12 +4,12 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/types', $routes );
-		$this->assertArrayHasKey( '/wp/types/(?P<type>[\w-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/types', $routes );
+		$this->assertArrayHasKey( '/wp/v2/types/(?P<type>[\w-]+)', $routes );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/types' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/types' );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
@@ -23,13 +23,13 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', '/wp/types/post' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
 		$response = $this->server->dispatch( $request );
 		$this->check_post_type_object_response( $response );
 	}
 
 	public function test_get_item_invalid_type() {
-		$request = new WP_REST_Request( 'GET', '/wp/types/invalid' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/types/invalid' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_type_invalid', $response, 404 );
 	}
@@ -54,7 +54,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/types/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/types/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -29,14 +29,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/posts', $routes );
-		$this->assertCount( 2, $routes['/wp/posts'] );
-		$this->assertArrayHasKey( '/wp/posts/(?P<id>[\d]+)', $routes );
-		$this->assertCount( 3, $routes['/wp/posts/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/posts', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/posts'] );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/posts/(?P<id>[\d]+)'] );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/posts' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_get_posts_response( $response );
@@ -48,7 +48,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @issue 862
 	 */
 	public function test_get_items_empty_query() {
-		$request = new WP_REST_Request( 'GET', '/wp/posts' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array(
 			'type'           => 'post',
 			'year'           => 2008,
@@ -65,7 +65,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		) );
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/posts' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -79,28 +79,28 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_get_post_response( $response, 'view' );
 	}
 
 	public function test_get_item_links() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$response = rest_ensure_response( $response );
 		$links = $response->get_links();
 
-		$this->assertEquals( rest_url( '/wp/posts/' . $this->post_id ), $links['self'][0]['href'] );
-		$this->assertEquals( rest_url( '/wp/posts' ), $links['collection'][0]['href'] );
-		$this->assertEquals( rest_url( '/wp/users/0' ), $links['author'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/posts/' . $this->post_id ), $links['self'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/posts' ), $links['collection'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/users/0' ), $links['author'][0]['href'] );
 
-		$replies_url = rest_url( '/wp/comments' );
+		$replies_url = rest_url( '/wp/v2/comments' );
 		$replies_url = add_query_arg( 'post_id', $this->post_id, $replies_url );
 		$this->assertEquals( $replies_url, $links['replies'][0]['href'] );
 
-		$this->assertEquals( rest_url( '/wp/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );
 
 		$attachments_url = rest_url( 'wp/media' );
 		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
@@ -121,21 +121,21 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		) );
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $draft_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $draft_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_get_post_invalid_id() {
-		$request = new WP_REST_Request( 'GET', '/wp/posts/100' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/100' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
 	}
 
 	public function test_get_post_context_without_permission() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -151,7 +151,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->check_get_post_response( $response, 'view' );
@@ -161,7 +161,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$post_id = $this->factory->post->create( array(
 			'post_password' => '$inthebananastand',
 		) );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -170,7 +170,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_prepare_item() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_query_params( array( 'context' => 'edit' ) );
 		$response = $this->server->dispatch( $request );
 
@@ -180,7 +180,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_item() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$params = $this->set_post_data();
 		$request->set_body_params( $params );
@@ -192,7 +192,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_rest_create_item() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$request->add_header( 'content-type', 'application/json' );
 		$params = $this->set_post_data();
 		$request->set_body( json_encode( $params ) );
@@ -204,7 +204,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_invalid_id() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'id' => '3',
 		) );
@@ -217,7 +217,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_as_contributor() {
 		wp_set_current_user( $this->contributor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data(array(
 			'status' => 'pending'
 		));
@@ -230,7 +230,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_sticky() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'sticky' => true,
 		) );
@@ -246,7 +246,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_sticky_as_contributor() {
 		wp_set_current_user( $this->contributor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'sticky' => true,
 			'status' => 'pending'
@@ -260,7 +260,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_other_author_without_permission() {
 		wp_set_current_user( $this->author_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data(array(
 			'author' => $this->editor_id
 		));
@@ -274,7 +274,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$user = wp_get_current_user();
 		$user->add_cap( 'edit_posts', false );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'draft',
 			'author' => $user->ID,
@@ -288,7 +288,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_draft() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'draft',
 		) );
@@ -309,7 +309,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_private() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'private',
 		) );
@@ -330,7 +330,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$user->get_role_caps();
 		$user->update_user_level_from_caps();
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'private',
 			'author' => $this->author_id,
@@ -349,7 +349,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$user->get_role_caps();
 		$user->update_user_level_from_caps();
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'publish',
 		) );
@@ -363,7 +363,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_invalid_status() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'status' => 'teststatus',
 		) );
@@ -379,7 +379,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_format() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'format' => 'gallery',
 		) );
@@ -402,7 +402,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'featured_image' => $this->attachment_id,
 		) );
@@ -413,7 +413,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $this->attachment_id, $data['featured_image'] );
 		$this->assertEquals( $this->attachment_id, (int) get_post_thumbnail_id( $new_post->ID ) );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts/' . $new_post->ID );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $new_post->ID );
 		$params = $this->set_post_data( array(
 			'featured_image' => 0,
 		) );
@@ -427,7 +427,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_invalid_author() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'author' => -1,
 		) );
@@ -440,7 +440,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_invalid_author_without_permission() {
 		wp_set_current_user( $this->author_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'author' => $this->editor_id,
 		) );
@@ -453,7 +453,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_password() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'password' => 'testing',
 		) );
@@ -472,7 +472,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$user->get_role_caps();
 		$user->update_user_level_from_caps();
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'password' => 'testing',
 			'author'   => $this->author_id,
@@ -487,7 +487,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_falsy_password() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'password' => '0',
 		) );
@@ -502,7 +502,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_password_and_sticky_fails() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'password' => '123',
 			'sticky'   => true
@@ -516,7 +516,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_custom_date() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'date' => '2010-01-01T02:00:00Z',
 		) );
@@ -533,7 +533,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_custom_date_with_timezone() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'date' => '2010-01-01T02:00:00-10:00',
 		) );
@@ -550,7 +550,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_db_error() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params  = $this->set_post_data( array() );
 		$request->set_body_params( $params );
 
@@ -572,7 +572,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_invalid_date() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'date' => '2010-60-01T02:00:00Z',
 		) );
@@ -585,7 +585,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_post_with_invalid_date_gmt() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/posts' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params = $this->set_post_data( array(
 			'date_gmt' => '2010-60-01T02:00:00',
 		) );
@@ -598,7 +598,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$params = $this->set_post_data();
 		$request->set_body_params( $params );
@@ -619,7 +619,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_rest_update_post() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$params = $this->set_post_data();
 		$request->set_body( json_encode( $params ) );
@@ -640,7 +640,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_rest_update_post_raw() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$params = $this->set_raw_post_data();
 		$request->set_body( json_encode( $params ) );
@@ -661,7 +661,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_without_extra_params() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data();
 		unset( $params['type'] );
 		unset( $params['name'] );
@@ -681,7 +681,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$user->get_role_caps();
 		$user->update_user_level_from_caps();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data();
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
@@ -692,7 +692,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_sticky_as_contributor() {
 		wp_set_current_user( $this->contributor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'sticky' => true,
 			'status' => 'pending'
@@ -706,7 +706,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_invalid_id() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', 100 ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', 100 ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 400 );
@@ -715,7 +715,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_with_format() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'format' => 'gallery',
 		) );
@@ -731,7 +731,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_slug() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'slug' => 'sample-slug',
 		) );
@@ -747,7 +747,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_sticky() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'sticky' => true,
 		) );
@@ -760,7 +760,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( true, is_sticky( $post->ID ) );
 
 		// Updating another field shouldn't change sticky status
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'title'       => 'This should not reset sticky',
 		) );
@@ -776,7 +776,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_excerpt() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_body_params( array(
 			'excerpt' => 'An Excerpt'
 		) );
@@ -789,7 +789,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_empty_excerpt() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_body_params( array(
 			'excerpt' => ''
 		) );
@@ -802,7 +802,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_content() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_body_params( array(
 			'content' => 'Some Content'
 		) );
@@ -815,7 +815,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_empty_content() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$request->set_body_params( array(
 			'content' => ''
 		) );
@@ -828,7 +828,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_update_post_with_password_and_sticky_fails() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'password' => '123',
 			'sticky'   => true
@@ -844,7 +844,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		stick_post( $this->post_id );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'password' => '123'
 		) );
@@ -859,7 +859,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_update_post( array( 'ID' => $this->post_id, 'post_password' => '123' ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$params = $this->set_post_data( array(
 			'sticky' => true
 		) );
@@ -873,7 +873,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$post_id = $this->factory->post->create();
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d', $post_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d', $post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -884,7 +884,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_delete_post_invalid_id() {
 		wp_set_current_user( $this->editor_id );
 
-		$request = new WP_REST_Request( 'DELETE', '/wp/posts/100' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/100' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -893,7 +893,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_delete_post_without_permission() {
 		wp_set_current_user( $this->author_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/posts/%d', $this->post_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
@@ -904,13 +904,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		register_post_type( 'invalid-controller', array( 'show_in_rest' => true, 'rest_controller_class' => 'Fake_Class_Baba' ) );
 		create_initial_rest_routes();
 		$routes = $this->server->get_routes();
-		$this->assertFalse( isset( $routes['/wp/invalid-controller'] ) );
+		$this->assertFalse( isset( $routes['/wp/v2/invalid-controller'] ) );
 		_unregister_post_type( 'invalid-controller' );
 
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/posts/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -102,15 +102,15 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$this->assertEquals( rest_url( '/wp/v2/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );
 
-		$attachments_url = rest_url( 'wp/media' );
+		$attachments_url = rest_url( '/wp/v2/media' );
 		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
 		$this->assertEquals( $attachments_url, $links['attachments'][0]['href'] );
 
-		$tags_url = rest_url( 'wp/terms/tag' );
+		$tags_url = rest_url( '/wp/v2/terms/tag' );
 		$tags_url = add_query_arg( 'post', $this->post_id, $tags_url );
 		$this->assertEquals( $tags_url, $links['post_tag'][0]['href'] );
 
-		$category_url = rest_url( 'wp/terms/category' );
+		$category_url = rest_url( '/wp/v2/terms/category' );
 		$category_url = add_query_arg( 'post', $this->post_id, $category_url );
 		$this->assertEquals( $category_url, $links['category'][0]['href'] );
 	}

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -31,15 +31,15 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/posts/(?P<parent_id>[\d]+)/revisions', $routes );
-		$this->assertArrayHasKey( '/wp/posts/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', $routes );
-		$this->assertArrayHasKey( '/wp/pages/(?P<parent_id>[\d]+)/revisions', $routes );
-		$this->assertArrayHasKey( '/wp/pages/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<parent_id>[\d]+)/revisions', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/pages/(?P<parent_id>[\d]+)/revisions', $routes );
+		$this->assertArrayHasKey( '/wp/v2/pages/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', $routes );
 	}
 
 	public function test_get_items() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
@@ -53,7 +53,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
@@ -64,21 +64,21 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_items_missing_parent() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/9999999999999/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/9999999999999/revisions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent_id', $response, 404 );
 	}
 
 	public function test_get_items_invalid_parent_post_type() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->page_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->page_id . '/revisions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent_id', $response, 404 );
 	}
 
 	public function test_get_item() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
@@ -87,7 +87,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
@@ -98,21 +98,21 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_missing_parent() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/9999999999999/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/9999999999999/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent_id', $response, 404 );
 	}
 
 	public function test_get_item_invalid_parent_post_type() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->page_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->page_id . '/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent_id', $response, 404 );
 	}
 
 	public function test_delete_item() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'DELETE', '/wp/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertNull( get_post( $this->revision_id1 ) );
@@ -120,14 +120,14 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_delete_item_no_permission() {
 		wp_set_current_user( $this->contributor_id );
-		$request = new WP_REST_Request( 'DELETE', '/wp/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
 	}
 
 	public function test_prepare_item() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
@@ -135,7 +135,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/posts/revisions/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/revisions/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];
@@ -155,13 +155,13 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	}
 
 	public function test_create_item() {
-		$request = new WP_REST_Request( 'POST', '/wp/posts/revisions' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/revisions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
 	public function test_update_item() {
-		$request = new WP_REST_Request( 'POST', '/wp/posts/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/revisions/' . $this->revision_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -5,12 +5,12 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/taxonomies', $routes );
-		$this->assertArrayHasKey( '/wp/taxonomies/(?P<taxonomy>[\w-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/taxonomies', $routes );
+		$this->assertArrayHasKey( '/wp/v2/taxonomies/(?P<taxonomy>[\w-]+)', $routes );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$taxonomies = $this->get_public_taxonomies( get_taxonomies( '', 'objects' ) );
@@ -25,20 +25,20 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_taxonomies_with_types() {
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
 		$request->set_param( 'post_type', 'post' );
 		$response = $this->server->dispatch( $request );
 		$this->check_taxonomies_for_type_response( 'post', $response );
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
 		$response = $this->server->dispatch( $request );
 		$this->check_taxonomy_object_response( $response );
 	}
 
 	public function test_get_invalid_taxonomy() {
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies/invalid' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/invalid' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
 	}
@@ -46,7 +46,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_get_non_public_taxonomy() {
 		register_taxonomy( 'api-private', 'post', array( 'public' => false ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies/api-private' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/api-private' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -71,7 +71,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/taxonomies/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -20,13 +20,13 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/terms/(?P<taxonomy>[\w-]+)', $routes );
-		$this->assertArrayHasKey( '/wp/terms/(?P<taxonomy>[\w-]+)/(?P<id>[\d]+)', $routes );
-		$this->assertArrayHasKey( '/wp/terms/(?P<taxonomy>[\w-]+)/schema', $routes );
+		$this->assertArrayHasKey( '/wp/v2/terms/(?P<taxonomy>[\w-]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/terms/(?P<taxonomy>[\w-]+)/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/terms/(?P<taxonomy>[\w-]+)/schema', $routes );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_terms_response( $response );
 	}
@@ -40,7 +40,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		 * - order
 		 * - per_page
 		 */
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'desc' );
 		$request->set_param( 'per_page', 1 );
@@ -49,7 +49,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'Banana', $data[0]['name'] );
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'asc' );
 		$request->set_param( 'per_page', 2 );
@@ -66,7 +66,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$tag2 = $this->factory->tag->create( array( 'name' => 'Marvel' ) );
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -83,7 +83,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/batman' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/batman' );
 		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -97,7 +97,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$draft_id = $this->factory->post->create( array(
 			'post_status' => 'draft',
 		) );
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'post', $draft_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
@@ -110,14 +110,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		 * Tests:
 		 * - search
 		 */
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'search', 'App' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'Apple', $data[0]['name'] );
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'search', 'Garbage' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -130,19 +130,19 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'robin' ) );
 		$term2 = $this->factory->term->create( array( 'name' => 'Mask', 'taxonomy' => 'robin' ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/robin' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/robin' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_get_terms_invalid_taxonomy() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/invalid-taxonomy' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/invalid-taxonomy' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
 	}
 
 	public function test_get_items_invalid_post() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'post', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -152,26 +152,26 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$page_id = $this->factory->post->create( array(
 			'post_type' => 'page',
 		) );
-		$request = new WP_REST_Request( 'GET', '/wp/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
 		$request->set_param( 'post', $page_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_taxonomy_invalid', $response, 404 );
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category/1' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/1' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_term_response( $response );
 	}
 
 	public function test_get_term_invalid_taxonomy() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/invalid-taxonomy/1' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/invalid-taxonomy/1' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
 	}
 
 	public function test_get_term_invalid_term() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category/2' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/2' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
 	}
@@ -180,14 +180,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		register_taxonomy( 'robin', 'post', array( 'public' => false ) );
 		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'robin' ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/robin/' . $term1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/robin/' . $term1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_create_item() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'description', 'This term is so awesome.' );
 		$request->set_param( 'slug', 'so-awesome' );
@@ -201,7 +201,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_create_item_invalid_taxonomy() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/invalid-taxonomy' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/invalid-taxonomy' );
 		$request->set_param( 'name', 'Invalid Taxonomy' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
@@ -209,7 +209,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_create_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
 		$request->set_param( 'name', 'Incorrect permissions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -217,7 +217,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_create_item_missing_arguments() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
 	}
@@ -230,7 +230,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'original-slug',
 			);
 		$term = get_term_by( 'id', $this->factory->category->create( $orig_args ), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
 		$request->set_param( 'name', 'New Name' );
 		$request->set_param( 'description', 'New Description' );
 		$request->set_param( 'slug', 'new-slug' );
@@ -244,7 +244,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_update_item_invalid_taxonomy() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/invalid-taxonomy/9999999' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/invalid-taxonomy/9999999' );
 		$request->set_param( 'name', 'Invalid Taxonomy' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
@@ -252,7 +252,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_update_item_invalid_term() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category/9999999' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/9999999' );
 		$request->set_param( 'name', 'Invalid Term' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -261,7 +261,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
 		$request->set_param( 'name', 'Incorrect permissions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -270,21 +270,21 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item() {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_delete_item_invalid_taxonomy() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'DELETE', '/wp/terms/invalid-taxonomy/9999999' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/invalid-taxonomy/9999999' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
 	}
 
 	public function test_delete_item_invalid_term() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'DELETE', '/wp/terms/category/9999999' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/9999999' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
 	}
@@ -292,7 +292,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -300,7 +300,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_prepare_item() {
 		$term = get_term( 1, 'category' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category/1' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/1' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
@@ -313,7 +313,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		) );
 		$term = get_term( $child, 'category' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category/' . $child );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/' . $child );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
@@ -322,11 +322,11 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 1, $data['parent'] );
 
 		$links = $response->get_links();
-		$this->assertEquals( rest_url( '/wp/terms/category/1' ), $links['up'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/terms/category/1' ), $links['up'][0]['href'] );
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/terms/category/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -27,17 +27,17 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/users', $routes );
-		$this->assertCount( 2, $routes['/wp/users'] );
-		$this->assertArrayHasKey( '/wp/users/(?P<id>[\d]+)', $routes );
-		$this->assertCount( 3, $routes['/wp/users/(?P<id>[\d]+)'] );
-		$this->assertArrayHasKey( '/wp/users/me', $routes );
+		$this->assertArrayHasKey( '/wp/v2/users', $routes );
+		$this->assertCount( 2, $routes['/wp/v2/users'] );
+		$this->assertArrayHasKey( '/wp/v2/users/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes['/wp/v2/users/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/users/me', $routes );
 	}
 
 	public function test_get_items() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'GET', '/wp/users' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_users_response( $response );
@@ -46,7 +46,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_without_permission() {
 		wp_set_current_user( $this->editor );
 
-		$request = new WP_REST_Request( 'GET', '/wp/users' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -55,7 +55,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$user_id = $this->factory->user->create();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $user_id ) );
 
 		$response = $this->server->dispatch( $request );
 		$this->check_get_user_response( $response, 'embed' );
@@ -72,7 +72,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_get_user_invalid_id() {
 		wp_set_current_user( $this->user );
-		$request = new WP_REST_Request( 'GET', '/wp/users/100' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users/100' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 404 );
@@ -81,7 +81,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_item_without_permission() {
 		wp_set_current_user( $this->editor );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/users/%d', $this->user ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->user ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_user_cannot_view', $response, 403 );
@@ -95,7 +95,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'post_author' => $this->author_id
 		));
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/users/%d', $this->author_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->author_id ) );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_user_response( $response, 'embed' );
 	}
@@ -104,7 +104,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$user_id = $this->factory->user->create();
 		$this->allow_user_to_manage_multisite();
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$request->set_param( 'context', 'edit' );
 
 		$response = $this->server->dispatch( $request );
@@ -119,7 +119,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'post_author' => $this->author_id
 		));
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/users/%d', $this->author_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->author_id ) );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_user_cannot_view', $response, 403 );
@@ -128,7 +128,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_current_user() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'GET', '/wp/users/me' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users/me' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -136,12 +136,12 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$headers = $response->get_headers();
 		$this->assertArrayHasKey( 'Location', $headers );
-		$this->assertEquals( rest_url( '/wp/users/' . $this->user ), $headers['Location'] );
+		$this->assertEquals( rest_url( '/wp/v2/users/' . $this->user ), $headers['Location'] );
 	}
 
 	public function test_get_current_user_without_permission() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', '/wp/users/me' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users/me' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_not_logged_in', $response, 401 );
@@ -163,7 +163,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'url'         => 'http://example.com',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/users' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
 
@@ -181,7 +181,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'email'    => 'testjson@example.com',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/users' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -198,7 +198,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'email'    => 'chunkylover53@aol.com',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/users' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
@@ -217,7 +217,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'email'    => 'smartgirl63_\@yahoo.com',
 		);
 
-		$request = new WP_REST_Request( 'POST', '/wp/users' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
@@ -242,7 +242,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$_POST['username'] = $userdata->user_login;
 		$_POST['first_name'] = 'New Name';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $_POST );
 
@@ -266,7 +266,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', '/wp/users/' . $user2 );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/users/' . $user2 );
 		$request->set_param( 'email', 'testjson@example.com' );
 		$response = $this->server->dispatch( $request );
 		$this->assertInstanceOf( 'WP_Error', $response->as_error() );
@@ -279,7 +279,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', '/wp/users/' . $user2 );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/users/' . $user2 );
 		$request->set_param( 'username', 'test_json_user' );
 		$response = $this->server->dispatch( $request );
 		$this->assertInstanceOf( 'WP_Error', $response->as_error() );
@@ -292,7 +292,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', '/wp/users/' . $user2 );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/users/' . $user2 );
 		$request->set_param( 'slug', 'test_json_user' );
 		$response = $this->server->dispatch( $request );
 		$this->assertInstanceOf( 'WP_Error', $response->as_error() );
@@ -320,7 +320,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$userdata = get_userdata( $user_id );
 		$pw_before = $userdata->user_pass;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( json_encode( $params ) );
 
@@ -349,7 +349,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'email'    => 'chunkylover53@aol.com',
 		);
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/users/%d', $this->user ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $this->user ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
@@ -368,7 +368,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'email'    => 'smartgirl63_\@yahoo.com',
 		);
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/users/%d', $this->editor ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $this->editor ) );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
@@ -382,7 +382,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -396,7 +396,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->editor );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_user_cannot_delete', $response, 403 );
@@ -406,7 +406,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'DELETE', '/wp/users/100' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/users/100' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_user_invalid_id', $response, 400 );
@@ -428,7 +428,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		// Delete our test user, and reassign to the new author
 		wp_set_current_user( $this->user );
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$request->set_param( 'reassign', $reassign_id );
 		$response = $this->server->dispatch( $request );
 
@@ -447,7 +447,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/users/%d', $user_id ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/users/%d', $user_id ) );
 		$request->set_param( 'reassign', 100 );
 		$response = $this->server->dispatch( $request );
 
@@ -455,7 +455,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'GET', '/wp/users/schema' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users/schema' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['properties'];


### PR DESCRIPTION
Adds the endpoint versioning piece of #1119 

Core routes now use the `wp/v2` namespace.