### PR TITLE
Make the embed context a default, not forced

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -495,7 +495,9 @@ class WP_REST_Server {
 				}
 
 				// Embedded resources get passed context=embed
-				$query_params['context'] = 'embed';
+				if ( empty( $query_params['context'] ) ) {
+					$query_params['context'] = 'embed';
+				}
 
 				$request = new WP_REST_Request( 'GET', $parsed['path'] );
 				$request->set_query_params( $query_params );


### PR DESCRIPTION
We should allow linking with the `view` context explicitly set. This allows you to build custom endpoints that link out to other collections and include the full data when embedding.

A good use for this is having your Blog page link to the full posts collection to allow loading in the title/permalink as well as the posts to display on the page.