### PR TITLE
Include programmatically readable erros for validation

### DIFF
--- a/lib/infrastructure/class-wp-rest-request.php
+++ b/lib/infrastructure/class-wp-rest-request.php
@@ -683,7 +683,7 @@ class WP_REST_Request implements ArrayAccess {
 				$valid_check = call_user_func( $arg['validate_callback'], $param, $this );
 
 				if ( false === $valid_check ) {
-					$invalid_params[$key] = __( 'Invalid param.' );
+					$invalid_params[ $key ] = __( 'Invalid param.' );
 				}
 
 				if ( is_wp_error( $valid_check ) ) {

--- a/lib/infrastructure/class-wp-rest-request.php
+++ b/lib/infrastructure/class-wp-rest-request.php
@@ -669,7 +669,7 @@ class WP_REST_Request implements ArrayAccess {
 		}
 
 		if ( ! empty( $required ) ) {
-			return new WP_Error( 'rest_missing_callback_param', sprintf( __( 'Missing parameter(s): %s' ), implode( ', ', $required ) ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_missing_callback_param', sprintf( __( 'Missing parameter(s): %s' ), implode( ', ', $required ) ), array( 'status' => 400, 'params' => $required ) );
 		}
 
 		// check the validation callbacks for each registered arg.
@@ -683,7 +683,7 @@ class WP_REST_Request implements ArrayAccess {
 				$valid_check = call_user_func( $arg['validate_callback'], $param, $this );
 
 				if ( false === $valid_check ) {
-					$invalid_params[] = $key;
+					$invalid_params[$key] = __( 'Invalid param.' );
 				}
 
 				if ( is_wp_error( $valid_check ) ) {
@@ -693,7 +693,7 @@ class WP_REST_Request implements ArrayAccess {
 		}
 
 		if ( $invalid_params ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( 'Invalid parameter(s): %s' ), implode( ', ', $invalid_params ) ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_invalid_param', sprintf( __( 'Invalid parameter(s): %s' ), implode( ', ', $invalid_params ) ), array( 'status' => 400, 'params' => $invalid_params ) );
 		}
 
 		return true;

--- a/tests/test-rest-request.php
+++ b/tests/test-rest-request.php
@@ -321,6 +321,30 @@ class WP_Test_REST_Request extends WP_UnitTestCase {
 		$this->assertEquals( 'rest_missing_callback_param', $valid->get_error_code() );
 	}
 
+	public function test_has_valid_params_required_flag_multiple() {
+
+		$this->request->set_attributes(array(
+			'args' => array(
+				'someinteger' => array(
+					'required' => true,
+				),
+				'someotherinteger' => array(
+					'required' => true,
+				),
+			),
+		));
+
+		$valid = $this->request->has_valid_params();
+
+		$this->assertWPError( $valid );
+		$this->assertEquals( 'rest_missing_callback_param', $valid->get_error_code() );
+
+		$data = $valid->get_error_data( 'rest_missing_callback_param' );
+		
+		$this->assertTrue( in_array( 'someinteger', $data['params'] ) );
+		$this->assertTrue( in_array( 'someotherinteger', $data['params'] ) );
+	}
+
 	public function test_has_valid_params_validate_callback() {
 
 		$this->request->set_url_params(array(
@@ -339,5 +363,34 @@ class WP_Test_REST_Request extends WP_UnitTestCase {
 
 		$this->assertWPError( $valid );
 		$this->assertEquals( 'rest_invalid_param', $valid->get_error_code() );
+	}
+
+	public function test_has_multiple_invalid_params_validate_callback() {
+
+		$this->request->set_url_params(array(
+			'someinteger' => '123',
+			'someotherinteger' => '123'
+		));
+
+		$this->request->set_attributes(array(
+			'args' => array(
+				'someinteger' => array(
+					'validate_callback' => '__return_false',
+				),
+				'someotherinteger' => array(
+					'validate_callback' => '__return_false',
+				),
+			),
+		));
+
+		$valid = $this->request->has_valid_params();
+
+		$this->assertWPError( $valid );
+		$this->assertEquals( 'rest_invalid_param', $valid->get_error_code() );
+
+		$data = $valid->get_error_data( 'rest_invalid_param' );
+
+		$this->assertArrayHasKey( 'someinteger', $data['params'] );
+		$this->assertArrayHasKey( 'someotherinteger', $data['params'] );
 	}
 }

--- a/tests/test-rest-request.php
+++ b/tests/test-rest-request.php
@@ -340,7 +340,7 @@ class WP_Test_REST_Request extends WP_UnitTestCase {
 		$this->assertEquals( 'rest_missing_callback_param', $valid->get_error_code() );
 
 		$data = $valid->get_error_data( 'rest_missing_callback_param' );
-		
+
 		$this->assertTrue( in_array( 'someinteger', $data['params'] ) );
 		$this->assertTrue( in_array( 'someotherinteger', $data['params'] ) );
 	}
@@ -369,7 +369,7 @@ class WP_Test_REST_Request extends WP_UnitTestCase {
 
 		$this->request->set_url_params(array(
 			'someinteger' => '123',
-			'someotherinteger' => '123'
+			'someotherinteger' => '123',
 		));
 
 		$this->request->set_attributes(array(


### PR DESCRIPTION
This was the client know exactly which fields failed. See #1143