### PR TITLE
Set pagination headers even when no found posts

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -92,6 +92,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$args = (array) $request->get_params();
 		$args['post_type'] = $this->post_type;
 		$args['paged'] = $args['page'];
+		$args['posts_per_page'] = $args['per_page'];
 		unset( $args['page'] );
 
 		/**

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -16,11 +16,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$base = $this->get_post_type_base( $this->post_type );
 
 		$posts_args = array(
-			'context'          => array(
-				'default'      => 'view',
+			'context'               => array(
+				'default'           => 'view',
 			),
-			'page'            => array(
-				'default'           => 0,
+			'page'                  => array(
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page'              => array(
+				'default'           => 10,
 				'sanitize_callback' => 'absint',
 			),
 		);
@@ -104,9 +108,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$posts_query = new WP_Query();
 		$query_result = $posts_query->query( $query_args );
-		if ( 0 === $posts_query->found_posts ) {
-			return rest_ensure_response( array() );
-		}
 
 		$posts = array();
 		foreach ( $query_result as $post ) {
@@ -119,7 +120,28 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $posts );
-		$response->query_navigation_headers( $posts_query );
+		$count_query = new WP_Query();
+		unset( $query_args['paged'] );
+		$query_result = $count_query->query( $query_args );
+		$total_posts = $count_query->found_posts;
+		$response->header( 'X-WP-Total', (int) $total_posts );
+		$max_pages = ceil( $total_posts / $request['per_page'] );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$base = add_query_arg( $request->get_query_params(), rest_url( '/wp/v2/' . $this->get_post_type_base( $this->post_type ) ) );
+		if ( $request['page'] > 1 ) {
+			$prev_page = $request['page'] - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $request['page'] ) {
+			$next_page = $request['page'] + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
 
 		return $response;
 	}

--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -84,41 +84,6 @@ class WP_REST_Response extends WP_HTTP_Response {
 	}
 
 	/**
-	 * Send navigation-related headers for post collections
-	 *
-	 * @param WP_Query $query
-	 */
-	public function query_navigation_headers( $query ) {
-		$max_page = $query->max_num_pages;
-		$paged    = $query->get( 'paged' );
-
-		if ( ! $paged ) {
-			$paged = 1;
-		}
-
-		$nextpage = intval( $paged ) + 1;
-
-		if ( ! $query->is_single() ) {
-			if ( $paged > 1 ) {
-				$request = remove_query_arg( 'page' );
-				$request = add_query_arg( 'page', $paged - 1, $request );
-				$this->link_header( 'prev', untrailingslashit( home_url() ) . $request );
-			}
-
-			if ( $nextpage <= $max_page ) {
-				$request = remove_query_arg( 'page' );
-				$request = add_query_arg( 'page', $nextpage, $request );
-				$this->link_header( 'next', untrailingslashit( home_url() ) . $request );
-			}
-		}
-
-		$this->header( 'X-WP-Total', $query->found_posts );
-		$this->header( 'X-WP-TotalPages', $max_page );
-
-		do_action( 'rest_query_navigation_headers', $this, $query );
-	}
-
-	/**
 	 * Get the route that was used to
 	 *
 	 * @return string

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -122,7 +122,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
 		$request->set_query_params( array(
 			'page'           => 2,
-			'posts_per_page' => 4,
+			'per_page'       => 4,
 		) );
 		$response = $this->server->dispatch( $request );
 


### PR DESCRIPTION
Also handles adding `prev` link when outside of bounds

Removes `query_navigation_headers()` from `WP_REST_Response`, which was an oddball.

Fixes #890