### PR TITLE
Use wp_get_attachment_image_src() on the image sizes in attachments

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -169,7 +169,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 			foreach ( $data['media_details']['sizes'] as $size => &$size_data ) {
 				// Use the same method image_downsize() does
-				$size_data['source_url'] = str_replace( $img_url_basename, $size_data['file'], $data['source_url'] );
+				$image_src = wp_get_attachment_image_src( $post->ID, $size );
+
+				if ( ! $image_src ) {
+					continue;
+				}
+
+				$size_data['source_url'] = $image_src[0];
 			}
 		} else {
 			$data['media_details']['sizes'] = new stdClass;

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -57,6 +57,24 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->check_get_post_response( $response );
 	}
 
+	public function test_get_item_sizes() {
+		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_excerpt'   => 'A sample caption',
+		), $this->test_file );
+
+		add_image_size( 'rest-api-test', 119, 119, true );
+		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $this->test_file ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		remove_image_size( 'rest-api-test' );
+
+		$image_src = wp_get_attachment_image_src( $attachment_id, 'rest-api-test' );
+		$this->assertEquals( $image_src[0], $data['media_details']['sizes']['rest-api-test']['source_url'] );
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -75,6 +75,26 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( $image_src[0], $data['media_details']['sizes']['rest-api-test']['source_url'] );
 	}
 
+	public function test_get_item_sizes_with_no_url() {
+		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_excerpt'   => 'A sample caption',
+		), $this->test_file );
+
+		add_image_size( 'rest-api-test', 119, 119, true );
+		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $this->test_file ) );
+
+		add_filter( 'wp_get_attachment_image_src', '__return_false' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		remove_filter( 'wp_get_attachment_image_src', '__return_false' );
+		remove_image_size( 'rest-api-test' );
+
+		$this->assertFalse( isset( $data['media_details']['sizes']['rest-api-test']['source_url'] ) );
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -69,9 +69,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
+		$image_src = wp_get_attachment_image_src( $attachment_id, 'rest-api-test' );
 		remove_image_size( 'rest-api-test' );
 
-		$image_src = wp_get_attachment_image_src( $attachment_id, 'rest-api-test' );
 		$this->assertEquals( $image_src[0], $data['media_details']['sizes']['rest-api-test']['source_url'] );
 	}
 


### PR DESCRIPTION
Currently it builds this with str_replace which can be error prone, and 
doesn't file the expected `image_downsize` filter than a lot of media related
plugins use to alter the image.