### PR TITLE
Migrate to docker container-based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 # Tell Travis CI we're using PHP
 language: php
 
+sudo: false
+
 matrix:
   include:
   - php: 5.6


### PR DESCRIPTION
I [noticed](https://travis-ci.org/WP-API/WP-API/jobs/73981334) that you are running your tests on the [legacy infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy) on Travis and it looks like you don't use `sudo` so adding `sudo: false` to `.travis.yml` will tell Travis to run on docker container-based infrastructure.