### PR TITLE
Don't set the Location header in update responses

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -114,9 +114,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'id'      => $data['id'],
 			'context' => 'edit',
 		));
-		$response = rest_ensure_response( $response );
-		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $this->post_type ) . '/' . $data['id'] ) );
-		return $response;
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -243,13 +243,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'id'      => $id,
 			'context' => 'edit',
 		) );
-		$response = rest_ensure_response( $response );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-		$response->header( 'Location', rest_url( '/wp/v2/comments/' . $comment->comment_ID ) );
 
-		return $response;
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -291,10 +291,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'id'      => $user_id,
 			'context' => 'edit',
 		));
-		$response = rest_ensure_response( $response );
-		$response->header( 'Location', rest_url( '/wp/v2/users/' . $user_id ) );
 
-		return $response;
+		return rest_ensure_response( $response );
 	}
 
 	/**


### PR DESCRIPTION
This should have been removed as part of #1348.  There is no need to set the Location header in update requests, because the response location isn't changing.

I found this while looking into #1436, and noticed that my response HTTP code when editing a user was `302` instead of the expected `200`.