### PR TITLE
Resolves two issues with term creation and term assocaition

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -126,8 +126,8 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}
-		
-		$term = get_term_by('term_taxonomy_id', $term_id, $this->taxonomy);
+
+		$term = get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy );
 		$tt_ids = wp_set_object_terms( $post->ID, $term->term_id, $this->taxonomy, true );
 
 		if ( is_wp_error( $tt_ids ) ) {

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -126,8 +126,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $is_request_valid ) ) {
 			return $is_request_valid;
 		}
-
-		$tt_ids = wp_set_object_terms( $post->ID, $term_id, $this->taxonomy, true );
+		
+		$term = get_term_by('term_taxonomy_id', $term_id, $this->taxonomy);
+		$tt_ids = wp_set_object_terms( $post->ID, $term->term_id, $this->taxonomy, true );
 
 		if ( is_wp_error( $tt_ids ) ) {
 			return $tt_ids;

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -170,15 +170,15 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$term = wp_insert_term( $name, $this->taxonomy, $args );
 		if ( is_wp_error( $term ) ) {
-			
+
 			// If we're going to inform the client that the term exists, give them the identifier
 			// they can actually use (term_taxonomy_id) -- NOT term_id.
-			
-			if ( ( $term_id = $term->get_error_data('term_exists') ) ) {
+
+			if ( ( $term_id = $term->get_error_data( 'term_exists' ) ) ) {
 				$existing_term = get_term( $term_id, $this->taxonomy );
 				$term->add_data( $existing_term->term_taxonomy_id, 'term_exists' );
 			}
-			
+
 			return $term;
 		}
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -170,6 +170,15 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$term = wp_insert_term( $name, $this->taxonomy, $args );
 		if ( is_wp_error( $term ) ) {
+			
+			// If we're going to inform the client that the term exists, give them the identifier
+			// they can actually use (term_taxonomy_id) -- NOT term_id.
+			
+			if ( ( $term_id = $term->get_error_data('term_exists') ) ) {
+				$existing_term = get_term( $term_id, $this->taxonomy );
+				$term->add_data( $existing_term->term_taxonomy_id, 'term_exists' );
+			}
+			
 			return $term;
 		}
 


### PR DESCRIPTION
 * When the client attempts to create a term that already exists, we should return to them the `term_taxonomy_id` as part of the error data, NOT the `term_id`. The `term_id` is useless and arguably dangerous to the client, since they may attempt to use it elsewhere (ahem ;)).

 * When associating terms, we must resolve the `term_id` from the client-provided `term_taxonomy_id`. Wordpress core uses the `term_id` to make the association.