### PR TITLE
Inline docs for `global $wp_rest_server`

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -56,9 +56,7 @@ include_once( dirname( __FILE__ ) . '/extras.php' );
  */
 function register_rest_route( $namespace, $route, $args = array(), $override = false ) {
 
-	/**
-	 * @var WP_REST_Server $wp_rest_server
-	 */
+	/** @var WP_REST_Server $wp_rest_server */
 	global $wp_rest_server;
 
 	if ( isset( $args['callback'] ) ) {
@@ -324,9 +322,7 @@ function rest_api_loaded() {
 	 */
 	define( 'REST_REQUEST', true );
 
-	/**
-	 * @var WP_REST_Server $wp_rest_server
-	 */
+	/** @var WP_REST_Server $wp_rest_server */
 	global $wp_rest_server;
 
 	// Allow for a plugin to insert a different class to handle requests.

--- a/plugin.php
+++ b/plugin.php
@@ -55,6 +55,10 @@ include_once( dirname( __FILE__ ) . '/extras.php' );
  * @param boolean $override If the route already exists, should we override it? True overrides, false merges (with newer overriding if duplicate keys exist)
  */
 function register_rest_route( $namespace, $route, $args = array(), $override = false ) {
+
+	/**
+	 * @var WP_REST_Server $wp_rest_server
+	 */
 	global $wp_rest_server;
 
 	if ( isset( $args['callback'] ) ) {
@@ -320,6 +324,9 @@ function rest_api_loaded() {
 	 */
 	define( 'REST_REQUEST', true );
 
+	/**
+	 * @var WP_REST_Server $wp_rest_server
+	 */
 	global $wp_rest_server;
 
 	// Allow for a plugin to insert a different class to handle requests.

--- a/tests/class-wp-test-rest-controller-testcase.php
+++ b/tests/class-wp-test-rest-controller-testcase.php
@@ -7,9 +7,7 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/**
-		 * @var WP_REST_Server $wp_rest_server
-		 */
+		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new WP_REST_Server;
 		do_action( 'rest_api_init' );
@@ -18,9 +16,7 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		/**
-		 * @var WP_REST_Server $wp_rest_server
-		 */
+		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = null;
 	}

--- a/tests/class-wp-test-rest-controller-testcase.php
+++ b/tests/class-wp-test-rest-controller-testcase.php
@@ -6,6 +6,10 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 
 	public function setUp() {
 		parent::setUp();
+
+		/**
+		 * @var WP_REST_Server $wp_rest_server
+		 */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new WP_REST_Server;
 		do_action( 'rest_api_init' );
@@ -13,6 +17,10 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 
 	public function tearDown() {
 		parent::tearDown();
+
+		/**
+		 * @var WP_REST_Server $wp_rest_server
+		 */
 		global $wp_rest_server;
 		$wp_rest_server = null;
 	}

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -10,9 +10,7 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/**
-		 * @var WP_REST_Server $wp_rest_server
-		 */
+		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server();
 

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -10,6 +10,9 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		/**
+		 * @var WP_REST_Server $wp_rest_server
+		 */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server();
 


### PR DESCRIPTION
I added inline docs to usages of `global $wp_rest_server` so its explicitly clear what the variable contains and so phpStorm can autocomplete methods of the class called using the global variable.