### PR TITLE
Remove permissions checks from get users so we can show public users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ php:
   - 5.5
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=nightly WP_MULTISITE=0
 
 matrix:
   include:
     - php: 5.2
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env: WP_VERSION=nightly WP_MULTISITE=1
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -32,7 +32,7 @@ install_wp() {
 	wget -nv -O /tmp/wordpress.zip https://wordpress.org/${ARCHIVE_NAME}.zip
 	unzip /tmp/wordpress.zip -d $TMP_EXTRACT
 	DIRS=($TMP_EXTRACT/*)
-	mv "${DIRS[@]:0:1}/*" $WP_CORE_DIR
+	mv ${DIRS[@]:0:1}/* $WP_CORE_DIR
 	rm -r $TMP_EXTRACT
 
 	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -19,14 +19,21 @@ set -ex
 install_wp() {
 	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then 
+	if [ $WP_VERSION == 'latest' ]; then
 		local ARCHIVE_NAME='latest'
+	else if [ $WP_VERSION == 'nightly' ]; then
+		local ARCHIVE_NAME='nightly-builds/wordpress-latest'
 	else
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
 	fi
 
-	wget -nv -O /tmp/wordpress.tar.gz https://wordpress.org/${ARCHIVE_NAME}.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	TMP_EXTRACT=$(mktemp -d /tmp/wp-XXXXX)
+
+	wget -nv -O /tmp/wordpress.zip https://wordpress.org/${ARCHIVE_NAME}.zip
+	unzip /tmp/wordpress.zip -d $TMP_EXTRACT
+	DIRS=($TMP_EXTRACT/*)
+	mv ${DIRS[@]:0:1}/* $WP_CORE_DIR
+	rm -r $TMP_EXTRACT
 
 	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
 }

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -21,7 +21,7 @@ install_wp() {
 
 	if [ $WP_VERSION == 'latest' ]; then
 		local ARCHIVE_NAME='latest'
-	else if [ $WP_VERSION == 'nightly' ]; then
+	elif [ $WP_VERSION == 'nightly' ]; then
 		local ARCHIVE_NAME='nightly-builds/wordpress-latest'
 	else
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
@@ -32,7 +32,7 @@ install_wp() {
 	wget -nv -O /tmp/wordpress.zip https://wordpress.org/${ARCHIVE_NAME}.zip
 	unzip /tmp/wordpress.zip -d $TMP_EXTRACT
 	DIRS=($TMP_EXTRACT/*)
-	mv ${DIRS[@]:0:1}/* $WP_CORE_DIR
+	mv "${DIRS[@]:0:1}/*" $WP_CORE_DIR
 	rm -r $TMP_EXTRACT
 
 	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -15,7 +15,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'            => $query_params,
 			),
 			array(
@@ -91,6 +90,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			);
 		$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
 		$prepared_args['search'] = $request['search'];
+
+		if ( ! current_user_can( 'list_users' ) ) {
+			$prepared_args['has_published_posts'] = true;
+		}
 
 		$prepared_args = apply_filters( 'rest_user_query', $prepared_args, $request );
 
@@ -333,21 +336,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		return $orig_user;
-	}
-
-	/**
-	 * Check if a given request has access to list users
-	 *
-	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return bool
-	 */
-	public function get_items_permissions_check( $request ) {
-
-		if ( ! current_user_can( 'list_users' ) ) {
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -64,9 +64,10 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$response = $this->server->dispatch( $request );
 		$users = $response->get_data();
-		$this->assertEquals( 1, count( $users ) );
 
-		$this->assertEquals( $this->editor, $users[0]['id'] );
+		foreach ( $users as $user ) {
+			$this->assertTrue( count_user_posts( $user['id'] ) > 0 );
+		}
 	}
 
 	/**

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -41,15 +41,32 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'context', 'view' );
 		$response = $this->server->dispatch( $request );
-		$this->check_get_users_response( $response );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$response = rest_ensure_response( $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$all_data = $response->get_data();
+		$data = $all_data[0];
+		$userdata = get_userdata( $data['id'] );
+		$this->check_user_data( $userdata, $data, 'view' );
 	}
 
-	public function test_get_items_without_permission() {
-		wp_set_current_user( $this->editor );
+	public function test_get_items_unauthenticated_only_shows_public_users() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( array(), $response->get_data() );
+
+		$this->factory->post->create( array( 'post_author' => $this->editor ) );
+		$this->factory->post->create( array( 'post_author' => $this->user, 'post_status' => 'draft' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+		$users = $response->get_data();
+		$this->assertEquals( 1, count( $users ) );
+
+		$this->assertEquals( $this->editor, $users[0]['id'] );
 	}
 
 	/**
@@ -894,17 +911,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertArrayNotHasKey( 'username', $data );
 		}
 
-	}
-
-	protected function check_get_users_response( $response, $context = 'view' ) {
-		$this->assertNotInstanceOf( 'WP_Error', $response );
-		$response = rest_ensure_response( $response );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$all_data = $response->get_data();
-		$data = $all_data[0];
-		$userdata = get_userdata( $data['id'] );
-		$this->check_user_data( $userdata, $data, $context );
 	}
 
 	protected function check_get_user_response( $response, $context = 'view' ) {


### PR DESCRIPTION
Using the new WordPress `WP_User_Query` `has_published_posts` flag we can show only public users that would otherwise be exposed via authors on public posts on the `/wp/v2/users` endpoint.

See #839