### PR TITLE
Remove 201 status response for missed endpoints

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -111,7 +111,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'context' => 'edit',
 		));
 		$response = rest_ensure_response( $response );
-		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $data['id'] ) );
 		return $response;
 	}

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -263,7 +263,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( '/wp/v2/comments/' . $comment->comment_ID ) );
 
 		return $response;

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -290,7 +290,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'context' => 'edit',
 		));
 		$response = rest_ensure_response( $response );
-		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( '/wp/v2/users/' . $user_id ) );
 
 		return $response;

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -451,7 +451,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
-		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
 
 		$comment = $response->get_data();
 		$updated = get_comment( $this->approved_id );
@@ -481,7 +481,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
-		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
 
 		$comment = $response->get_data();
 		$updated = get_comment( $comment_id );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -415,7 +415,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params( $_POST );
 
 		$response = $this->server->dispatch( $request );
-		$this->check_add_edit_user_response( $response );
+		$this->check_add_edit_user_response( $response, true );
 
 		// Check that the name has been updated correctly
 		$new_data = $response->get_data();
@@ -493,7 +493,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_body( json_encode( $params ) );
 
 		$response = $this->server->dispatch( $request );
-		$this->check_add_edit_user_response( $response );
+		$this->check_add_edit_user_response( $response, true );
 
 		// Check that the name has been updated correctly
 		$new_data = $response->get_data();
@@ -895,10 +895,14 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->check_user_data( $userdata, $data, $context );
 	}
 
-	protected function check_add_edit_user_response( $response ) {
+	protected function check_add_edit_user_response( $response, $update = false ) {
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
-		$this->assertEquals( 201, $response->get_status() );
+		if ( $update ) {
+			$this->assertEquals( 200, $response->get_status() );
+		} else {
+			$this->assertEquals( 201, $response->get_status() );
+		}
 
 		$data = $response->get_data();
 		$userdata = get_userdata( $data['id'] );


### PR DESCRIPTION
Previous changes in #1142 only addressed Posts.  This PR fixes the HTTP response code for update responses in Comments, Attachments, and Users.  I reviewed all endpoint controllers and these were the only remaining places this issue still existed.

