### PR TITLE
Experimental - Auto route registration

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -133,13 +133,17 @@ add_action( 'init', '_add_extra_api_post_type_arguments', 11 );
 function _add_extra_api_taxonomy_arguments() {
 	global $wp_taxonomies;
 
-	$wp_taxonomies['category']->show_in_rest = true;
-	$wp_taxonomies['category']->rest_base = 'category';
-	$wp_taxonomies['category']->rest_controller_class = 'WP_REST_Terms_Controller';
+	if ( isset( $wp_taxonomies['category'] ) ) {
+		$wp_taxonomies['category']->show_in_rest = true;
+		$wp_taxonomies['category']->rest_base = 'category';
+		$wp_taxonomies['category']->rest_controller_class = 'WP_REST_Terms_Controller';
+	}
 
-	$wp_taxonomies['post_tag']->show_in_rest = true;
-	$wp_taxonomies['post_tag']->rest_base = 'tag';
-	$wp_taxonomies['post_tag']->rest_controller_class = 'WP_REST_Terms_Controller';
+	if ( isset( $wp_taxonomies['post_tag'] ) ) {
+		$wp_taxonomies['post_tag']->show_in_rest = true;
+		$wp_taxonomies['post_tag']->rest_base = 'tag';
+		$wp_taxonomies['post_tag']->rest_controller_class = 'WP_REST_Terms_Controller';
+	}
 }
 add_action( 'init', '_add_extra_api_taxonomy_arguments', 11 );
 


### PR DESCRIPTION
Given that we have established a pretty clear pattern for our controllers, as an experiment I wanted to see if we could auto register the routes based off what is implemented in each controller. It worked out pretty well, at least with the current abstraction.

The idea for this came when I was writing documentation for adding routes. By implementing `WP_REST_Controller` it's also required that one know the syntax and underlaying API of `register_rest_route` which would be nice to not _require_. Of course, child classes can always overwrite `register_routes` if required (which for example `WP_REST_Users_Controller` does.