### PR TITLE
Don't link everything with rest_get_url_prefix() to the API.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -290,7 +290,7 @@ add_action( 'init', 'rest_api_init' );
  */
 function rest_api_register_rewrites() {
 	add_rewrite_rule( '^' . rest_get_url_prefix() . '/?$','index.php?rest_route=/','top' );
-	add_rewrite_rule( '^' . rest_get_url_prefix() . '(.*)?','index.php?rest_route=$matches[1]','top' );
+	add_rewrite_rule( '^' . rest_get_url_prefix() . '/(.*)?','index.php?rest_route=/$matches[1]','top' );
 }
 
 /**


### PR DESCRIPTION
Currently when you have a page with the slug wp-json-info it will show the API instead of the page.