### PR TITLE
Add controller for a post's terms

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -60,7 +60,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$post = get_post( $request['id'] );
 
-		$is_request_valid = $this->validate_request();
+		$is_request_valid = $this->validate_request( $request );
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}
@@ -88,7 +88,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		$is_request_valid = $this->validate_request();
+		$is_request_valid = $this->validate_request( $request );
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}
@@ -116,7 +116,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		$is_request_valid = $this->validate_request();
+		$is_request_valid = $this->validate_request( $request );
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}
@@ -145,7 +145,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		$is_request_valid = $this->validate_request();
+		$is_request_valid = $this->validate_request( $request );
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -204,13 +204,20 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {
-		$post_check = $this->posts_controller->get_item_permissions_check( $request );
+
+		$post_request = new WP_REST_Request();
+		$post_request->set_param( 'id', $request['post_id'] );
+
+		$post_check = $this->posts_controller->get_item_permissions_check( $post_request );
 
 		if ( ! $post_check || is_wp_error( $post_check ) ) {
 			return $post_check;
 		}
 
-		$terms_check = $this->terms_controller->get_item_permissions_check( $request );
+		$term_request = new WP_REST_Request();
+		$term_request->set_param( 'id', $request['term_id'] );
+
+		$terms_check = $this->terms_controller->get_item_permissions_check( $term_request );
 
 		if ( ! $terms_check || is_wp_error( $terms_check ) ) {
 			return $terms_check;
@@ -227,7 +234,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function create_item_permissions_check( $request ) {
 
-		$post_check = $this->posts_controller->update_item_permissions_check( $request );
+		$post_request = new WP_REST_Request();
+		$post_request->set_param( 'id', $request['post_id'] );
+		$post_check = $this->posts_controller->update_item_permissions_check( $post_request );
 
 		if ( ! $post_check || is_wp_error( $post_check ) ) {
 			return $post_check;

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -55,8 +55,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$post = get_post( $request['id'] );
 
-		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
-			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		$post_check = $this->posts_controller->get_item( $request );
+		if ( is_wp_error( $post_check ) ) {
+			return $post_check;
 		}
 
 		$valid_taxonomies = get_object_taxonomies( $post->post_type );
@@ -87,8 +88,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
-			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		$post_check = $this->posts_controller->get_item( $request );
+		if ( is_wp_error( $post_check ) ) {
+			return $post_check;
 		}
 
 		$valid_taxonomies = get_object_taxonomies( $post->post_type );
@@ -123,8 +125,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
-			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		$post_check = $this->posts_controller->get_item( $request );
+		if ( is_wp_error( $post_check ) ) {
+			return $post_check;
 		}
 
 		$valid_taxonomies = get_object_taxonomies( $post->post_type );
@@ -160,8 +163,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
-			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		$post_check = $this->posts_controller->get_item( $request );
+		if ( is_wp_error( $post_check ) ) {
+			return $post_check;
 		}
 
 		$valid_taxonomies = get_object_taxonomies( $post->post_type );

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -18,7 +18,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$base = $this->posts_controller->get_post_type_base( $this->post_type );
 
-		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<id>[\d]+)/terms/%s', $base, $this->taxonomy ), array(
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s', $base, $this->taxonomy ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -26,7 +26,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<id>[\d]+)/terms/%s/(?P<term_id>[\d]+)', $base, $this->taxonomy ), array(
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s/(?P<term_id>[\d]+)', $base, $this->taxonomy ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -44,7 +44,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			),
 		) );
 
-		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<id>[\d]+)/terms/%s', $base, $this->taxonomy ) . '/schema', array(
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s', $base, $this->taxonomy ) . '/schema', array(
 			'methods'         => WP_REST_Server::READABLE,
 			'callback'        => array( $this, 'get_item_schema' ),
 		) );
@@ -58,7 +58,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$post = get_post( $request['id'] );
+		$post = get_post( absint( $request['post_id'] ) );
 
 		$is_request_valid = $this->validate_request( $request );
 		if ( is_wp_error( $is_request_valid ) ) {
@@ -85,7 +85,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {
-		$post     = get_post( $request['id'] );
+		$post     = get_post( absint( $request['post_id'] ) );
 		$term_id  = absint( $request['term_id'] );
 
 		$is_request_valid = $this->validate_request( $request );
@@ -113,7 +113,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function create_item( $request ) {
-		$post     = get_post( $request['id'] );
+		$post     = get_post( $request['post_id'] );
 		$term_id  = absint( $request['term_id'] );
 
 		$is_request_valid = $this->validate_request( $request );
@@ -142,7 +142,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_Error|null
 	 */
 	public function delete_item( $request ) {
-		$post     = get_post( $request['id'] );
+		$post     = get_post( absint( $request['post_id'] ) );
 		$term_id  = absint( $request['term_id'] );
 
 		$is_request_valid = $this->validate_request( $request );
@@ -178,9 +178,10 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	protected function validate_request( $request ) {
 
-		$post     = get_post( $request['id'] );
+		$post_request = new WP_REST_Request();
+		$post_request->set_param( 'id', $request['post_id'] );
 
-		$post_check = $this->posts_controller->get_item( $request );
+		$post_check = $this->posts_controller->get_item( $post_request );
 		if ( is_wp_error( $post_check ) ) {
 			return $post_check;
 		}

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -46,7 +46,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get a collection of posts
+	 * Get all the terms that are attached to a post
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_Error|WP_REST_Response
@@ -79,7 +79,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get a single post
+	 * Get a term that is attached to a post
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_Error|WP_REST_Response
@@ -116,7 +116,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Create a single post
+	 * Add a term to a post
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_Error|WP_REST_Response
@@ -154,7 +154,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Delete a single post.
+	 * Remove a term from a post.
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_Error|null

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -150,6 +150,17 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			return $is_request_valid;
 		}
 
+		$previous_item = $this->get_item( $request );
+
+		$remove = wp_remove_object_terms( $post->ID, $term_id, $this->taxonomy );
+
+		if ( is_wp_error( $remove ) ) {
+			return $remove;
+		}
+
+		return $previous_item;
+	}
+
 	/**
 	 * Validate the API request for relationship requests.
 	 *

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -1,0 +1,229 @@
+<?php
+
+class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
+
+	protected $post_type;
+
+	public function __construct( $post_type ) {
+		$this->post_type = $post_type;
+		$this->posts_controller = new WP_REST_Posts_Controller( $post_type );
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+
+		$base = $this->posts_controller->get_post_type_base( $this->post_type );
+
+		register_rest_route( 'wp/v2', '/' . $base . '/(?P<id>[\d]+)/terms/(?P<taxonomy>[^/]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+		) );
+
+		register_rest_route( 'wp/v2', '/' . $base . '/(?P<id>[\d]+)/terms/(?P<taxonomy>[^/]+)/(?P<term_id>[\d]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+			),
+			array(
+				'methods'         => WP_REST_Server::DELETABLE,
+				'callback'        => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+			),
+		) );
+	}
+
+	/**
+	 * Get a collection of posts
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+
+		$post = get_post( $request['id'] );
+		$taxonomy = $request['taxonomy'];
+
+		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$valid_taxonomies = get_object_taxonomies( $post->post_type );
+		if ( ! in_array( $taxonomy, $valid_taxonomies ) ) {
+			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$terms = wp_get_object_terms( $post->ID, $taxonomy );
+		$terms_controller = new WP_REST_Terms_Controller( $request['taxonomy'] );
+
+		$response = array();
+		foreach ( $terms as $term ) {
+			$data = $terms_controller->prepare_item_for_response( $term, $request );
+			$response[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$response = rest_ensure_response( $response );
+
+		return $response;
+	}
+
+	/**
+	 * Get a single post
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$post     = get_post( $request['id'] );
+		$taxonomy = $request['taxonomy'];
+		$term_id  = absint( $request['term_id'] );
+
+		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$valid_taxonomies = get_object_taxonomies( $post->post_type );
+		if ( ! in_array( $taxonomy, $valid_taxonomies ) ) {
+			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		}
+
+		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $taxonomy ) ) {
+			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
+		}
+
+		$terms = wp_get_object_terms( $post->ID, $taxonomy );
+
+		if ( ! in_array( $term_id, wp_list_pluck( $terms, 'term_taxonomy_id' ) ) ) {
+			return new WP_Error( 'rest_post_not_in_term', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$terms_controller = new WP_REST_Terms_Controller( $request['taxonomy'] );
+		$term = $terms_controller->prepare_item_for_response( get_term_by( 'term_taxonomy_id', $term_id, $taxonomy ), $request );
+
+		$response = rest_ensure_response( $term );
+
+		return $response;
+	}
+
+	/**
+	 * Create a single post
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$post     = get_post( $request['id'] );
+		$taxonomy = $request['taxonomy'];
+		$term_id  = absint( $request['term_id'] );
+
+		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$valid_taxonomies = get_object_taxonomies( $post->post_type );
+		if ( ! in_array( $taxonomy, $valid_taxonomies ) ) {
+			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		}
+
+		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $taxonomy ) ) {
+			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
+		}
+
+		$tt_ids = wp_set_object_terms( $post->ID, $term_id, $taxonomy, true );
+
+		if ( is_wp_error( $tt_ids ) ) {
+			return $tt_ids;
+		}
+
+		$terms_controller = new WP_REST_Terms_Controller( $request['taxonomy'] );
+		$term = $terms_controller->prepare_item_for_response( get_term_by( 'term_taxonomy_id', $term_id, $taxonomy ), $request );
+
+		$response = rest_ensure_response( $term );
+		$response->set_status( 201 );
+
+		return $term;
+	}
+
+	/**
+	 * Delete a single post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|null
+	 */
+	public function delete_item( $request ) {
+		$post     = get_post( $request['id'] );
+		$taxonomy = $request['taxonomy'];
+		$term_id  = absint( $request['term_id'] );
+
+		if ( empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$valid_taxonomies = get_object_taxonomies( $post->post_type );
+		if ( ! in_array( $taxonomy, $valid_taxonomies ) ) {
+			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		}
+
+		$terms = wp_get_object_terms( $post->ID, $taxonomy );
+		$terms = wp_list_filter( $terms, array( 'term_taxonomy_id' => $term_id ), 'NOT' );
+		$tt_ids = wp_set_object_terms( $post->ID, $terms, $taxonomy );
+
+		if ( is_wp_error( $tt_ids ) ) {
+			return $tt_ids;
+		}
+
+		$terms_controller = new WP_REST_Terms_Controller( $request['taxonomy'] );
+
+		return null;
+	}
+
+	/**
+	 * Check if a given request has access to read a post's term.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_check = $this->posts_controller->get_item_permissions_check( $request );
+
+		if ( ! $post_check || is_wp_error( $post_check ) ) {
+			return $post_check;
+		}
+
+		$terms_controller = new WP_REST_Terms_Controller( $request['taxonomy'] );
+		$terms_check = $terms_controller->get_item_permissions_check( $request );
+
+		if ( ! $terms_check || is_wp_error( $terms_check ) ) {
+			return $terms_check;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to create a post/term relationship.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) {
+
+		$post_check = $this->posts_controller->update_item_permissions_check( $request );
+
+		if ( ! $post_check || is_wp_error( $post_check ) ) {
+			return $post_check;
+		}
+
+		return true;
+	}
+}

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -83,9 +83,6 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-
-		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ) ) {
-			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
 		$is_request_valid = $this->validate_request();
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
@@ -114,8 +111,6 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ) ) {
-			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
 		$is_request_valid = $this->validate_request();
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -55,14 +55,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$post = get_post( $request['id'] );
 
-		$post_check = $this->posts_controller->get_item( $request );
-		if ( is_wp_error( $post_check ) ) {
-			return $post_check;
-		}
-
-		$valid_taxonomies = get_object_taxonomies( $post->post_type );
-		if ( ! in_array( $this->taxonomy, $valid_taxonomies ) ) {
-			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		$is_request_valid = $this->validate_request();
+		if ( is_wp_error( $is_request_valid ) ) {
+			return $is_request_valid;
 		}
 
 		$terms = wp_get_object_terms( $post->ID, $this->taxonomy );
@@ -88,18 +83,12 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		$post_check = $this->posts_controller->get_item( $request );
-		if ( is_wp_error( $post_check ) ) {
-			return $post_check;
-		}
-
-		$valid_taxonomies = get_object_taxonomies( $post->post_type );
-		if ( ! in_array( $this->taxonomy, $valid_taxonomies ) ) {
-			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
-		}
 
 		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ) ) {
 			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
+		$is_request_valid = $this->validate_request();
+		if ( is_wp_error( $is_request_valid ) ) {
+			return $is_request_valid;
 		}
 
 		$terms = wp_get_object_terms( $post->ID, $this->taxonomy );
@@ -125,18 +114,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
-		$post_check = $this->posts_controller->get_item( $request );
-		if ( is_wp_error( $post_check ) ) {
-			return $post_check;
-		}
-
-		$valid_taxonomies = get_object_taxonomies( $post->post_type );
-		if ( ! in_array( $this->taxonomy, $valid_taxonomies ) ) {
-			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
-		}
-
 		if ( ! get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ) ) {
 			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
+		$is_request_valid = $this->validate_request();
+		if ( is_wp_error( $is_request_valid ) ) {
+			return $is_request_valid;
 		}
 
 		$tt_ids = wp_set_object_terms( $post->ID, $term_id, $this->taxonomy, true );
@@ -163,25 +145,35 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$post     = get_post( $request['id'] );
 		$term_id  = absint( $request['term_id'] );
 
+		$is_request_valid = $this->validate_request();
+		if ( is_wp_error( $is_request_valid ) ) {
+			return $is_request_valid;
+		}
+
+	/**
+	 * Validate the API request for relationship requests.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_Error|true
+	 */
+	protected function validate_request( $request ) {
+
+		$post     = get_post( $request['id'] );
+
 		$post_check = $this->posts_controller->get_item( $request );
 		if ( is_wp_error( $post_check ) ) {
 			return $post_check;
 		}
 
-		$valid_taxonomies = get_object_taxonomies( $post->post_type );
-		if ( ! in_array( $this->taxonomy, $valid_taxonomies ) ) {
-			return new WP_Error( 'rest_post_taxonomy_invalid', __( 'Invalid taxonomy for post ID.' ), array( 'status' => 404 ) );
+		if ( ! empty( $request['term_id'] ) ) {
+			$term_id  = absint( $request['term_id'] );
+
+			if ( ! get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ) ) {
+				return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
+			}
 		}
 
-		$terms = wp_get_object_terms( $post->ID, $this->taxonomy );
-		$terms = wp_list_filter( $terms, array( 'term_taxonomy_id' => $term_id ), 'NOT' );
-		$tt_ids = wp_set_object_terms( $post->ID, $terms, $this->taxonomy );
-
-		if ( is_wp_error( $tt_ids ) ) {
-			return $tt_ids;
-		}
-
-		return null;
+		return true;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -43,6 +43,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
 			),
 		) );
+
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<id>[\d]+)/terms/%s', $base, $this->taxonomy ) . '/schema', array(
+			'methods'         => WP_REST_Server::READABLE,
+			'callback'        => array( $this, 'get_item_schema' ),
+		) );
 	}
 
 	/**
@@ -154,6 +159,15 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		}
 
 		return $previous_item;
+	}
+
+	/**
+	 * Get the Term schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return $this->terms_controller->get_item_schema();
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -98,9 +98,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$prepared_args['order']   = $request['order'];
 		$prepared_args['orderby'] = $request['orderby'];
 
-<<<<<<< HEAD
-		$query_result = get_terms( $this->taxonomy, $prepared_args );
-=======
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy_obj->hierarchical && isset( $request['parent'] ) ) {
 			$parent = get_term_by( 'term_taxonomy_id', (int) $request['parent'], $this->taxonomy );
@@ -109,23 +106,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( isset( $request['post'] ) ) {
-			$post_id = $request['post'];
-
-			$permission_check = $this->check_post_taxonomy_permission( $this->taxonomy, $post_id );
-			if ( is_wp_error( $permission_check ) ) {
-				return $permission_check;
-			}
-
-			$query_result = wp_get_object_terms( $post_id, $this->taxonomy, $prepared_args );
-		} else {
-			$query_result = get_terms( $this->taxonomy, $prepared_args );
-		}
->>>>>>> develop
-		if ( is_wp_error( $query_result ) ) {
-			return new WP_Error( 'rest_taxonomy_invalid', __( "Taxonomy doesn't exist" ), array( 'status' => 404 ) );
-		}
-
+		$query_result = get_terms( $this->taxonomy, $prepared_args );
 		$response = array();
 		foreach ( $query_result as $term ) {
 			$data = $this->prepare_item_for_response( $term, $request );
@@ -559,11 +540,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'sanitize_callback'  => 'absint',
 			);
 		}
-		$query_params['post'] = array(
-			'description'        => 'Limit result set to terms assigned to a specific post.',
-			'type'               => 'integer',
-			'sanitize_callback'  => 'absint',
-		);
 		return $query_params;
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -172,7 +172,7 @@ function create_initial_rest_routes() {
 
 		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
 
-			if ( ! $taxonomy->public ) {
+			if ( empty( $taxonomy->show_in_rest ) ) {
 				continue;
 			}
 

--- a/plugin.php
+++ b/plugin.php
@@ -170,8 +170,13 @@ function create_initial_rest_routes() {
 			$revisions_controller->register_routes();
 		}
 
-		if ( get_object_taxonomies( $post_type->name ) ) {
-			$posts_terms_controller = new WP_REST_Posts_Terms_Controller( $post_type->name );
+		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
+
+			if ( ! $taxonomy->public ) {
+				continue;
+			}
+
+			$posts_terms_controller = new WP_REST_Posts_Terms_Controller( $post_type->name, $taxonomy->name );
 			$posts_terms_controller->register_routes();
 		}
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -43,6 +43,7 @@ require_once dirname( __FILE__ ) . '/lib/endpoints/class-wp-rest-users-controlle
 require_once dirname( __FILE__ ) . '/lib/endpoints/class-wp-rest-comments-controller.php';
 include_once dirname( __FILE__ ) . '/lib/endpoints/class-wp-rest-meta-controller.php';
 include_once dirname( __FILE__ ) . '/lib/endpoints/class-wp-rest-meta-posts-controller.php';
+include_once dirname( __FILE__ ) . '/lib/endpoints/class-wp-rest-posts-terms-controller.php';
 
 include_once( dirname( __FILE__ ) . '/extras.php' );
 
@@ -167,6 +168,11 @@ function create_initial_rest_routes() {
 		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
 			$revisions_controller = new WP_REST_Revisions_Controller( $post_type->name );
 			$revisions_controller->register_routes();
+		}
+
+		if ( get_object_taxonomies( $post_type->name ) ) {
+			$posts_terms_controller = new WP_REST_Posts_Terms_Controller( $post_type->name );
+			$posts_terms_controller->register_routes();
 		}
 	}
 

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -1,0 +1,213 @@
+<?php
+
+class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testcase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->post_id = $this->factory->post->create();
+		$this->admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)/terms/(?P<taxonomy>[^/]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)/terms/(?P<taxonomy>[^/]+)/(?P<term_id>[\d]+)', $routes );
+	}
+
+	public function test_get_items() {
+
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag', $this->post_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertEquals( array( 'test-tag' ), wp_list_pluck( $response->data, 'slug' ) );
+	}
+
+	public function test_get_items_invalid_post() {
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag', 9999 ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	public function test_get_items_invalid_taxonomy() {
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/invalid_tax', $this->post_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
+	}
+
+	public function test_get_item() {
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertFalse( $response->is_error() );
+
+		$this->assertEquals( 'test-tag', $response->data['slug'] );
+	}
+
+	public function test_get_item_invalid_post() {
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	public function test_get_item_invalid_taxonomy() {
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, 123 ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_taxonomy_invalid', $response, 404 );
+	}
+
+	public function test_get_item_invalid_taxonomy_term() {
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, 9999 ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
+	}
+
+	public function test_get_item_unassigned_taxonomy_term() {
+
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
+	}
+
+	public function test_get_item_term_id_not_added() {
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
+	}
+
+	public function test_create_item() {
+
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertTrue( is_object_in_term( $this->post_id, 'post_tag', $tag['term_id'] ) );
+	}
+
+	public function test_create_item_invalid_permission() {
+
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+	}
+
+	public function test_create_item_invalid_post() {
+
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	public function test_create_item_invalid_taxonomy() {
+
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_taxonomy_invalid', $response, 404 );
+	}
+
+	public function test_create_item_invalid_taxonomy_term() {
+
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, 9999 ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
+	}
+
+	public function test_delete_item() {
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( is_object_in_term( $this->post_id, 'post_tag', $tag['term_id'] ) );
+	}
+
+	public function test_delete_item_invalid_permission() {
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/post_tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+	}
+
+	public function test_delete_item_invalid_taxonomy() {
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_taxonomy_invalid', $response, 404 );
+	}
+
+	public function test_delete_item_invalid_taxonomy_term() {
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_taxonomy_invalid', $response, 404 );
+	}
+
+	public function test_delete_item_invalid_post() {
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	public function test_update_item() {
+		/** Can't update a relationship **/
+	}
+
+	public function test_prepare_item() {
+		/** Post types can't be updated **/
+	}
+
+	public function test_get_item_schema() {
+		/** Post types can't be deleted **/
+	}
+}

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -14,8 +14,8 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)/terms/post_tag', $routes );
-		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)/terms/post_tag/(?P<term_id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/terms/post_tag', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/terms/post_tag/(?P<term_id>[\d]+)', $routes );
 	}
 
 	public function test_get_items() {

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -98,16 +98,6 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'Cape', $data[0]['name'] );
 	}
 
-	public function test_get_terms_post_args_no_permission() {
-		$draft_id = $this->factory->post->create( array(
-			'post_status' => 'draft',
-		) );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
-		$request->set_param( 'post', $draft_id );
-		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
-	}
-
 	public function test_get_items_search_args() {
 		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
 		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );
@@ -155,23 +145,6 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/invalid-taxonomy' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
-	}
-
-	public function test_get_items_invalid_post() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
-		$request->set_param( 'post', 9999 );
-		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
-	}
-
-	public function test_get_items_invalid_taxonomy_for_post_type() {
-		$page_id = $this->factory->post->create( array(
-			'post_type' => 'page',
-		) );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
-		$request->set_param( 'post', $page_id );
-		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_taxonomy_invalid', $response, 404 );
 	}
 
 	public function test_get_terms_pagination_headers() {


### PR DESCRIPTION
Should we allow `DELETE /wp/v2/posts/1/terms/post_tag` to remove all tags from the post?

Also should we allow `POST /wp/v2/posts/1/terms/post_tag` with body `{ ids: 1,2,3,4 }` to assign more than 1 term to a post?

See #1199