### PR TITLE
Sort out link relations and embedded data

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -178,7 +178,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );
 
-		$links = parent::prepare_links( $post );
+		$links = $this->prepare_links( $post );
 		foreach ( $links as $rel => $attributes ) {
 			$data->add_link( $rel, $attributes['href'], $attributes );
 		}

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -178,10 +178,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $post );
-		foreach ( $links as $rel => $attributes ) {
-			$data->add_link( $rel, $attributes['href'], $attributes );
-		}
+		$data->add_links( $this->prepare_links( $post ) );
 
 		return apply_filters( 'rest_prepare_attachment', $data, $post, $request );
 	}

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -195,7 +195,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['alt_text'] = array(
 			'description'     => 'Alternative text to display when attachment is not displayed.',
 			'type'            => 'string',
-			'context'         => array( 'view', 'edit' ),
+			'context'         => array( 'view', 'edit', 'embed' ),
 			);
 		$schema['properties']['caption'] = array(
 			'description'     => 'The caption for the attachment.',
@@ -211,7 +211,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'description'     => 'Type of attachment.',
 			'type'            => 'string',
 			'enum'            => array( 'image', 'file' ),
-			'context'         => array( 'view', 'edit' ),
+			'context'         => array( 'view', 'edit', 'embed' ),
 			'readonly'        => true,
 			);
 		$schema['properties']['media_details'] = array(
@@ -229,7 +229,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'description'     => 'URL to the original attachment file.',
 			'type'            => 'string',
 			'format'          => 'uri',
-			'context'         => array( 'view', 'edit' ),
+			'context'         => array( 'view', 'edit', 'embed' ),
 			'readonly'        => true,
 			);
 		return $schema;

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -669,13 +669,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'id'               => array(
 					'description'  => 'Unique identifier for the object.',
 					'type'         => 'integer',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 					'readonly'     => true,
 					),
 				'author'           => array(
 					'description'  => 'The ID of the user object, if author was a user.',
 					'type'         => 'integer',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 					),
 				'author_email'     => array(
 					'description'  => 'Email address for the object author.',
@@ -692,13 +692,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'author_name'     => array(
 					'description'  => 'Display name for the object author.',
 					'type'         => 'string',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 					),
 				'author_url'       => array(
 					'description'  => 'Url for the object author.',
 					'type'         => 'string',
 					'format'       => 'uri',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 					),
 				'author_user_agent'     => array(
 					'description'  => 'User agent for the object author.',
@@ -709,7 +709,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'content'          => array(
 					'description'     => 'The content for the object.',
 					'type'            => 'object',
-					'context'         => array( 'view', 'edit' ),
+					'context'         => array( 'view', 'edit', 'embed' ),
 					'properties'      => array(
 						'raw'         => array(
 							'description'     => 'Content for the object, as it exists in the database.',
@@ -719,7 +719,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 						'rendered'    => array(
 							'description'     => 'Content for the object, transformed for display.',
 							'type'            => 'string',
-							'context'         => array( 'view', 'edit' ),
+							'context'         => array( 'view', 'edit', 'embed' ),
 							),
 						),
 					),
@@ -727,7 +727,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'description'  => 'The date the object was published.',
 					'type'         => 'string',
 					'format'       => 'date-time',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 				),
 				'date_gmt'         => array(
 					'description'  => 'The date the object was published as GMT.',
@@ -745,13 +745,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'description'  => 'URL to the object.',
 					'type'         => 'string',
 					'format'       => 'uri',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 					'readonly'     => true,
 				),
 				'parent'           => array(
 					'description'  => 'The ID for the parent of the object.',
 					'type'         => 'integer',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 				),
 				'post'             => array(
 					'description'  => 'The ID of the associated post object.',
@@ -761,12 +761,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'status'           => array(
 					'description'  => 'State of the object.',
 					'type'         => 'string',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 				),
 				'type'             => array(
 					'description'  => 'Type of Comment for the object.',
 					'type'         => 'string',
-					'context'      => array( 'view', 'edit' ),
+					'context'      => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -443,10 +443,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $comment );
-		foreach ( $links as $rel => $attributes ) {
-			$data->add_link( $rel, $attributes['href'], $attributes );
-		}
+		$data->add_links( $this->prepare_links( $comment ) );
 
 		return apply_filters( 'rest_prepare_comment', $data, $comment, $request );
 	}

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -761,7 +761,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'status'           => array(
 					'description'  => 'State of the object.',
 					'type'         => 'string',
-					'context'      => array( 'view', 'edit', 'embed' ),
+					'context'      => array( 'view', 'edit' ),
 				),
 				'type'             => array(
 					'description'  => 'Type of Comment for the object.',

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -480,9 +480,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				$posts_controller = new WP_REST_Posts_Controller( $post->post_type );
 				$base = $posts_controller->get_post_type_base( $post->post_type );
 
-				$links[ $post->post_type ] = array(
+				$links['up'] = array(
 					'href'       => rest_url( '/wp/v2/' . $base . '/' . $comment->comment_post_ID ),
 					'embeddable' => true,
+					'post_type'  => $post->post_type,
 				);
 			}
 		}

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1123,7 +1123,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
 			$attachments_url = rest_url( 'wp/v2/media' );
 			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
-			$links['http://wp-api.org/v2/attachment'] = array(
+			$links['http://v2.wp-api.org/attachment'] = array(
 				'href'       => $attachments_url,
 				'embeddable' => true,
 			);
@@ -1131,7 +1131,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = get_object_taxonomies( $post->post_type );
 		if ( ! empty( $taxonomies ) ) {
-			$links['http://wp-api.org/v2/term'] = array();
+			$links['http://v2.wp-api.org/term'] = array();
 
 			foreach ( $taxonomies as $tax ) {
 				$taxonomy_obj = get_taxonomy( $tax );
@@ -1148,7 +1148,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$terms_url = add_query_arg( 'post', $post->ID, $terms_url );
 
-				$links['http://wp-api.org/v2/term'][] = array(
+				$links['http://v2.wp-api.org/term'][] = array(
 					'href'       => $terms_url,
 					'taxonomy'   => $tax,
 					'embeddable' => true,
@@ -1157,7 +1157,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( post_type_supports( $post->post_type, 'custom-fields' ) ) {
-			$links['http://wp-api.org/v2/meta'] = array(
+			$links['http://v2.wp-api.org/meta'] = array(
 				'href' => rest_url( trailingslashit( $base ) . $post->ID . '/meta' ),
 				'embeddable' => true,
 			);

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1131,7 +1131,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = get_object_taxonomies( $post->post_type );
 		if ( ! empty( $taxonomies ) ) {
-			$links['http://wp-api.org/2.0/term'] = array();
+			$links['http://wp-api.org/v2/term'] = array();
 
 			foreach ( $taxonomies as $tax ) {
 				$taxonomy_obj = get_taxonomy( $tax );
@@ -1148,7 +1148,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$terms_url = add_query_arg( 'post', $post->ID, $terms_url );
 
-				$links['http://wp-api.org/2.0/term'][] = array(
+				$links['http://wp-api.org/v2/term'][] = array(
 					'href'       => $terms_url,
 					'taxonomy'   => $tax,
 					'embeddable' => true,
@@ -1157,7 +1157,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( post_type_supports( $post->post_type, 'custom-fields' ) ) {
-			$links['http://wp-api.org/2.0/meta'] = array(
+			$links['http://wp-api.org/v2/meta'] = array(
 				'href' => rest_url( trailingslashit( $base ) . $post->ID . '/meta' ),
 				'embeddable' => true,
 			);

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1123,7 +1123,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
 			$attachments_url = rest_url( 'wp/v2/media' );
 			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
-			$links['attachments'] = array(
+			$links['http://wp-api.org/v2/attachment'] = array(
 				'href'       => $attachments_url,
 				'embeddable' => true,
 			);
@@ -1131,6 +1131,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = get_object_taxonomies( $post->post_type );
 		if ( ! empty( $taxonomies ) ) {
+			$links['http://wp-api.org/2.0/term'] = array();
+
 			foreach ( $taxonomies as $tax ) {
 				$taxonomy_obj = get_taxonomy( $tax );
 				// Skip taxonomies that are not public.
@@ -1146,8 +1148,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$terms_url = add_query_arg( 'post', $post->ID, $terms_url );
 
-				$links[ $tax ] = array(
-					'href' => $terms_url,
+				$links['http://wp-api.org/2.0/term'][] = array(
+					'href'       => $terms_url,
+					'taxonomy'   => $tax,
 					'embeddable' => true,
 				);
 			}

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1186,7 +1186,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'description' => 'The date the object was published.',
 					'type'        => 'string',
 					'format'      => 'date-time',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'date_gmt'        => array(
 					'description' => 'The date the object was published, as GMT.',
@@ -1215,14 +1215,14 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'id'              => array(
 					'description' => 'Unique identifier for the object.',
 					'type'        => 'integer',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'link'            => array(
 					'description' => 'URL to the object.',
 					'type'        => 'string',
 					'format'      => 'uri',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 				'modified'        => array(
@@ -1245,7 +1245,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'slug'            => array(
 					'description' => 'An alphanumeric identifier for the object unique to its type.',
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'status'          => array(
 					'description' => 'A named status for the object.',
@@ -1256,7 +1256,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'type'            => array(
 					'description' => 'Type of Post for the object.',
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),
 			),
@@ -1323,7 +1323,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					$schema['properties']['title'] = array(
 						'description' => 'The title for the object.',
 						'type'        => 'object',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'properties'  => array(
 							'raw' => array(
 								'description' => 'Title for the object, as it exists in the database.',
@@ -1333,7 +1333,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 							'rendered' => array(
 								'description' => 'Title for the object, transformed for display.',
 								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
+								'context'     => array( 'view', 'edit', 'embed' ),
 							),
 						),
 					);
@@ -1363,7 +1363,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					$schema['properties']['author'] = array(
 						'description' => 'The ID for the author of the object.',
 						'type'        => 'integer',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 					);
 					break;
 
@@ -1371,7 +1371,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					$schema['properties']['excerpt'] = array(
 						'description' => 'The excerpt for the object.',
 						'type'        => 'object',
-						'context'     => array( 'view', 'edit' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 						'properties'  => array(
 							'raw' => array(
 								'description' => 'Excerpt for the object, as it exists in the database.',
@@ -1381,7 +1381,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 							'rendered' => array(
 								'description' => 'Excerpt for the object, transformed for display.',
 								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
+								'context'     => array( 'view', 'edit', 'embed' ),
 							),
 						),
 					);

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1066,10 +1066,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $post );
-		foreach ( $links as $rel => $attributes ) {
-			$data->add_link( $rel, $attributes['href'], $attributes );
-		}
+		$data->add_links( $this->prepare_links( $post ) );
 
 		return apply_filters( 'rest_prepare_' . $this->post_type, $data, $post, $request );
 	}

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -198,11 +198,13 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
 		if ( ! empty( $data['parent'] ) ) {
-			$data['_links'] = array(
-				'parent'    => rest_url( sprintf( 'wp/%s/%d', $this->parent_base, $data['parent'] ) ),
-				);
+			$response->add_link( 'parent', rest_url( sprintf( 'wp/%s/%d', $this->parent_base, $data['parent'] ) ) );
 		}
 
 		return $data;

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -207,7 +207,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			$response->add_link( 'parent', rest_url( sprintf( 'wp/%s/%d', $this->parent_base, $data['parent'] ) ) );
 		}
 
-		return $data;
+		return $response;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -441,10 +441,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$data = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $item );
-		foreach ( $links as $rel => $attributes ) {
-			$data->add_link( $rel, $attributes['href'], $attributes );
-		}
+		$data->add_links( $this->prepare_links( $item ) );
 
 		return apply_filters( 'rest_prepare_term', $data, $item, $request );
 	}

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -490,7 +490,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'id'               => array(
 					'description'  => 'Unique identifier for the object.',
 					'type'         => 'integer',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
 					),
 				'count'            => array(
@@ -508,24 +508,24 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'description'  => 'URL to the object.',
 					'type'         => 'string',
 					'format'       => 'uri',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
 					),
 				'name'             => array(
 					'description'  => 'The title for the object.',
 					'type'         => 'string',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'embed' ),
 					),
 				'slug'             => array(
 					'description'  => 'An alphanumeric identifier for the object unique to its type.',
 					'type'         => 'string',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'embed' ),
 					),
 				'taxonomy'         => array(
 					'description'  => 'Type attribution for the object.',
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
 					),
 				),

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -466,10 +466,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $user );
-		foreach ( $links as $rel => $attributes ) {
-			$data->add_link( $rel, $attributes['href'], $attributes );
-		}
+		$data->add_links( $this->prepare_links( $user ) );
 
 		return apply_filters( 'rest_prepare_user', $data, $user, $request );
 	}

--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -51,6 +51,29 @@ class WP_REST_Response extends WP_HTTP_Response {
 	}
 
 	/**
+	 * Add multiple links to the response.
+	 *
+	 * Link data should be an associative array with link relation as the key.
+	 * The value can either be an associative array of link attributes
+	 * (including `href` with the URL for the response), or a list of these
+	 * associative arrays.
+	 *
+	 * @param array $links Map of link relation to list of links.
+	 */
+	public function add_links( $links ) {
+		foreach ( $links as $rel => $set ) {
+			// If it's a single link, wrap with an array for consistent handling
+			if ( isset( $set['href'] ) ) {
+				$set = array( $set );
+			}
+
+			foreach ( $set as $attributes ) {
+				$this->add_link( $rel, $attributes['href'], $attributes );
+			}
+		}
+	}
+
+	/**
 	 * Get links for the response
 	 *
 	 * @return array

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -167,9 +167,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$attachments_url = rest_url( '/wp/v2/media' );
 		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
-		$this->assertEquals( $attachments_url, $links['http://wp-api.org/v2/attachment'][0]['href'] );
+		$this->assertEquals( $attachments_url, $links['http://v2.wp-api.org/attachment'][0]['href'] );
 
-		$term_links = $links['http://wp-api.org/v2/term'];
+		$term_links = $links['http://v2.wp-api.org/term'];
 		$tag_link = $cat_link = null;
 		foreach ( $term_links as $link ) {
 			if ( 'post_tag' === $link['attributes']['taxonomy'] ) {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -167,7 +167,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$attachments_url = rest_url( '/wp/v2/media' );
 		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
-		$this->assertEquals( $attachments_url, $links['attachments'][0]['href'] );
+		$this->assertEquals( $attachments_url, $links['http://wp-api.org/v2/attachment'][0]['href'] );
 
 		$tags_url = rest_url( '/wp/v2/terms/tag' );
 		$tags_url = add_query_arg( 'post', $this->post_id, $tags_url );

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -169,13 +169,25 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
 		$this->assertEquals( $attachments_url, $links['http://wp-api.org/v2/attachment'][0]['href'] );
 
+		$term_links = $links['http://wp-api.org/v2/term'];
+		$tag_link = $cat_link = null;
+		foreach ( $term_links as $link ) {
+			if ( 'post_tag' === $link['attributes']['taxonomy'] ) {
+				$tag_link = $link;
+			} elseif ( 'category' === $link['attributes']['taxonomy'] ) {
+				$cat_link = $link;
+			}
+		}
+		$this->assertNotEmpty( $tag_link );
+		$this->assertNotEmpty( $cat_link );
+
 		$tags_url = rest_url( '/wp/v2/terms/tag' );
 		$tags_url = add_query_arg( 'post', $this->post_id, $tags_url );
-		$this->assertEquals( $tags_url, $links['post_tag'][0]['href'] );
+		$this->assertEquals( $tags_url, $tag_link['href'] );
 
 		$category_url = rest_url( '/wp/v2/terms/category' );
 		$category_url = add_query_arg( 'post', $this->post_id, $category_url );
-		$this->assertEquals( $category_url, $links['category'][0]['href'] );
+		$this->assertEquals( $category_url, $cat_link['href'] );
 	}
 
 	public function test_get_item_links_no_author() {


### PR DESCRIPTION
This is a start to fix #1139.

Right now, this still uses the custom relation types, but next step is going to be trying switching that over.

I've also gone through and added a lot more fields to the embed context to make these links actually useful. Now you can go and get everything to render a single post nice and easily ([example post with embedding](https://gist.github.com/rmccue/1eba34f4ec6300e5513a)).

Also fixes #1289, fixes #1287