### PR TITLE
List namespaces in the index

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -52,6 +52,13 @@ class WP_REST_Server {
 	);
 
 	/**
+	 * Namespaces registered to the server
+	 *
+	 * @var array
+	 */
+	protected $namespaces = array();
+
+	/**
 	 * Endpoints registered to the server
 	 *
 	 * @var array
@@ -475,7 +482,12 @@ class WP_REST_Server {
 	 * @param array $route_args
 	 * @param boolean $override If the route already exists, should we override it? True overrides, false merges (with newer overriding if duplicate keys exist)
 	 */
-	public function register_route( $route, $route_args, $override = false ) {
+	public function register_route( $namespace, $route, $route_args, $override = false ) {
+		if ( ! isset( $this->namespaces[ $namespace ] ) ) {
+			$this->namespaces[ $namespace ] = array();
+		}
+		$this->namespaces[ $namespace ][] = $route;
+
 		if ( $override || empty( $this->endpoints[ $route ] ) ) {
 			$this->endpoints[ $route ] = $route_args;
 		} else {
@@ -673,6 +685,7 @@ class WP_REST_Server {
 			'description'    => get_option( 'blogdescription' ),
 			'URL'            => get_option( 'siteurl' ),
 			'routes'         => array(),
+			'namespaces'     => array_keys( $this->namespaces ),
 			'authentication' => array(),
 			'_links' => array(
 				'help'    => array(

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -687,11 +687,6 @@ class WP_REST_Server {
 			'namespaces'     => array_keys( $this->namespaces ),
 			'authentication' => array(),
 			'routes'         => array(),
-			'_links' => array(
-				'help'    => array(
-					'href' => 'https://github.com/WP-API/WP-API',
-				),
-			),
 		);
 
 		// Find the available routes
@@ -725,7 +720,11 @@ class WP_REST_Server {
 
 			$available['routes'][ $route ] = apply_filters( 'rest_endpoints_description', $data );
 		}
-		return apply_filters( 'rest_index', $available );
+
+		$response = new WP_REST_Response( $available );
+		$response->add_link( 'help', 'http://v2.wp-api.org/' );
+
+		return apply_filters( 'rest_index', $response );
 	}
 
 	/**

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -582,6 +582,15 @@ class WP_REST_Server {
 	}
 
 	/**
+	 * Get namespaces registered on the server.
+	 *
+	 * @return array Map of namespace to list of routes registered for the namespace.
+	 */
+	public function get_namespaces() {
+		return $this->namespaces;
+	}
+
+	/**
 	 * Match the request to a callback and call it
 	 *
 	 * @param WP_REST_Request $request Request to attempt dispatching

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -706,6 +706,15 @@ class WP_REST_Server {
 		$response = new WP_REST_Response( $available );
 		$response->add_link( 'help', 'http://v2.wp-api.org/' );
 
+		/**
+		 * Filter the API root index data.
+		 *
+		 * This contains the data describing the API. This includes information
+		 * about supported authentication schemes, supported namespaces, routes
+		 * available on the API, and a small amount of data about the site.
+		 *
+		 * @param WP_REST_Response $response Response data.
+		 */
 		return apply_filters( 'rest_index', $response );
 	}
 
@@ -721,7 +730,18 @@ class WP_REST_Server {
 		$routes = $this->namespaces[ $namespace ];
 		$endpoints = array_intersect_key( $this->get_routes(), $routes );
 
-		return $this->get_route_data( $endpoints );
+		$response = rest_ensure_response( $this->get_route_data( $endpoints ) );
+
+		/**
+		 * Filter the namespace index data.
+		 *
+		 * This typically is just the route data for the namespace, but you can
+		 * add any data you'd like here.
+		 *
+		 * @param WP_REST_Response $response Response data.
+		 * @param WP_REST_Request $request Request data. The namespace is passed as the 'namespace' parameter.
+		 */
+		return apply_filters( 'rest_namespace_index', $response, $request );
 	}
 
 	/**
@@ -764,7 +784,17 @@ class WP_REST_Server {
 			$available[ $route ] = apply_filters( 'rest_endpoints_description', $data );
 		}
 
-		return $available;
+		/**
+		 * Filter the publicly-visible data for routes.
+		 *
+		 * This data is exposed on indexes and can be used by clients or
+		 * developers to investigate the site and find out how to use it. It
+		 * acts as a form of self-documentation.
+		 *
+		 * @param array $available Map of route to route data.
+		 * @param array $routes Internal route data as an associative array.
+		 */
+		return apply_filters( 'rest_route_data', $available, $routes );
 	}
 
 	/**

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -592,7 +592,7 @@ class WP_REST_Server {
 		$path   = $request->get_route();
 
 		foreach ( $this->get_routes() as $route => $handlers ) {
-			foreach ( $handlers as $key => $handler ) {
+			foreach ( $handlers as $handler ) {
 				$callback  = $handler['callback'];
 				$supported = $handler['methods'];
 				$response = null;

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -559,7 +559,7 @@ class WP_REST_Server {
 				if ( ! is_numeric( $key ) ) {
 					// Route option, move it to the options
 					$this->route_options[ $route ][ $key ] = $handler;
-					unset( $handler );
+					unset( $handlers[ $key ] );
 					continue;
 				}
 				$handler = wp_parse_args( $handler, $defaults );

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -740,6 +740,9 @@ class WP_REST_Server {
 		);
 		$response = rest_ensure_response( $data );
 
+		// Link to the root index
+		$response->add_link( 'up', rest_url( '/' ) );
+
 		/**
 		 * Filter the namespace index data.
 		 *

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -498,7 +498,9 @@ class WP_REST_Server {
 				),
 			) );
 		}
-		$this->namespaces[ $namespace ][] = $route;
+
+		// Associative to avoid double-registration
+		$this->namespaces[ $namespace ][ $route ] = true;
 
 		if ( $override || empty( $this->endpoints[ $route ] ) ) {
 			$this->endpoints[ $route ] = $route_args;
@@ -717,7 +719,7 @@ class WP_REST_Server {
 		$namespace = $request['namespace'];
 
 		$routes = $this->namespaces[ $namespace ];
-		$endpoints = array_intersect_key( $this->get_routes(), array_flip( $routes ) );
+		$endpoints = array_intersect_key( $this->get_routes(), $routes );
 
 		return $this->get_route_data( $endpoints );
 	}

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -584,10 +584,10 @@ class WP_REST_Server {
 	/**
 	 * Get namespaces registered on the server.
 	 *
-	 * @return array Map of namespace to list of routes registered for the namespace.
+	 * @return array List of registered namespaces.
 	 */
 	public function get_namespaces() {
-		return $this->namespaces;
+		return array_keys( $this->namespaces );
 	}
 
 	/**

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -727,6 +727,10 @@ class WP_REST_Server {
 	public function get_namespace_index( $request ) {
 		$namespace = $request['namespace'];
 
+		if ( ! isset( $this->namespaces[ $namespace ] ) ) {
+			return new WP_Error( 'rest_invalid_namespace', __( 'The specified namespace could not be found.' ), array( 'status' => 404 ) );
+		}
+
 		$routes = $this->namespaces[ $namespace ];
 		$endpoints = array_intersect_key( $this->get_routes(), $routes );
 

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -683,10 +683,10 @@ class WP_REST_Server {
 		$available = array(
 			'name'           => get_option( 'blogname' ),
 			'description'    => get_option( 'blogdescription' ),
-			'URL'            => get_option( 'siteurl' ),
-			'routes'         => array(),
+			'url'            => get_option( 'siteurl' ),
 			'namespaces'     => array_keys( $this->namespaces ),
 			'authentication' => array(),
+			'routes'         => array(),
 			'_links' => array(
 				'help'    => array(
 					'href' => 'https://github.com/WP-API/WP-API',

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -734,7 +734,11 @@ class WP_REST_Server {
 		$routes = $this->namespaces[ $namespace ];
 		$endpoints = array_intersect_key( $this->get_routes(), $routes );
 
-		$response = rest_ensure_response( $this->get_route_data( $endpoints ) );
+		$data = array(
+			'namespace' => $namespace,
+			'routes' => $this->get_route_data( $endpoints ),
+		);
+		$response = rest_ensure_response( $data );
 
 		/**
 		 * Filter the namespace index data.

--- a/plugin.php
+++ b/plugin.php
@@ -615,11 +615,7 @@ function rest_send_allow_header( $response, $server, $request ) {
 	$allowed_methods = array();
 
 	// get the allowed methods across the routes
-	foreach ( $routes[ $matched_route ] as $key => $_handler ) {
-		if ( ! is_numeric( $key ) ) {
-			continue;
-		}
-
+	foreach ( $routes[ $matched_route ] as $_handler ) {
 		foreach ( $_handler['methods'] as $handler_method => $value ) {
 
 			if ( ! empty( $_handler['permission_callback'] ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -615,7 +615,11 @@ function rest_send_allow_header( $response, $server, $request ) {
 	$allowed_methods = array();
 
 	// get the allowed methods across the routes
-	foreach ( $routes[ $matched_route ] as $_handler ) {
+	foreach ( $routes[ $matched_route ] as $key => $_handler ) {
+		if ( ! is_numeric( $key ) ) {
+			continue;
+		}
+
 		foreach ( $_handler['methods'] as $handler_method => $value ) {
 
 			if ( ! empty( $_handler['permission_callback'] ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -74,7 +74,7 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 	}
 
 	$full_route = '/' . trim( $namespace, '/' ) . '/' . trim( $route, '/' );
-	$wp_rest_server->register_route( $full_route, $args, $override );
+	$wp_rest_server->register_route( $namespace, $full_route, $args, $override );
 }
 
 /**

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -48,7 +48,14 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		// Check the route was wrapped in an array
 		$endpoint = $endpoints['/test-ns/test'];
 		$this->assertArrayNotHasKey( 'callback', $endpoint );
-		$this->assertCount( 1, $endpoint );
+		$this->assertArrayHasKey( 'namespace', $endpoint );
+		$this->assertEquals( 'test-ns', $endpoint['namespace'] );
+
+		// Grab the filtered data
+		$filtered_endpoints = $GLOBALS['wp_rest_server']->get_routes();
+		$this->assertArrayHasKey( '/test-ns/test', $filtered_endpoints );
+		$endpoint = $filtered_endpoints['/test-ns/test'];
+		$this->assertCount( 2, $endpoint );
 		$this->assertArrayHasKey( 'callback', $endpoint[0] );
 		$this->assertArrayHasKey( 'methods',  $endpoint[0] );
 		$this->assertArrayHasKey( 'args',     $endpoint[0] );
@@ -78,6 +85,11 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		// Check the route was wrapped in an array
 		$endpoint = $endpoints['/test-ns/test'];
 		$this->assertArrayNotHasKey( 'callback', $endpoint );
+		$this->assertArrayHasKey( 'namespace', $endpoint );
+		$this->assertEquals( 'test-ns', $endpoint['namespace'] );
+
+		$filtered_endpoints = $GLOBALS['wp_rest_server']->get_routes();
+		$endpoint = $filtered_endpoints['/test-ns/test'];
 		$this->assertCount( 2, $endpoint );
 
 		// Check for both methods
@@ -102,7 +114,7 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		) );
 
 		// Check both routes exist
-		$endpoints = $GLOBALS['wp_rest_server']->get_raw_endpoint_data();
+		$endpoints = $GLOBALS['wp_rest_server']->get_routes();
 		$endpoint = $endpoints['/test-ns/test'];
 		$this->assertCount( 2, $endpoint );
 	}
@@ -123,7 +135,7 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		), true );
 
 		// Check we only have one route
-		$endpoints = $GLOBALS['wp_rest_server']->get_raw_endpoint_data();
+		$endpoints = $GLOBALS['wp_rest_server']->get_routes();
 		$endpoint = $endpoints['/test-ns/test'];
 		$this->assertCount( 1, $endpoint );
 

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -55,7 +55,7 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		$filtered_endpoints = $GLOBALS['wp_rest_server']->get_routes();
 		$this->assertArrayHasKey( '/test-ns/test', $filtered_endpoints );
 		$endpoint = $filtered_endpoints['/test-ns/test'];
-		$this->assertCount( 2, $endpoint );
+		$this->assertCount( 1, $endpoint );
 		$this->assertArrayHasKey( 'callback', $endpoint[0] );
 		$this->assertArrayHasKey( 'methods',  $endpoint[0] );
 		$this->assertArrayHasKey( 'args',     $endpoint[0] );

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -322,7 +322,7 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 
 	public function test_link_embedding() {
 		// Register our testing route
-		$this->server->register_route( '/test/embeddable', array(
+		$this->server->register_route( 'test', '/test/embeddable', array(
 			'methods' => 'GET',
 			'callback' => array( $this, 'embedded_response_callback' ),
 		) );
@@ -356,7 +356,7 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 	 */
 	public function test_link_embedding_self() {
 		// Register our testing route
-		$this->server->register_route( '/test/embeddable', array(
+		$this->server->register_route( 'test', '/test/embeddable', array(
 			'methods' => 'GET',
 			'callback' => array( $this, 'embedded_response_callback' ),
 		) );
@@ -375,7 +375,7 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 	 */
 	public function test_link_embedding_params() {
 		// Register our testing route
-		$this->server->register_route( '/test/embeddable', array(
+		$this->server->register_route( 'test', '/test/embeddable', array(
 			'methods' => 'GET',
 			'callback' => array( $this, 'embedded_response_callback' ),
 		) );
@@ -399,7 +399,7 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 	 */
 	public function test_link_embedding_error() {
 		// Register our testing route
-		$this->server->register_route( '/test/embeddable', array(
+		$this->server->register_route( 'test', '/test/embeddable', array(
 			'methods' => 'GET',
 			'callback' => array( $this, 'embedded_response_callback' ),
 		) );

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -539,20 +539,8 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 		) );
 
 		$namespaces = $server->get_namespaces();
-		$this->assertArrayHasKey( 'test/example', $namespaces );
-		$this->assertArrayHasKey( 'test/another', $namespaces );
-
-		$example_routes = array(
-			'/test/example' => true,
-			'/test/example/some-route' => true,
-		);
-		$this->assertEquals( $example_routes, $namespaces['test/example'] );
-
-		$other_routes = array(
-			'/test/another' => true,
-			'/test/another/route' => true,
-		);
-		$this->assertEquals( $other_routes, $namespaces['test/another'] );
+		$this->assertContains( 'test/example', $namespaces );
+		$this->assertContains( 'test/another', $namespaces );
 	}
 
 }

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -523,4 +523,36 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertArrayNotHasKey( '/test/another/route', $data['routes'] );
 	}
 
+	public function test_get_namespaces() {
+		$server = new WP_REST_Server();
+		$server->register_route( 'test/example', '/test/example/some-route', array(
+			array(
+				'methods' => WP_REST_Server::READABLE,
+				'callback' => '__return_true',
+			),
+		) );
+		$server->register_route( 'test/another', '/test/another/route', array(
+			array(
+				'methods' => WP_REST_Server::READABLE,
+				'callback' => '__return_false',
+			),
+		) );
+
+		$namespaces = $server->get_namespaces();
+		$this->assertArrayHasKey( 'test/example', $namespaces );
+		$this->assertArrayHasKey( 'test/another', $namespaces );
+
+		$example_routes = array(
+			'/test/example' => true,
+			'/test/example/some-route' => true,
+		);
+		$this->assertEquals( $example_routes, $namespaces['test/example'] );
+
+		$other_routes = array(
+			'/test/another' => true,
+			'/test/another/route' => true,
+		);
+		$this->assertEquals( $other_routes, $namespaces['test/another'] );
+	}
+
 }


### PR DESCRIPTION
This is an alternate approach to #577 that we discussed.

Right now, we have the ability to take a site and discover whether it has the API enabled (and where it is). From there, you can see what routes are available on the site, but you can't actually tell what the site supports. For example, how do I know if the site has WooCommerce enabled? How do I know what versions of the API are supported?

In #577, we talked about a possible solution to this, which is to list out the core objects and where they're available in the API. This would allow for some feature detection based on what objects are available. However, this makes it a bit of a pain to actually use, since you still might not be able to understand the API. It doesn't really solve the core problem of discovery.

This PR tackles it from a different angle, and uses the new concept of namespaces that we have in version 2. The index now contains a list of the available namespaces, and namespaces each have their own index (that you can override with your own index if needed). This allows for simple feature detection.

Let's say we later come out with version 3 of the REST API, and you want to assess what's available on the site. You can grab the index and check `namespaces` for `wp/v3`, which would indicate it's supported on the site. If that's not there, you could then fall back to version 2, and check for `wp/v2` instead.

You could do the same for checking for plugins. Simply check `namespaces` for `woocommerce` or `woocommerce/v2` or something like that.