### PR TITLE
Fix issue #1273, do not redirect /users/me to /users/123

### DIFF
--- a/lib/class-wp-json-users.php
+++ b/lib/class-wp-json-users.php
@@ -97,22 +97,7 @@ class WP_JSON_Users {
 			return new WP_Error( 'json_not_logged_in', __( 'You are not currently logged in.' ), array( 'status' => 401 ) );
 		}
 
-		$response = $this->get_user( $current_user_id, $context );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		if ( ! ( $response instanceof WP_JSON_ResponseInterface ) ) {
-			$response = new WP_JSON_Response( $response );
-		}
-
-		$data = $response->get_data();
-
-		$response->header( 'Location', $data['meta']['links']['self'] );
-		$response->set_status( 302 );
-
-		return $response;
+		return $this->get_user( $current_user_id, $context );
 	}
 
 	/**

--- a/tests/test-json-users.php
+++ b/tests/test-json-users.php
@@ -35,12 +35,7 @@ class WP_Test_JSON_User extends WP_UnitTestCase {
 		}
 
 		// Check that we succeeded
-		$this->assertEquals( 302, $response->get_status() );
-
-		$headers = $response->get_headers();
-		$response_data = $response->get_data();
-		$this->assertArrayHasKey( 'Location', $headers );
-		$this->assertEquals( $response_data['meta']['links']['self'], $headers['Location'] );
+		$this->assertEquals( 200, $response->get_status() );
 
 		$this->check_get_user_response( $response, $this->user_obj );
 


### PR DESCRIPTION
This breaks OAuth signatures as the URL has now changed from underneath
the client, so the provided URL no longer matches.