### PR TITLE
If not namespace is provided, don't create double slashes

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -76,6 +76,11 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 	if ( $namespace ) {
 		$full_route = '/' . trim( $namespace, '/' ) . '/' . trim( $route, '/' );
 	} else {
+		// Non-namespaced routes are not allowed, with the exception of the main
+		// and namespace indexes. If you really need to register a
+		// non-namespaced route, call `WP_REST_Server::register_route` directly.
+		_doing_it_wrong( 'register_rest_route', 'Routes must be namespaced with plugin name and version', 'WPAPI-2.0' );
+
 		$full_route = '/' . trim( $route, '/' );
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -73,7 +73,12 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 		$arg_group = array_merge( $defaults, $arg_group );
 	}
 
-	$full_route = '/' . trim( $namespace, '/' ) . '/' . trim( $route, '/' );
+	if ( $namespace ) {
+		$full_route = '/' . trim( $namespace, '/' ) . '/' . trim( $route, '/' );
+	} else {
+		$full_route = '/' . trim( $route, '/' );
+	}
+
 	$wp_rest_server->register_route( $namespace, $full_route, $args, $override );
 }
 


### PR DESCRIPTION
In cases where I'm writing a full bespoke/whitelabelled API rather than adding to WordPress's routes, or them even being available, I want to not use namespaces at all.

This is probably controversial - but point being I want my api at `myserviers.com/api` for better or worse. (In this specific case I'm migrating from another API system, so I need the URLs to match the old ones as it's a drop in replacement).

In this case, it's pretty easy for us to support this by just checking if a namespace was not-empty and don't add the double slashes if so.