### PR TITLE
Allow removing links froma response object

### DIFF
--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -58,18 +58,18 @@ class WP_REST_Response extends WP_HTTP_Response {
 	 */
 	public function remove_link( $rel, $href = null ) {
 
-		if ( ! isset( $this->links[$rel] ) ) {
+		if ( ! isset( $this->links[ $rel ] ) ) {
 			return;
 		}
 
 		if ( $href	 ) {
-			$this->links[$rel] = wp_list_filter( $this->links[$rel], array( 'href' => $href ), 'NOT' );
+			$this->links[ $rel ] = wp_list_filter( $this->links[ $rel ], array( 'href' => $href ), 'NOT' );
 		} else {
-			$this->links[$rel] = array();
+			$this->links[ $rel ] = array();
 		}
 
-		if ( ! $this->links[$rel] ) {
-			unset( $this->links[$rel] );
+		if ( ! $this->links[ $rel ] ) {
+			unset( $this->links[ $rel ] );
 		}
 	}
 

--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -30,9 +30,10 @@ class WP_REST_Response extends WP_HTTP_Response {
 	 * @link http://tools.ietf.org/html/rfc5988
 	 * @link http://www.iana.org/assignments/link-relations/link-relations.xml
 	 *
-	 * @param string $rel Link relation. Either an IANA registered type, or an absolute URL
-	 * @param string $link Target IRI for the link
-	 * @param array $attributes Link parameters to send along with the URL
+	 * @param string $rel        Link relation. Either an IANA registered type,
+	 *                           or an absolute URL.
+	 * @param string $href       Target URI for the link.
+	 * @param array  $attributes Link parameters to send along with the URL.
 	 */
 	public function add_link( $rel, $href, $attributes = array() ) {
 		if ( empty( $this->links[ $rel ] ) ) {

--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -52,18 +52,19 @@ class WP_REST_Response extends WP_HTTP_Response {
 	}
 
 	/**
-	 * Remove a link from the response
+	 * Remove a link from the response.
 	 *
-	 * @param  string $rel   Link relation. Either an IANA registered type, or an absolute URL
-	 * @param  string $href  Optional. Only remove a links for the relation matching the given href
+	 * @param  string $rel  Link relation. Either an IANA registered type, or
+	 *                      an absolute URL.
+	 * @param  string $href Optional. Only remove links for the relation
+	 *                      matching the given href. Default null.
 	 */
 	public function remove_link( $rel, $href = null ) {
-
 		if ( ! isset( $this->links[ $rel ] ) ) {
 			return;
 		}
 
-		if ( $href	 ) {
+		if ( $href ) {
 			$this->links[ $rel ] = wp_list_filter( $this->links[ $rel ], array( 'href' => $href ), 'NOT' );
 		} else {
 			$this->links[ $rel ] = array();

--- a/lib/infrastructure/class-wp-rest-response.php
+++ b/lib/infrastructure/class-wp-rest-response.php
@@ -51,6 +51,29 @@ class WP_REST_Response extends WP_HTTP_Response {
 	}
 
 	/**
+	 * Remove a link from the response
+	 *
+	 * @param  string $rel   Link relation. Either an IANA registered type, or an absolute URL
+	 * @param  string $href  Optional. Only remove a links for the relation matching the given href
+	 */
+	public function remove_link( $rel, $href = null ) {
+
+		if ( ! isset( $this->links[$rel] ) ) {
+			return;
+		}
+
+		if ( $href	 ) {
+			$this->links[$rel] = wp_list_filter( $this->links[$rel], array( 'href' => $href ), 'NOT' );
+		} else {
+			$this->links[$rel] = array();
+		}
+
+		if ( ! $this->links[$rel] ) {
+			unset( $this->links[$rel] );
+		}
+	}
+
+	/**
 	 * Add multiple links to the response.
 	 *
 	 * Link data should be an associative array with link relation as the key.

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -448,6 +448,25 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 		return $data;
 	}
 
+	public function test_removing_links() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', 'http://example.com/' );
+		$response->add_link( 'alternate', 'http://example.org/', array( 'type' => 'application/xml' ) );
+
+		$response->remove_link( 'self' );
+
+		$data = $this->server->response_to_data( $response, false );
+		$this->assertArrayHasKey( '_links', $data );
+
+		$this->assertArrayNotHasKey( 'self', $data['_links'] );
+
+		$alternate = array(
+			'href' => 'http://example.org/',
+			'type' => 'application/xml',
+		);
+		$this->assertEquals( $alternate, $data['_links']['alternate'][0] );
+	}
+
 	public function test_get_index() {
 		$server = new WP_REST_Server();
 		$server->register_route( 'test/example', '/test/example/some-route', array(

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -467,6 +467,24 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertEquals( $alternate, $data['_links']['alternate'][0] );
 	}
 
+	public function test_removing_links_for_href() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', 'http://example.com/' );
+		$response->add_link( 'self', 'https://example.com/' );
+
+		$response->remove_link( 'self', 'https://example.com/' );
+
+		$data = $this->server->response_to_data( $response, false );
+		$this->assertArrayHasKey( '_links', $data );
+
+		$this->assertArrayHasKey( 'self', $data['_links'] );
+
+		$self_not_filtered = array(
+			'href' => 'http://example.com/',
+		);
+		$this->assertEquals( $self_not_filtered, $data['_links']['self'][0] );
+	}
+
 	public function test_get_index() {
 		$server = new WP_REST_Server();
 		$server->register_route( 'test/example', '/test/example/some-route', array(


### PR DESCRIPTION
Currently there's no way a filter can easily remote link relations via the reponse object. This allows that!