### PR TITLE
Sanitize pass on all controllers args

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -103,7 +103,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$data = $response->get_data();
 
 		if ( isset( $request['alt_text'] ) ) {
-			update_post_meta( $data['id'], '_wp_attachment_image_alt', sanitize_text_field( $request['alt_text'] ) );
+			update_post_meta( $data['id'], '_wp_attachment_image_alt', $request['alt_text'] );
 		}
 
 		$response = $this->get_item( array(
@@ -125,11 +125,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$prepared_attachment = parent::prepare_item_for_database( $request );
 
 		if ( isset( $request['caption'] ) ) {
-			$prepared_attachment->post_excerpt = wp_filter_post_kses( $request['caption'] );
+			$prepared_attachment->post_excerpt = $request['caption'];
 		}
 
 		if ( isset( $request['description'] ) ) {
-			$prepared_attachment->post_content = wp_filter_post_kses( $request['description'] );
+			$prepared_attachment->post_content = $request['description'];
 		}
 
 		if ( isset( $request['post'] ) ) {
@@ -197,16 +197,25 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'description'     => 'Alternative text to display when attachment is not displayed.',
 			'type'            => 'string',
 			'context'         => array( 'view', 'edit', 'embed' ),
+			'arg_options'     => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 			);
 		$schema['properties']['caption'] = array(
 			'description'     => 'The caption for the attachment.',
 			'type'            => 'string',
 			'context'         => array( 'view', 'edit' ),
+			'arg_options'     => array(
+				'sanitize_callback' => 'wp_filter_post_kses',
+			),
 			);
 		$schema['properties']['description'] = array(
 			'description'     => 'The description for the attachment.',
 			'type'            => 'string',
 			'context'         => array( 'view', 'edit' ),
+			'arg_options'     => array(
+				'sanitize_callback' => 'wp_filter_post_kses',
+			),
 			);
 		$schema['properties']['media_type'] = array(
 			'description'     => 'Type of attachment.',

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -668,7 +668,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 		// Post slug
 		if ( isset( $request['slug'] ) ) {
-			$prepared_post->post_name = sanitize_title( $request['slug'] );
+			$prepared_post->post_name = $request['slug'];
 		}
 
 		// Author
@@ -718,12 +718,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Comment status
 		if ( ! empty( $schema['properties']['comment_status'] ) && ! empty( $request['comment_status'] ) ) {
-			$prepared_post->comment_status = sanitize_text_field( $request['comment_status'] );
+			$prepared_post->comment_status = $request['comment_status'];
 		}
 
 		// Ping status
 		if ( ! empty( $schema['properties']['ping_status'] ) && ! empty( $request['ping_status'] ) ) {
-			$prepared_post->ping_status = sanitize_text_field( $request['ping_status'] );
+			$prepared_post->ping_status = $request['ping_status'];
 		}
 
 		return apply_filters( 'rest_pre_insert_' . $this->post_type, $prepared_post, $request );
@@ -737,7 +737,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return WP_Error|string $post_status
 	 */
 	protected function handle_status_param( $post_status, $post_type ) {
-		$post_status = sanitize_text_field( $post_status );
+		$post_status = $post_status;
 
 		switch ( $post_status ) {
 			case 'draft':
@@ -1247,6 +1247,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'description' => 'An alphanumeric identifier for the object unique to its type.',
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_title',
+					),
 				),
 				'status'          => array(
 					'description' => 'A named status for the object.',

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -32,19 +32,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'     => WP_REST_Server::CREATABLE,
 				'callback'    => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'        => array(
-					'name'        => array(
-						'required'          => true,
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'description' => array(
-						'sanitize_callback' => 'wp_filter_post_kses',
-					),
-					'slug'        => array(
-						'sanitize_callback' => 'sanitize_title',
-					),
-					'parent'      => array(),
-				),
+				'args'        => $this->get_endpoint_args_for_item_schema( true ),
 			),
 		));
 		register_rest_route( 'wp/v2', '/terms/' . $base . '/(?P<id>[\d]+)', array(
@@ -57,18 +45,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'    => WP_REST_Server::EDITABLE,
 				'callback'   => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'       => array(
-					'name'        => array(
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'description' => array(
-						'sanitize_callback' => 'wp_filter_post_kses',
-					),
-					'slug'        => array(
-						'sanitize_callback' => 'sanitize_title',
-					),
-					'parent'         => array(),
-				),
+				'args'        => $this->get_endpoint_args_for_item_schema( false ),
 			),
 			array(
 				'methods'    => WP_REST_Server::DELETABLE,
@@ -496,44 +473,54 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'type'         => 'integer',
 					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
-					),
+				),
 				'count'            => array(
 					'description'  => 'Number of published posts for the object.',
 					'type'         => 'integer',
 					'context'      => array( 'view' ),
 					'readonly'     => true,
-					),
+				),
 				'description'      => array(
 					'description'  => 'A human-readable description of the object.',
 					'type'         => 'string',
 					'context'      => array( 'view' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'wp_filter_post_kses',
 					),
+				),
 				'link'             => array(
 					'description'  => 'URL to the object.',
 					'type'         => 'string',
 					'format'       => 'uri',
 					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
-					),
+				),
 				'name'             => array(
 					'description'  => 'The title for the object.',
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
 					),
+					'required'     => true,
+				),
 				'slug'             => array(
 					'description'  => 'An alphanumeric identifier for the object unique to its type.',
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_title',
 					),
+				),
 				'taxonomy'         => array(
 					'description'  => 'Type attribution for the object.',
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
 					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
-					),
 				),
-			);
+			),
+		);
 		$taxonomy = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy->hierarchical ) {
 			$schema['properties']['parent'] = array(

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -152,6 +152,18 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 401 );
 	}
 
+	public function test_create_item_unsafe_alt_text() {
+		wp_set_current_user( $this->author_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_body( file_get_contents( $this->test_file ) );
+		$request->set_param( 'alt_text', '<script>alert(document.cookie)</script>' );
+		$response = $this->server->dispatch( $request );
+		$attachment = $response->get_data();
+		$this->assertEquals( '', $attachment['alt_text'] );
+	}
+
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(

--- a/tests/test-rest-meta-posts-controller.php
+++ b/tests/test-rest-meta-posts-controller.php
@@ -332,6 +332,19 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
 	}
 
+	public function test_create_item_empty_string_key() {
+		$post_id = $this->factory->post->create();
+		$data = array(
+			'key' => '',
+			'value' => 'testvalue',
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/meta', $post_id ) );
+		$request->set_body_params( $data );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_meta_invalid_key', $response, 400 );
+	}
+
 	public function test_create_item_invalid_key() {
 		$post_id = $this->factory->post->create();
 		$data = array(
@@ -373,7 +386,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 		$this->assertEmpty( get_post_meta( $post_id, 'testkey' ) );
 	}
 
@@ -388,7 +401,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 		$this->assertEmpty( get_post_meta( $post_id, 'testkey' ) );
 	}
 
@@ -702,7 +715,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 		$this->assertEquals( array( 'testvalue' ), get_post_meta( $post_id, 'testkey' ) );
 	}
 
@@ -717,7 +730,7 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$request->set_body_params( $data );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_action', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 		$this->assertEquals( array( 'testvalue' ), get_post_meta( $post_id, 'testkey' ) );
 	}
 


### PR DESCRIPTION
This is a sweep for all the args to make sure we are snitizing where needed. The basic principle is sanitize evertyhing, however the shema does a bunch of stuff for us so we don't need to sepficy it in every case, such as:

- the schema is marked up as an `enum` as we have chcking to make sure values are only these
- the `format` is set in the schema whereby we have validation, for example, `date-time`
- the type is `integer`

Also, for `content` and `title` in the `wp/v2/posts` endpoint does not have any, as `wp_insert_post` handles that depending on whatever permissions the user has, so rather than replicating this, we just pass it through.