### PR TITLE
Revert "Ensure the REST API URL has a trailing slash"

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -448,7 +448,7 @@ function rest_get_url_prefix() {
  */
 function get_rest_url( $blog_id = null, $path = '', $scheme = 'json' ) {
 	if ( get_option( 'permalink_structure' ) ) {
-		$url = trailingslashit( get_home_url( $blog_id, rest_get_url_prefix(), $scheme ) );
+		$url = get_home_url( $blog_id, rest_get_url_prefix(), $scheme );
 
 		if ( ! empty( $path ) && is_string( $path ) && strpos( $path, '..' ) === false ) {
 			$url .= '/' . ltrim( $path, '/' );

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -250,18 +250,4 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		$this->assertEquals( 'tag', $taxonomy->rest_base );
 		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
 	}
-
-	/**
-	 * The get_rest_url function should return a URL consistently terminated with a "/",
-	 * whether the blog is configured with pretty permalink support or not.
-	 */
-	public function test_rest_url_generation() {
-		// In pretty permalinks case, we expect a path of wp-json/ with no query
-		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
-		$this->assertEquals( 'http://example.org/wp-json/', get_rest_url() );
-
-		// In non-pretty case, we get a query string to invoke the rest router
-		update_option( 'permalink_structure', '' );
-		$this->assertEquals( 'http://example.org/?rest_route=/', get_rest_url() );
-	}
 }


### PR DESCRIPTION
This breaks substantial amounts of the API, alas. See #1442.

Reverts WP-API/WP-API#1426

We'll need to fix this again at some point.