### PR TITLE
Limit the Users response fields in the embed context

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -594,7 +594,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'description' => array(
 					'description' => 'Description of the object.',
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'embed', 'view', 'edit' ),
 				),
 				'email'       => array(
 					'description' => 'The email address for the object.',
@@ -662,7 +662,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => 'URL of the object.',
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'username'    => array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -594,7 +594,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'description' => array(
 					'description' => 'Description of the object.',
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'email'       => array(
 					'description' => 'The email address for the object.',
@@ -612,7 +612,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'first_name'  => array(
 					'description' => 'First name for the object.',
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'id'          => array(
 					'description' => 'Unique identifier for the object.',
@@ -623,7 +623,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'last_name'   => array(
 					'description' => 'Last name for the object.',
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'link'        => array(
 					'description' => 'Author URL to the object.',
@@ -640,7 +640,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'nickname'    => array(
 					'description' => 'The nickname for the object.',
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'registered_date' => array(
 					'description' => 'Registration date for the user.',
@@ -656,13 +656,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'slug'        => array(
 					'description' => 'An alphanumeric identifier for the object unique to its type.',
 					'type'        => 'string',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'url'         => array(
 					'description' => 'URL of the object.',
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'embed', 'view', 'edit' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'username'    => array(

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -770,6 +770,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	protected function check_user_data( $user, $data, $context ) {
 		$this->assertEquals( $user->ID, $data['id'] );
 		$this->assertEquals( $user->display_name, $data['name'] );
+		$this->assertEquals( $user->user_url, $data['url'] );
+		$this->assertEquals( $user->description, $data['description'] );
 		$this->assertEquals( rest_get_avatar_url( $user->user_email ), $data['avatar_url'] );
 		$this->assertEquals( get_author_posts_url( $user->ID ), $data['link'] );
 
@@ -778,8 +780,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertEquals( $user->last_name, $data['last_name'] );
 			$this->assertEquals( $user->nickname, $data['nickname'] );
 			$this->assertEquals( $user->user_nicename, $data['slug'] );
-			$this->assertEquals( $user->user_url, $data['url'] );
-			$this->assertEquals( $user->description, $data['description'] );
 		}
 
 		if ( 'view' !== $context && 'edit' !== $context ) {
@@ -790,8 +790,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertArrayNotHasKey( 'last_name', $data );
 			$this->assertArrayNotHasKey( 'nickname', $data );
 			$this->assertArrayNotHasKey( 'slug', $data );
-			$this->assertArrayNotHasKey( 'url', $data );
-			$this->assertArrayNotHasKey( 'description', $data );
 		}
 
 		if ( 'view' == $context ) {

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -770,28 +770,36 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	protected function check_user_data( $user, $data, $context ) {
 		$this->assertEquals( $user->ID, $data['id'] );
 		$this->assertEquals( $user->display_name, $data['name'] );
-		$this->assertEquals( $user->first_name, $data['first_name'] );
-		$this->assertEquals( $user->last_name, $data['last_name'] );
-		$this->assertEquals( $user->nickname, $data['nickname'] );
-		$this->assertEquals( $user->user_nicename, $data['slug'] );
-		$this->assertEquals( $user->user_url, $data['url'] );
 		$this->assertEquals( rest_get_avatar_url( $user->user_email ), $data['avatar_url'] );
-		$this->assertEquals( $user->description, $data['description'] );
 		$this->assertEquals( get_author_posts_url( $user->ID ), $data['link'] );
 
-		if ( 'view' == $context ) {
-			$this->assertEquals( $user->roles, $data['roles'] );
-			$this->assertEquals( $user->allcaps, $data['capabilities'] );
-			$this->assertEquals( date( 'c', strtotime( $user->user_registered ) ), $data['registered_date'] );
-
-			$this->assertEquals( $user->user_email, $data['email'] );
-			$this->assertArrayNotHasKey( 'extra_capabilities', $data );
+		if ( 'view' === $context || 'edit' === $context ) {
+			$this->assertEquals( $user->first_name, $data['first_name'] );
+			$this->assertEquals( $user->last_name, $data['last_name'] );
+			$this->assertEquals( $user->nickname, $data['nickname'] );
+			$this->assertEquals( $user->user_nicename, $data['slug'] );
+			$this->assertEquals( $user->user_url, $data['url'] );
+			$this->assertEquals( $user->description, $data['description'] );
 		}
 
 		if ( 'view' !== $context && 'edit' !== $context ) {
 			$this->assertArrayNotHasKey( 'data', $data );
 			$this->assertArrayNotHasKey( 'capabilities', $data );
 			$this->assertArrayNotHasKey( 'registered', $data );
+			$this->assertArrayNotHasKey( 'first_name', $data );
+			$this->assertArrayNotHasKey( 'last_name', $data );
+			$this->assertArrayNotHasKey( 'nickname', $data );
+			$this->assertArrayNotHasKey( 'slug', $data );
+			$this->assertArrayNotHasKey( 'url', $data );
+			$this->assertArrayNotHasKey( 'description', $data );
+		}
+
+		if ( 'view' == $context ) {
+			$this->assertEquals( $user->roles, $data['roles'] );
+			$this->assertEquals( $user->allcaps, $data['capabilities'] );
+			$this->assertEquals( date( 'c', strtotime( $user->user_registered ) ), $data['registered_date'] );
+			$this->assertEquals( $user->user_email, $data['email'] );
+			$this->assertArrayNotHasKey( 'extra_capabilities', $data );
 		}
 
 		if ( 'edit' == $context ) {

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -783,7 +783,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		}
 
 		if ( 'view' !== $context && 'edit' !== $context ) {
-			$this->assertArrayNotHasKey( 'data', $data );
+			$this->assertArrayNotHasKey( 'roles', $data );
 			$this->assertArrayNotHasKey( 'capabilities', $data );
 			$this->assertArrayNotHasKey( 'registered', $data );
 			$this->assertArrayNotHasKey( 'first_name', $data );


### PR DESCRIPTION
Changed the following fields to only display in the view or edit contexts:
    - first_name
    - last_name
    - slug
    - nickname 

Includes test coverage.

The `embed` context now only includes the following response fields:

`avatar_url`
`id`
`link`
`name`
`url`
`description`