### PR TITLE
Embed links inside items in a collection

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -399,8 +399,13 @@ class WP_REST_Server {
 		if ( ! empty( $links ) ) {
 			// Convert links to part of the data
 			$data['_links'] = $links;
-
-			if ( $embed ) {
+		}
+		if ( $embed ) {
+			// Is this a numeric array?
+			if ( rest_is_list( $data ) ) {
+				$data = array_map( array( $this, 'embed_links' ), $data );
+			}
+			else {
 				$data = $this->embed_links( $data );
 			}
 		}

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -404,8 +404,7 @@ class WP_REST_Server {
 			// Is this a numeric array?
 			if ( rest_is_list( $data ) ) {
 				$data = array_map( array( $this, 'embed_links' ), $data );
-			}
-			else {
+			} else {
 				$data = $this->embed_links( $data );
 			}
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -730,3 +730,19 @@ if ( ! function_exists( 'json_last_error_msg' ) ) :
 		}
 	}
 endif;
+
+/**
+ * Is the variable a list? (Numeric-indexed array)
+ *
+ * @param mixed $data Variable to check.
+ * @return boolean
+ */
+function rest_is_list( $data ) {
+	if ( ! is_array( $data ) ) {
+		return false;
+	}
+
+	$keys = array_keys( $data );
+	$string_keys = array_filter( $keys, 'is_string' );
+	return count( $string_keys ) === 0;
+}


### PR DESCRIPTION
See #865

This is a very simple approach. Essentially: if you return a list from your endpoint, apply `embed_links` to the items inside that rather than the top-level.

If we switch collections to objects, we can handle this differently, but that's a separate issue at #1196.