### PR TITLE
Add `role` to schema for users

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -192,10 +192,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_exists', __( 'Cannot create existing user.' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! empty( $request['role'] ) && ! isset( $wp_roles->role_objects[ $request['role'] ] ) ) {
-			return new WP_Error( 'rest_user_invalid_role', __( 'Role is invalid.' ), array( 'status' => 400 ) );
-		}
-
 		$user = $this->prepare_item_for_database( $request );
 
 		if ( is_multisite() ) {
@@ -538,7 +534,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			$prepared_user->description = $request['description'];
 		}
 		if ( isset( $request['role'] ) ) {
-			$prepared_user->role = sanitize_text_field( $request['role'] );
+			$prepared_user->role = $request['role'];
 		}
 		if ( isset( $request['url'] ) ) {
 			$prepared_user->user_url = $request['url'];
@@ -556,10 +552,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	protected function check_role_update( $user_id, $role ) {
 		global $wp_roles;
-
-		if ( ! isset( $wp_roles->role_objects[ $role ] ) ) {
-			return new WP_Error( 'rest_user_invalid_role', __( 'Role is invalid.' ), array( 'status' => 400 ) );
-		}
 
 		$potential_role = $wp_roles->role_objects[ $role ];
 
@@ -594,6 +586,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'context'     => array( 'embed', 'view', 'edit' ),
 			);
 		}
+
+		global $wp_roles;
 
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
@@ -688,6 +682,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => 'Roles assigned to the user.',
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'role'            => array(
+					'description' => 'Role assigned to the user.',
+					'type'        => 'string',
+					'enum'        => array_keys( $wp_roles->role_objects ),
 				),
 				'slug'        => array(
 					'description' => 'An alphanumeric identifier for the object unique to its type.',

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -412,7 +412,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	public function test_update_item() {
@@ -612,7 +612,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'role', 'BeSharp' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$user = get_userdata( $this->editor );
 		$this->assertArrayHasKey( 'editor', $user->caps );
@@ -763,7 +763,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$data = $response->get_data();
 		$properties = $data['properties'];
 
-		$this->assertEquals( 16, count( $properties ) );
+		$this->assertEquals( 17, count( $properties ) );
 		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
@@ -779,6 +779,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'url', $properties );
 		$this->assertArrayHasKey( 'username', $properties );
+		$this->assertArrayHasKey( 'roles', $properties );
+		$this->assertArrayHasKey( 'role', $properties );
 	}
 
 	public function test_get_additional_field_registration() {


### PR DESCRIPTION
This way we get to supply the clients with an `enum` of roles, also the field
for updating / creating a user is `role`. The maining question is whether to
remove support for multiple roles or not. Currently it's half of both.

Adding this PR to get the discussion moving!