### PR TITLE
Permit post terms to be queried by term order

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -18,11 +18,13 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$base = $this->posts_controller->get_post_type_base( $this->post_type );
 
+		$query_params = $this->get_collection_params();
 		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s', $base, $this->taxonomy ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => $query_params,
 			),
 		) );
 
@@ -65,7 +67,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			return $is_request_valid;
 		}
 
-		$terms = wp_get_object_terms( $post->ID, $this->taxonomy );
+		$args = array(
+			'order'        => $request['order'],
+			'orderby'      => $request['orderby'],
+		);
+		$terms = wp_get_object_terms( $post->ID, $this->taxonomy, $args );
 
 		$response = array();
 		foreach ( $terms as $term ) {
@@ -250,4 +256,32 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		return true;
 	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$query_params = array();
+		$query_params['order'] = array(
+			'description'        => 'Order sort attribute ascending or descending.',
+			'type'               => 'string',
+			'default'            => 'asc',
+			'enum'               => array( 'asc', 'desc' ),
+		);
+		$query_params['orderby'] = array(
+			'description'        => 'Sort collection by object attribute.',
+			'type'               => 'string',
+			'default'            => 'name',
+			'enum'               => array(
+				'count',
+				'name',
+				'slug',
+				'term_order',
+			),
+		);
+		return $query_params;
+	}
+
 }

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -44,6 +44,33 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
+	public function test_get_items_orderby() {
+		wp_set_object_terms( $this->post_id, array( 'Banana', 'Carrot', 'Apple' ), 'post_tag' );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag', $this->post_id ) );
+		$request->set_param( 'orderby', 'term_order' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Banana', $data[0]['name'] );
+		$this->assertEquals( 'Carrot', $data[1]['name'] );
+		$this->assertEquals( 'Apple', $data[2]['name'] );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag', $this->post_id ) );
+		$request->set_param( 'orderby', 'name' );
+		$request->set_param( 'order', 'asc' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Apple', $data[0]['name'] );
+		$this->assertEquals( 'Banana', $data[1]['name'] );
+		$this->assertEquals( 'Carrot', $data[2]['name'] );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/post_tag', $this->post_id ) );
+		$request->set_param( 'orderby', 'name' );
+		$request->set_param( 'order', 'desc' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Carrot', $data[0]['name'] );
+		$this->assertEquals( 'Banana', $data[1]['name'] );
+		$this->assertEquals( 'Apple', $data[2]['name'] );
+	}
+
 	public function test_get_item() {
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );


### PR DESCRIPTION
But still default to ordering by `name`

Fixes #1214