### PR TITLE
Check taxonomies exist before trying to set properties

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -133,13 +133,17 @@ add_action( 'init', '_add_extra_api_post_type_arguments', 11 );
 function _add_extra_api_taxonomy_arguments() {
 	global $wp_taxonomies;
 
-	$wp_taxonomies['category']->show_in_rest = true;
-	$wp_taxonomies['category']->rest_base = 'category';
-	$wp_taxonomies['category']->rest_controller_class = 'WP_REST_Terms_Controller';
+	if ( isset( $wp_taxonomies['category'] ) ) {
+		$wp_taxonomies['category']->show_in_rest = true;
+		$wp_taxonomies['category']->rest_base = 'category';
+		$wp_taxonomies['category']->rest_controller_class = 'WP_REST_Terms_Controller';
+	}
 
-	$wp_taxonomies['post_tag']->show_in_rest = true;
-	$wp_taxonomies['post_tag']->rest_base = 'tag';
-	$wp_taxonomies['post_tag']->rest_controller_class = 'WP_REST_Terms_Controller';
+	if ( isset( $wp_taxonomies['post_tag'] ) ) {
+		$wp_taxonomies['post_tag']->show_in_rest = true;
+		$wp_taxonomies['post_tag']->rest_base = 'tag';
+		$wp_taxonomies['post_tag']->rest_controller_class = 'WP_REST_Terms_Controller';
+	}
 }
 add_action( 'init', '_add_extra_api_taxonomy_arguments', 11 );
 

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -234,4 +234,20 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 
 		$this->assertNull( $response );
 	}
+
+	public function test_add_extra_api_taxonomy_arguments() {
+
+		// bootstrap the taxonomy variables
+		_add_extra_api_taxonomy_arguments();
+
+		$taxonomy = get_taxonomy( 'category' );
+		$this->assertTrue( $taxonomy->show_in_rest );
+		$this->assertEquals( 'category', $taxonomy->rest_base );
+		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
+
+		$taxonomy = get_taxonomy( 'post_tag' );
+		$this->assertTrue( $taxonomy->show_in_rest );
+		$this->assertEquals( 'tag', $taxonomy->rest_base );
+		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
+	}
 }


### PR DESCRIPTION
In the case where a develop has unregistered the post_tag / category taxonomy,
it currently produces PHP Notices.