### PR TITLE
Add help properties to endpoint arguments.

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -18,16 +18,22 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$posts_args = array(
 			'context'               => array(
 				'default'           => 'view',
+				'description'       => 'Defines which properties to project',
+				'accepts'           => array( 'view', 'embed', 'edit' ),
 			),
 			'page'                  => array(
 				'default'           => 1,
 				'sanitize_callback' => 'absint',
+				'description'       => 'Number of page to load',
 			),
 			'per_page'              => array(
 				'default'           => 10,
 				'sanitize_callback' => 'absint',
+				'description'       => 'Quantity of posts to fetch per page',
 			),
-			'filter'                => array(),
+			'filter'                => array(
+				'description'       => 'Filter to apply to the query',
+			),
 		);
 
 		register_rest_route( 'wp/v2', '/' . $base, array(

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -950,6 +950,14 @@ class WP_REST_Server {
 					if ( isset( $opts['default'] ) ) {
 						$arg_data['default'] = $opts['default'];
 					}
+					if ( 'help' === $context ) {
+						if ( isset( $opts['description'] ) ) {
+							$arg_data['description'] = $opts['description'];
+						}
+						if ( isset( $opts['accepts'] ) ) {
+							$arg_data['accepts'] = $opts['accepts'];
+						}
+					}
 					$endpoint_data['args'][ $key ] = $arg_data;
 				}
 			}


### PR DESCRIPTION
Context 'help' already exists to show the schema of each endpoint.

This commits adds the possibility of adding helpful descriptions for humans to the arguments of an endpoint.

This is useful for those learning the API.

Example is given for some arguments of `class-wp-rest-posts-controller.php`.
