### PR TITLE
Fix adding alt text to attachments on create

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -73,6 +73,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $file ) );
 
+		if ( isset( $request['alt_text'] ) ) {
+			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $request['alt_text'] ) );
+		}
+
 		$this->update_additional_fields_for_object( $attachment, $request );
 
 		$response = $this->get_item( array(

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -152,6 +152,18 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 401 );
 	}
 
+	public function test_create_item_alt_text() {
+		wp_set_current_user( $this->author_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_body( file_get_contents( $this->test_file ) );
+		$request->set_param( 'alt_text', 'test alt text' );
+		$response = $this->server->dispatch( $request );
+		$attachment = $response->get_data();
+		$this->assertEquals( 'test alt text', $attachment['alt_text'] );
+	}
+
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(


### PR DESCRIPTION
This functionality was only available in `update` for one reason or another.
Preusming this is an oversite.