### PR TITLE
Fix force param logic when deleting Post Terms

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -42,9 +42,14 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
 			),
 			array(
-				'methods'         => WP_REST_Server::DELETABLE,
-				'callback'        => array( $this, 'delete_item' ),
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => array(
+					'force' => array(
+						'default' => false,
+					),
+				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -149,10 +154,10 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	public function delete_item( $request ) {
 		$post     = get_post( absint( $request['post_id'] ) );
 		$term_id  = absint( $request['term_id'] );
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force    = (bool) $request['force'];
 
 		// We don't support trashing for this type, error out
-		if ( ! $force ) {
+		if ( $force ) {
 			return new WP_Error( 'rest_trash_not_supported', __( 'Terms do not support trashing.' ), array( 'status' => 501 ) );
 		}
 

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -199,11 +199,22 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
-		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertFalse( is_object_in_term( $this->post_id, 'post_tag', $tag['term_id'] ) );
+	}
+
+	public function test_delete_item_invalid_force() {
+		wp_set_current_user( $this->admin_id );
+		$tag = wp_insert_term( 'test-tag', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request['force'] = true;
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
 	}
 
 	public function test_delete_item_invalid_permission() {
@@ -211,7 +222,6 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
-		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -223,7 +233,6 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
-		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
@@ -235,7 +244,6 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
-		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
@@ -247,7 +255,6 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
-		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );


### PR DESCRIPTION
Default the `force` param to false, and only display error about not supporting true if it is explicitly set. 

Fixes #1522 and #1512