### PR TITLE
Add `post_count` field in users response

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -460,6 +460,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'slug'               => $user->user_nicename,
 			'url'                => $user->user_url,
 			'username'           => $user->user_login,
+			'posts_count'        => count_user_posts($user->ID),
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'embed';


### PR DESCRIPTION
Add number of posts the user [author] has published in the json response of `prepare_item_for_response` in class `wp-rest-users-controller`.