### PR TITLE
Return the trashed status of delete posts/comments

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -271,6 +271,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$get_request = new WP_REST_Request( 'GET', rest_url( '/wp/v2/comments/' . $id ) );
 		$get_request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $comment, $get_request );
 
 		if ( $force ) {
 			$result = wp_delete_comment( $comment->comment_ID, true );
@@ -284,8 +285,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$result = wp_trash_comment( $comment->comment_ID );
 			$status = 'trashed';
 		}
-
-		$response = $this->prepare_item_for_response( $comment, $get_request );
 
 		$data = $response->get_data();
 		$data = array(

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -287,7 +287,16 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$status = 'trashed';
 		}
 
-		$response = $this->prepare_item_for_response( $comment, $get_request, $status );
+		$response = $this->prepare_item_for_response( $comment, $get_request );
+
+		if ( in_array( $status, array( 'trashed', 'deleted' ), true ) ) {
+			$data = $response->get_data();
+			$data = array(
+				'data'  => $data,
+				$status => true,
+			);
+			$response->set_data( $data );
+		}
 
 		if ( ! $result ) {
 			return new WP_Error( 'rest_cannot_delete', __( 'The comment cannot be deleted.' ), array( 'status' => 500 ) );
@@ -427,10 +436,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 *
 	 * @param  object          $comment Comment object.
 	 * @param  WP_REST_Request $request Request object.
-	 * @param  string          $status  Status of the comment.
 	 * @return array $fields
 	 */
-	public function prepare_item_for_response( $comment, $request, $status = '' ) {
+	public function prepare_item_for_response( $comment, $request ) {
 		$data = array(
 			'id'                 => (int) $comment->comment_ID,
 			'post'               => (int) $comment->comment_post_ID,
@@ -457,13 +465,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->filter_response_by_context( $data, $context );
 		$data = $this->add_additional_fields_to_object( $data, $request );
-
-		if ( in_array( $status, array( 'trashed', 'deleted' ), true ) ) {
-			$data = array(
-				'data'  => $data,
-				$status => true,
-			);
-		}
 
 		// Wrap the data in a response object
 		$data = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -250,7 +250,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * Delete a comment.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|WP_REST_Response $response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function delete_item( $request ) {
 		$id = (int) $request['id'];
@@ -432,7 +432,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 *
 	 * @param  object          $comment Comment object.
 	 * @param  WP_REST_Request $request Request object.
-	 * @return WP_REST_Response $response
+	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $comment, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -432,7 +432,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 *
 	 * @param  object          $comment Comment object.
 	 * @param  WP_REST_Request $request Request object.
-	 * @return array $fields
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $comment, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -250,7 +250,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * Delete a comment.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|array
+	 * @return WP_Error|WP_REST_Response $response
 	 */
 	public function delete_item( $request ) {
 		$id = (int) $request['id'];

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -272,8 +272,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$get_request = new WP_REST_Request( 'GET', rest_url( '/wp/v2/comments/' . $id ) );
 		$get_request->set_param( 'context', 'edit' );
 
-		$status = '';
-
 		if ( $force ) {
 			$result = wp_delete_comment( $comment->comment_ID, true );
 			$status = 'deleted';
@@ -289,14 +287,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$response = $this->prepare_item_for_response( $comment, $get_request );
 
-		if ( in_array( $status, array( 'trashed', 'deleted' ), true ) ) {
-			$data = $response->get_data();
-			$data = array(
-				'data'  => $data,
-				$status => true,
-			);
-			$response->set_data( $data );
-		}
+		$data = $response->get_data();
+		$data = array(
+			'data'  => $data,
+			$status => true,
+		);
+		$response->set_data( $data );
 
 		if ( ! $result ) {
 			return new WP_Error( 'rest_cannot_delete', __( 'The comment cannot be deleted.' ), array( 'status' => 500 ) );

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -34,7 +34,7 @@ abstract class WP_REST_Controller {
 	 * Create one item from the collection
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Request
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function create_item( $request ) {
 		return new WP_Error( 'invalid-method', __( 'Method not implemented. Must be over-ridden in subclass.' ), array( 'status' => 405 ) );
@@ -44,7 +44,7 @@ abstract class WP_REST_Controller {
 	 * Update one item from the collection
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Request
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
 		return new WP_Error( 'invalid-method', __( 'Method not implemented. Must be over-ridden in subclass.' ), array( 'status' => 405 ) );
@@ -54,7 +54,7 @@ abstract class WP_REST_Controller {
 	 * Delete one item from the collection
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Request
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function delete_item( $request ) {
 		return new WP_Error( 'invalid-method', __( 'Method not implemented. Must be over-ridden in subclass.' ), array( 'status' => 405 ) );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -308,7 +308,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * Delete a single post
 	 *
 	 * @param WP_REST_Request $request Full details about the request
-	 * @return array|WP_Error
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
 		$id = (int) $request['id'];

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -341,8 +341,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$request->set_param( 'context', 'edit' );
 		$response = rest_do_request( $request );
 
-		$status = '';
-
 		// If we're forcing, then delete permanently
 		if ( $force ) {
 			$result = wp_delete_post( $id, true );
@@ -368,14 +366,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_cannot_delete', __( 'The post cannot be deleted.' ), array( 'status' => 500 ) );
 		}
 
-		if ( in_array( $status, array( 'trashed', 'deleted' ), true ) ) {
-			$data = $response->get_data();
-			$data = array(
-				'data'  => $data,
-				$status => true,
-			);
-			$response->set_data( $data );
-		}
+		$data = $response->get_data();
+		$data = array(
+			'data'  => $data,
+			$status => true,
+		);
+		$response->set_data( $data );
 
 		return $response;
 	}

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -250,7 +250,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * Delete a single term from a taxonomy
 	 *
 	 * @param WP_REST_Request $request Full details about the request
-	 * @return null
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -260,6 +260,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$get_request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $term, $get_request );
 
+		$data = $response->get_data();
+		$data = array(
+			'data'    => $data,
+			'deleted' => true,
+		);
+		$response->set_data( $data );
+
 		$retval = wp_delete_term( $term->term_id, $term->taxonomy );
 		if ( ! $retval ) {
 			return new WP_Error( 'rest_cannot_delete', __( 'The term cannot be deleted.' ), array( 'status' => 500 ) );

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -447,7 +447,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 *
 	 * @param object $user User object.
 	 * @param WP_REST_Request $request Request object.
-	 * @return array $data Response data.
+	 * @return WP_REST_Response $data Response data.
 	 */
 	public function prepare_item_for_response( $user, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -447,7 +447,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 *
 	 * @param object $user User object.
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response $data Response data.
+	 * @return WP_REST_Response Response data.
 	 */
 	public function prepare_item_for_response( $user, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -340,6 +340,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$get_request->set_param( 'context', 'edit' );
 		$orig_user = $this->prepare_item_for_response( $user, $get_request );
 
+		$data = $orig_user->get_data();
+		$data = array(
+			'data'    => $data,
+			'deleted' => true,
+		);
+		$orig_user->set_data( $data );
+
 		$result = wp_delete_user( $id, $reassign );
 
 		if ( ! $result ) {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -685,6 +685,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( $this->post_id, $data['data']['post'] );
+		$this->assertTrue( $data['trashed'] );
 	}
 
 	public function test_delete_comment_invalid_id() {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -684,7 +684,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = rest_ensure_response( $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( $this->post_id, $data['post'] );
+		$this->assertEquals( $this->post_id, $data['data']['post'] );
 	}
 
 	public function test_delete_comment_invalid_id() {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -688,6 +688,25 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertTrue( $data['trashed'] );
 	}
 
+	public function test_delete_item_skip_trash() {
+		wp_set_current_user( $this->admin_id );
+
+		$comment_id = $this->factory->comment->create( array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => $this->post_id,
+			'user_id'          => $this->subscriber_id,
+		));
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request['force'] = true;
+
+		$response = $this->server->dispatch( $request );
+		$response = rest_ensure_response( $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $this->post_id, $data['data']['post'] );
+		$this->assertTrue( $data['deleted'] );
+	}
+
 	public function test_delete_comment_invalid_id() {
 		wp_set_current_user( $this->admin_id );
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1014,6 +1014,22 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertTrue( $data['trashed'] );
 	}
 
+	public function test_delete_item_skip_trash() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Deleted post' ) );
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$request['force'] = true;
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$response = rest_ensure_response( $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'Deleted post', $data['data']['title']['raw'] );
+		$this->assertTrue( $data['deleted'] );
+	}
+
 	public function test_delete_post_invalid_id() {
 		wp_set_current_user( $this->editor_id );
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1011,6 +1011,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Deleted post', $data['data']['title']['raw'] );
+		$this->assertTrue( $data['trashed'] );
 	}
 
 	public function test_delete_post_invalid_id() {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1010,7 +1010,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = rest_ensure_response( $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted post', $data['title']['raw'] );
+		$this->assertEquals( 'Deleted post', $data['data']['title']['raw'] );
 	}
 
 	public function test_delete_post_invalid_id() {

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -390,6 +390,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Deleted Category', $data['data']['name'] );
+		$this->assertTrue( $data['deleted'] );
 	}
 
 	public function test_delete_item_invalid_taxonomy() {

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -389,7 +389,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted Category', $data['name'] );
+		$this->assertEquals( 'Deleted Category', $data['data']['name'] );
 	}
 
 	public function test_delete_item_invalid_taxonomy() {

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -693,7 +693,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_ensure_response( $response );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted User', $data['name'] );
+		$this->assertEquals( 'Deleted User', $data['data']['name'] );
 	}
 
 	public function test_delete_item_no_trash() {

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -694,6 +694,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Deleted User', $data['data']['name'] );
+		$this->assertTrue( $data['deleted'] );
 	}
 
 	public function test_delete_item_no_trash() {


### PR DESCRIPTION
When a post or a comment is deleted, return a flag to say whether it's been trashed or properly deleted.

See #1260.