### PR TITLE
Don't nullify `parent`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1025,9 +1025,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $schema['properties']['parent'] ) ) {
 			$data['parent'] = (int) $post->post_parent;
-			if ( 0 == $data['parent'] ) {
-				$data['parent'] = null;
-			}
 		}
 
 		if ( ! empty( $schema['properties']['menu_order'] ) ) {


### PR DESCRIPTION
We don't want it to be unique

Fixes #1193