### PR TITLE
Only include `parent` in term response when tax is hierarchical

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -424,8 +424,11 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'name'         => $item->name,
 			'slug'         => $item->slug,
 			'taxonomy'     => $item->taxonomy,
-			'parent'       => (int) $parent_id,
 		);
+		$schema = $this->get_item_schema();
+		if ( ! empty( $schema['properties']['parent'] ) ) {
+			$data['parent'] = (int) $parent_id;
+		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->filter_response_by_context( $data, $context );
@@ -511,11 +514,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'type'         => 'string',
 					'context'      => array( 'view' ),
 					),
-				'parent'           => array(
-					'description'  => 'The ID for the parent of the object.',
-					'type'         => 'integer',
-					'context'      => array( 'view' ),
-					),
 				'slug'             => array(
 					'description'  => 'An alphanumeric identifier for the object unique to its type.',
 					'type'         => 'string',
@@ -530,6 +528,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					),
 				),
 			);
+		$taxonomy = get_taxonomy( $this->taxonomy );
+		if ( $taxonomy->hierarchical ) {
+			$schema['properties']['parent'] = array(
+					'description'  => 'The ID for the parent of the object.',
+					'type'         => 'integer',
+					'context'      => array( 'view' ),
+					);
+		}
 		return $this->add_additional_fields_schema( $schema );
 	}
 

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -408,6 +408,15 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( array_keys( get_taxonomies() ), $properties['taxonomy']['enum'] );
 	}
 
+	public function test_get_item_schema_non_hierarchical() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag/schema' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['properties'];
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertFalse( isset( $properties['parent'] ) );
+	}
+
 	public function tearDown() {
 		_unregister_taxonomy( 'batman' );
 		_unregister_taxonomy( 'robin' );
@@ -439,6 +448,12 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( $term->description, $data['description'] );
 		$this->assertEquals( get_term_link( $term ),  $data['link'] );
 		$this->assertEquals( $term->count, $data['count'] );
+		$taxonomy = get_taxonomy( $term->taxonomy );
+		if ( $taxonomy->hierarchical ) {
+			$this->assertEquals( $term->parent, $data['parent'] );
+		} else {
+			$this->assertFalse( isset( $term->parent ) );
+		}
 	}
 
 	protected function check_get_taxonomy_term_response( $response ) {


### PR DESCRIPTION
Fixes #899