### PR TITLE
Add a note mentioning WordPress Trunk should be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ There's no fixed timeline for integration into core at this time, but getting cl
 Drop this directory in and activate it. You need to be using pretty permalinks
 to use the plugin, as it uses custom rewrite rules to power the API.
 
+Also, be sure to use the `trunk` branch of WordPress Core as there are potentially
+recent commits to Core that the REST API relies on.
+
 ## Issue Tracking
 
 All tickets for the project are being tracked on [GitHub][]. You can also take a

--- a/extras.php
+++ b/extras.php
@@ -74,7 +74,7 @@ function rest_output_link_header() {
 
 	$api_root = get_rest_url();
 
-	if ( empty($api_root) ) {
+	if ( empty( $api_root ) ) {
 		return;
 	}
 

--- a/lib/infrastructure/class-wp-rest-request.php
+++ b/lib/infrastructure/class-wp-rest-request.php
@@ -680,7 +680,7 @@ class WP_REST_Request implements ArrayAccess {
 
 			$param = $this->get_param( $key );
 
-			if ( null !== $param && ! empty( $arg['validate_callback']) ) {
+			if ( null !== $param && ! empty( $arg['validate_callback'] ) ) {
 				$valid_check = call_user_func( $arg['validate_callback'], $param, $this, $key );
 
 				if ( false === $valid_check ) {

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -7,7 +7,7 @@
  * @package WordPress
  */
 
-require_once ( ABSPATH . 'wp-admin/includes/admin.php' );
+require_once( ABSPATH . 'wp-admin/includes/admin.php' );
 
 /**
  * WordPress REST API server handler


### PR DESCRIPTION
As we are using features / patches recently committed to WordPress Core, we
should let people know they should be using trunk.