### PR TITLE
Introduce `rest_do_request()` for making REST requests internally

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -340,7 +340,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_cannot_delete_post', __( 'Sorry, you are not allowed to delete this post.' ), array( 'status' => 401 ) );
 		}
 
-		$response = rest_do_request( 'GET', '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $post->ID, array( 'context' => 'edit' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $post->ID );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
 
 		// If we're forcing, then delete permanently
 		if ( $force ) {

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -340,9 +340,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_cannot_delete_post', __( 'Sorry, you are not allowed to delete this post.' ), array( 'status' => 401 ) );
 		}
 
-		$get_request = new WP_REST_Request( 'GET', rest_url( 'wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $post->ID ) );
-		$get_request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $post, $get_request );
+		$response = rest_do_request( 'GET', '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $post->ID, array( 'context' => 'edit' ) );
 
 		// If we're forcing, then delete permanently
 		if ( $force ) {

--- a/plugin.php
+++ b/plugin.php
@@ -474,7 +474,7 @@ function rest_url( $path = '', $scheme = 'json' ) {
 function rest_do_request( $method, $route, $params = array() ) {
 	global $wp_rest_server;
 	$request = new WP_REST_Request( $method, $route );
-	foreach( $params as $key => $value ) {
+	foreach ( $params as $key => $value ) {
 		$request->set_param( $key, $value );
 	}
 	return $wp_rest_server->dispatch( $request );

--- a/plugin.php
+++ b/plugin.php
@@ -464,19 +464,15 @@ function rest_url( $path = '', $scheme = 'json' ) {
 }
 
 /**
- * Make a REST request
+ * Do a REST request.
+ * Used primarily to route internal requests through WP_REST_Server
  *
- * @param string $method
- * @param string $route
- * @param array $params Parameters to pass to the request.
+ * @param WP_REST_Request|string $request
  * @return WP_REST_Response
  */
-function rest_do_request( $method, $route, $params = array() ) {
+function rest_do_request( $request ) {
 	global $wp_rest_server;
-	$request = new WP_REST_Request( $method, $route );
-	foreach ( $params as $key => $value ) {
-		$request->set_param( $key, $value );
-	}
+	$request = rest_ensure_request( $request );
 	return $wp_rest_server->dispatch( $request );
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -464,6 +464,23 @@ function rest_url( $path = '', $scheme = 'json' ) {
 }
 
 /**
+ * Make a REST request
+ *
+ * @param string $method
+ * @param string $route
+ * @param array $params Parameters to pass to the request.
+ * @return WP_REST_Response
+ */
+function rest_do_request( $method, $route, $params = array() ) {
+	global $wp_rest_server;
+	$request = new WP_REST_Request( $method, $route );
+	foreach( $params as $key => $value ) {
+		$request->set_param( $key, $value );
+	}
+	return $wp_rest_server->dispatch( $request );
+}
+
+/**
  * Ensure request arguments are a request object.
  *
  * This ensures that the request is consistent.


### PR DESCRIPTION
Routing requests through the server in a RESTful manner permits us to
de-couple controllers from one another, permitting subclassing, etc. It
also ensures all of the appropriate permission and validation checks are
run on each internal request.

See #1218