### PR TITLE
Fix MD5 check on file uploads.

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -352,8 +352,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		}
 
 		// Verify hash, if given
-		if ( ! empty( $headers['CONTENT_MD5'] ) ) {
-			$expected = trim( $headers['CONTENT_MD5'] );
+		if ( ! empty( $headers['content_md5'] ) ) {
+			$content_md5 = array_shift( $headers['content_md5'] );
+			$expected = trim( $content_md5 );
 			$actual = md5_file( $files['file']['tmp_name'] );
 			if ( $expected !== $actual ) {
 				return new WP_Error( 'rest_upload_hash_mismatch', __( 'Content hash did not match expected' ), array( 'status' => 412 ) );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -175,7 +175,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = $this->server->dispatch( $request );
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
-		$this->assertEquals( 201, $response->get_status() );
+		$this->assertErrorResponse( 'rest_upload_hash_mismatch', $response, 412 );
 	}
 
 	public function test_create_item_invalid_upload_files_capability() {


### PR DESCRIPTION
Upload from file checking for header 'CONTENT_MD5', but all headers are canonicalized by WP_REST_Request::canonicalize_header_name(), so this header is never present.

Upload from data correctly checks for 'content_md5' header.

Also, upload from file tries to handle the header as a string instead of as an array.

Surprisingly, the test case for 'bad MD5 header' is incorrectly checking for a 201 return, instead of a 412.

This commits fixes the MD5 check on upload from file by copying the way it is handled by upload from data.