### PR TITLE
Fix bug in post comments link query arg

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1115,7 +1115,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'comments' ) ) {
 			$replies_url = rest_url( '/wp/v2/comments' );
-			$replies_url = add_query_arg( 'post_id', $post->ID, $replies_url );
+			$replies_url = add_query_arg( 'post', $post->ID, $replies_url );
 			$links['replies'] = array(
 				'href'         => $replies_url,
 				'embeddable'   => true,

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -158,7 +158,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( rest_url( '/wp/v2/posts' ), $links['collection'][0]['href'] );
 
 		$replies_url = rest_url( '/wp/v2/comments' );
-		$replies_url = add_query_arg( 'post_id', $this->post_id, $replies_url );
+		$replies_url = add_query_arg( 'post', $this->post_id, $replies_url );
 		$this->assertEquals( $replies_url, $links['replies'][0]['href'] );
 
 		$this->assertEquals( rest_url( '/wp/v2/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );


### PR DESCRIPTION
Corrects the `replies` link in a single Post response to use the correct query arg.

Fixes #1525