### PR TITLE
Remove blank lines and extra space causing PHPCS failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer/installers": "~1.0"
     },
     "require-dev": {
-        "wp-coding-standards/wpcs": "dev-develop"
+        "wp-coding-standards/wpcs": "0.7.1"
     },
     "extra": {
         "installer-name": "json-rest-api"

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -377,5 +377,4 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		return $file;
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -150,5 +150,4 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 			);
 		return $this->add_additional_fields_schema( $schema );
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -127,5 +127,4 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			);
 		return $this->add_additional_fields_schema( $schema );
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1462,5 +1462,4 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		return $this->add_additional_fields_schema( $schema );
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -282,5 +282,4 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		);
 		return $query_params;
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -336,5 +336,4 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 		return $this->add_additional_fields_schema( $schema );
 	}
-
 }

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -163,5 +163,4 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			);
 		return $this->add_additional_fields_schema( $schema );
 	}
-
 }

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -786,7 +786,7 @@ class WP_REST_Server {
 	 *
 	 * @return boolean|string Boolean false or string error message
 	 */
-	protected function get_json_last_error( ) {
+	protected function get_json_last_error() {
 		// see https://core.trac.wordpress.org/ticket/27799
 		if ( ! function_exists( 'json_last_error' ) ) {
 			return false;

--- a/tests/class-wp-rest-test-controller.php
+++ b/tests/class-wp-rest-test-controller.php
@@ -64,5 +64,4 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 
 		return $schema;
 	}
-
 }

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -226,5 +226,4 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 			),
 		) ) );
 	}
-
 }

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -425,7 +425,5 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		}
 
 		$this->assertEquals( wp_get_attachment_url( $attachment->ID ), $data['source_url'] );
-
 	}
-
 }

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -238,5 +238,4 @@ EOT;
 		$args['type'] = 'page';
 		return $args;
 	}
-
 }

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -153,5 +153,4 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$obj = get_post_status_object( 'publish' );
 		$this->check_post_status_obj( $obj, $data );
 	}
-
 }

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -117,5 +117,4 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$obj = get_post_type_object( 'post' );
 		$this->check_post_type_obj( $obj, $data );
 	}
-
 }

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1168,5 +1168,4 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		}
 		return $query;
 	}
-
 }

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -236,5 +236,4 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$parent_base = $parent_controller->get_post_type_base( $parent->post_type );
 		$this->assertEquals( rest_url( 'wp/' . $parent_base . '/' . $revision->post_parent ), $links['parent'][0]['href'] );
 	}
-
 }

--- a/tests/test-rest-server.php
+++ b/tests/test-rest-server.php
@@ -539,5 +539,4 @@ class WP_Test_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertContains( 'test/example', $namespaces );
 		$this->assertContains( 'test/another', $namespaces );
 	}
-
 }

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -128,5 +128,4 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$taxonomies = $this->get_public_taxonomies( get_object_taxonomies( $type, 'objects' ) );
 		$this->assertEquals( count( $taxonomies ), count( $data ) );
 	}
-
 }


### PR DESCRIPTION
Hotfix for #1518. 
#1518 should remain open awaiting a better solution that prevents WPCS broken builds from new sniff rules.