### PR TITLE
Fix trailing slashes on non-pretty permalinks

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -451,21 +451,18 @@ function rest_get_url_prefix() {
  * @param string $scheme  Optional. Sanitization scheme. Default 'json'.
  * @return string Full URL to the endpoint.
  */
-function get_rest_url( $blog_id = null, $path = '', $scheme = 'json' ) {
+function get_rest_url( $blog_id = null, $path = '/', $scheme = 'json' ) {
+	if ( empty( $path ) ) {
+		$path = '/';
+	}
+
 	if ( get_option( 'permalink_structure' ) ) {
 		$url = get_home_url( $blog_id, rest_get_url_prefix(), $scheme );
-
-		if ( ! empty( $path ) && is_string( $path ) && strpos( $path, '..' ) === false ) {
-			$url .= '/' . ltrim( $path, '/' );
-		}
+		$url .= '/' . ltrim( $path, '/' );
 	} else {
 		$url = trailingslashit( get_home_url( $blog_id, '', $scheme ) );
 
-		if ( empty( $path ) ) {
-			$path = '/';
-		} else {
-			$path = '/' . ltrim( $path, '/' );
-		}
+		$path = '/' . ltrim( $path, '/' );
 
 		$url = add_query_arg( 'rest_route', $path, $url );
 	}

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -250,4 +250,18 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		$this->assertEquals( 'tag', $taxonomy->rest_base );
 		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
 	}
+
+	/**
+	 * The get_rest_url function should return a URL consistently terminated with a "/",
+	 * whether the blog is configured with pretty permalink support or not.
+	 */
+	public function test_rest_url_generation() {
+		// In pretty permalinks case, we expect a path of wp-json/ with no query
+		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/wp-json/', get_rest_url() );
+
+		// In non-pretty case, we get a query string to invoke the rest router
+		update_option( 'permalink_structure', '' );
+		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/?rest_route=/', get_rest_url() );
+	}
 }


### PR DESCRIPTION
See #1426. This one shouldn't accidentally break embedding; tested locally and it's all working.

Props @danielpunkass for the bug report and initial patch, plus the unit tests which I've borrowed here.