### PR TITLE
Remove unnecessary `handle_format_param()` method.

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -214,7 +214,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! empty( $schema['properties']['format'] ) && ! empty( $request['format'] ) ) {
-			$this->handle_format_param( $request['format'], $post );
+			set_post_format( $post, $request['format'] );
 		}
 
 		if ( ! empty( $schema['properties']['template'] ) && isset( $request['template'] ) ) {
@@ -273,7 +273,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$schema = $this->get_item_schema();
 
 		if ( ! empty( $schema['properties']['format'] ) && ! empty( $request['format'] ) ) {
-			$this->handle_format_param( $request['format'], $post );
+			set_post_format( $post, $request['format'] );
 		}
 
 		if ( ! empty( $schema['properties']['featured_image'] ) && isset( $request['featured_image'] ) ) {
@@ -814,23 +814,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return delete_post_thumbnail( $post_id );
 		}
 
-	}
-
-	/**
-	 * Determine if a post format should be set from format param.
-	 *
-	 * @param string $post_format
-	 * @param object $post
-	 */
-	protected function handle_format_param( $post_format, $post ) {
-		$post_format = sanitize_text_field( $post_format );
-
-		$formats = get_post_format_slugs();
-		if ( ! in_array( $post_format, $formats ) ) {
-			return new WP_Error( 'rest_invalid_post_format', __( 'Invalid post format.' ), array( 'status' => 400 ) );
-		}
-
-		return set_post_format( $post, $post_format );
 	}
 
 	/**

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -826,6 +826,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( 'gallery', get_post_format( $new_post->ID ) );
 	}
 
+	public function test_update_post_with_invalid_format() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data( array(
+			'format' => 'testformat',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
 	public function test_update_post_slug() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
Validation is now handled by the schema

See #1062, #1063