### PR TITLE
Add missing 'force' arg to posts-terms DELETE.

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -45,6 +45,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::DELETABLE,
 				'callback'        => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'            => array(
+					'force'       => array(
+						'default' => false,
+					),
+				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );


### PR DESCRIPTION
Function `delete_item()` requires de "force" arg, but the API description does not point it out.
