### PR TITLE
Don't expose non-public user information in the collection

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -93,6 +93,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		if ( ! current_user_can( 'list_users' ) ) {
 			$prepared_args['has_published_posts'] = true;
+
+			// Only display a public subset of information
+			$request['context'] = 'embed';
 		}
 
 		$prepared_args = apply_filters( 'rest_user_query', $prepared_args, $request );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -69,9 +69,9 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertTrue( count_user_posts( $user['id'] ) > 0 );
 
 			// Ensure we don't expose non-public data
-			$this->assertNotArrayHasKey( 'capabilities', $user );
-			$this->assertNotArrayHasKey( 'email', $user );
-			$this->assertNotArrayHasKey( 'roles', $user );
+			$this->assertArrayNotHasKey( 'capabilities', $user );
+			$this->assertArrayNotHasKey( 'email', $user );
+			$this->assertArrayNotHasKey( 'roles', $user );
 		}
 	}
 

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -67,6 +67,11 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		foreach ( $users as $user ) {
 			$this->assertTrue( count_user_posts( $user['id'] ) > 0 );
+
+			// Ensure we don't expose non-public data
+			$this->assertNotArrayHasKey( 'capabilities', $user );
+			$this->assertNotArrayHasKey( 'email', $user );
+			$this->assertNotArrayHasKey( 'roles', $user );
 		}
 	}
 


### PR DESCRIPTION
Just now in #1397, we added the ability to list users with published posts at `/wp/v2/users`. Problem is, right now, it's exposing *all* user data (`context=view`), but users should only be able to access `context=embed`

Merging now to avoid security issues, but we can fix up the handling later.

cc @joehoyle