### PR TITLE
Show `show_in_rest` for exposing taxonomies, not `public`

### DIFF
--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -74,7 +74,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 
 		$tax_obj = get_taxonomy( $request['taxonomy'] );
 
-		if ( $tax_obj && false === $tax_obj->public ) {
+		if ( $tax_obj && empty( $tax_obj->show_in_rest ) ) {
 			return false;
 		}
 
@@ -89,7 +89,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @return array Taxonomy data
 	 */
 	public function prepare_item_for_response( $taxonomy, $request ) {
-		if ( false === $taxonomy->public ) {
+		if ( empty( $taxonomy->show_in_rest ) ) {
 			return new WP_Error( 'rest_cannot_read_taxonomy', __( 'Cannot view taxonomy' ), array( 'status' => 403 ) );
 		}
 

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -93,7 +93,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	 * Utility function for use in get_public_taxonomies
 	 */
 	private function is_public( $taxonomy ) {
-		return $taxonomy->public !== false;
+		return ! empty( $taxonomy->show_in_rest );
 	}
 	/**
 	 * Utility function to filter down to only public taxonomies


### PR DESCRIPTION
Came out of #1216
