### PR TITLE
Docs/hooks plugin php

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -372,7 +372,7 @@ function rest_api_loaded() {
 	 * This filter allows you to adjust the server class used by the API, using a
 	 * different class to handle requests.
 	 *
-	 * @param string $class_name The name of the server class.
+	 * @param string $class_name The name of the server class. Default 'WP_REST_Server'.
 	 */
 	$wp_rest_server_class = apply_filters( 'wp_rest_server_class', 'WP_REST_Server' );
 	$wp_rest_server = new $wp_rest_server_class;

--- a/plugin.php
+++ b/plugin.php
@@ -366,7 +366,14 @@ function rest_api_loaded() {
 	/** @var WP_REST_Server $wp_rest_server */
 	global $wp_rest_server;
 
-	// Allow for a plugin to insert a different class to handle requests.
+	/**
+	 * Filter the REST Server Class.
+	 *
+	 * This filter allows you to adjust the server class used by the API, using a
+	 * different class to handle requests.
+	 *
+	 * @param string $class_name The name of the server class.
+	 */
 	$wp_rest_server_class = apply_filters( 'wp_rest_server_class', 'WP_REST_Server' );
 	$wp_rest_server = new $wp_rest_server_class;
 
@@ -442,9 +449,7 @@ register_deactivation_hook( __FILE__, 'rest_api_deactivation' );
  */
 function rest_get_url_prefix() {
 	/**
-	 * Filter the rest URL prefix.
-	 *
-	 * @since 1.0
+	 * Filter the REST URL prefix.
 	 *
 	 * @param string $prefix URL prefix. Default 'wp-json'.
 	 */
@@ -480,7 +485,7 @@ function get_rest_url( $blog_id = null, $path = '/', $scheme = 'json' ) {
 	/**
 	 * Filter the REST URL.
 	 *
-	 * @since 1.0
+	 * Use this filter to adjust the url returned by the `get_rest_url` function.
 	 *
 	 * @param string $url     REST URL.
 	 * @param string $path    REST route.


### PR DESCRIPTION
See 
https://github.com/WP-API/WP-API/issues/1549

* add missing hook docs
* remove use of @since, not used elsewhere
* fix typo rest->REST

Reviewed:
* plugin.php:370:	$wp_rest_server_class = apply_filters(
'wp_rest_server_class', 'WP_REST_Server' );
* plugin.php:382:	do_action( 'rest_api_init', $wp_rest_server );
* plugin.php:451:	return apply_filters( 'rest_url_prefix', 'wp-json' );
* plugin.php:490:	return apply_filters( 'rest_url', $url, $path,
$blog_id, $scheme );