### PR TITLE
Add meta tag to head that contains the path URL for WP-API.

### DIFF
--- a/extras.php
+++ b/extras.php
@@ -13,6 +13,7 @@ add_action( 'wp_enqueue_scripts', 'rest_register_scripts', -100 );
 add_action( 'admin_enqueue_scripts', 'rest_register_scripts', -100 );
 add_action( 'xmlrpc_rsd_apis', 'rest_output_rsd' );
 add_action( 'wp_head', 'rest_output_link_wp_head', 10, 0 );
+add_action( 'wp_head', 'rest_add_meta_tags' , 10, 0 );
 add_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
 add_action( 'auth_cookie_malformed',    'rest_cookie_collect_status' );
 add_action( 'auth_cookie_expired',      'rest_cookie_collect_status' );
@@ -62,6 +63,15 @@ function rest_output_link_wp_head() {
 	}
 
 	echo "<link rel='https://github.com/WP-API/WP-API' href='" . esc_url( $api_root ) . "' />\n";
+}
+
+/**
+ * Output a meta tag for obtaining WP-API url.
+ *
+ * @see get_rest_url()
+ */
+function rest_add_meta_tag() {
+	echo '<meta name="wp-api-url" content="/wp-json" />' . "\n";
 }
 
 /**

--- a/extras.php
+++ b/extras.php
@@ -13,7 +13,7 @@ add_action( 'wp_enqueue_scripts', 'rest_register_scripts', -100 );
 add_action( 'admin_enqueue_scripts', 'rest_register_scripts', -100 );
 add_action( 'xmlrpc_rsd_apis', 'rest_output_rsd' );
 add_action( 'wp_head', 'rest_output_link_wp_head', 10, 0 );
-add_action( 'wp_head', 'rest_add_meta_tags' , 10, 0 );
+add_action( 'wp_head', 'rest_add_meta_tag' , 10, 0 );
 add_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
 add_action( 'auth_cookie_malformed',    'rest_cookie_collect_status' );
 add_action( 'auth_cookie_expired',      'rest_cookie_collect_status' );


### PR DESCRIPTION
This might be helpful to build in now, so that in the future if the API url is changed or maybe on a different server altogether, it can be relayed to the frontend.