### PR TITLE
Improve @return inline docs for rest_ensure_response()

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -489,7 +489,7 @@ function rest_ensure_request( $request ) {
  * immediately check for this value.
  *
  * @param WP_Error|WP_HTTP_ResponseInterface|mixed $response Response to check.
- * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response WP_Error if response generated an error, WP_HTTP_ResponseInterface if response is a already an instance, otherwise rerurns a new WP_REST_Response instance.
+ * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response WP_Error if response generated an error, WP_HTTP_ResponseInterface if response is a already an instance, otherwise returns a new WP_REST_Response instance.
  */
 function rest_ensure_response( $response ) {
 	if ( is_wp_error( $response ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -489,8 +489,8 @@ function rest_ensure_request( $request ) {
  * immediately check for this value.
  *
  * @param WP_Error|WP_HTTP_ResponseInterface|mixed $response Response to check.
- * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response Return is WP_Error if present, WP_HTTP_ResponseInterface if instance,
- *               otherwise WP_REST_Response.
+ * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response WP_Error if response generated an error, WP_HTTP_ResponseInterface if response is a already an instance,
+ *               otherwise rerurns a new WP_REST_Response instance.
  */
 function rest_ensure_response( $response ) {
 	if ( is_wp_error( $response ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -489,8 +489,7 @@ function rest_ensure_request( $request ) {
  * immediately check for this value.
  *
  * @param WP_Error|WP_HTTP_ResponseInterface|mixed $response Response to check.
- * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response WP_Error if response generated an error, WP_HTTP_ResponseInterface if response is a already an instance,
- *               otherwise rerurns a new WP_REST_Response instance.
+ * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response WP_Error if response generated an error, WP_HTTP_ResponseInterface if response is a already an instance, otherwise rerurns a new WP_REST_Response instance.
  */
 function rest_ensure_response( $response ) {
 	if ( is_wp_error( $response ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -489,7 +489,7 @@ function rest_ensure_request( $request ) {
  * immediately check for this value.
  *
  * @param WP_Error|WP_HTTP_ResponseInterface|mixed $response Response to check.
- * @return mixed WP_Error if present, WP_HTTP_ResponseInterface if instance,
+ * @return WP_Error|WP_HTTP_ResponseInterface|WP_REST_Response Return is WP_Error if present, WP_HTTP_ResponseInterface if instance,
  *               otherwise WP_REST_Response.
  */
 function rest_ensure_response( $response ) {


### PR DESCRIPTION
Existing docs use "mixed" as the data type for return. That does not allow autocompletion doc reference for `rest_ensure_response()` in phpStorm, which made me sad.