### PR TITLE
Hook Docs for lib/endpoints/class-wp-rest-users-controller.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.lock
 node_modules
 vendor
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 composer.lock
 node_modules
 vendor
-
-.idea/

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -238,12 +238,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a user is created via the REST API.
 		 *
-		 * @param object          $user    Data used to create the user (not a WP_User object).
-		 * @param WP_REST_Request $request Request object.
-		 * @param bool            $bool    A boolean that is false.
-		 * @todo remove final bool = false variable, unused?
+		 * @param object          $user      Data used to create the user (not a WP_User object).
+		 * @param WP_REST_Request $request   Request object.
+		 * @param bool            $creating  True when creating user, false when updating user.
 		 */
-		do_action( 'rest_insert_user', $user, $request, false );
+		do_action( 'rest_insert_user', $user, $request, true );
 
 		$response = $this->get_item( array(
 			'id'      => $user_id,
@@ -304,13 +303,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a user is updated via the REST API.
 		 *
-		 * @param object          $user    Data used to update the user (not a WP_User object).
-		 * @param WP_REST_Request $request Request object.
-		 * @param bool            $bool    A boolean that is false.
-		 * @todo remove final bool = false variable, unused?
+		 * @param object          $user      Data used to update the user (not a WP_User object).
+		 * @param WP_REST_Request $request   Request object.
+		 * @param bool            $bool      A boolean that is false.
+		 * @param bool            $creating  True when creating user, false when updating user.
 		 */
-		do_action( 'rest_update_user', $user, $request, false );
-
+		do_action( 'rest_insert_user', $user, $request, false );
 		$response = $this->get_item( array(
 			'id'      => $user_id,
 			'context' => 'edit',

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -99,11 +99,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		/**
-		 * Filter arguments, before passing to WP_User_Query, when querying users via the REST API
+		 * Filter arguments, before passing to WP_User_Query, when querying users via the REST API.
 		 *
 		 * @see https://codex.wordpress.org/Class_Reference/WP_User_Query
-		 * @param array $prepared_args Arguments for WP_User_Query
-		 * @param WP_REST_Request $request The current request
+		 *
+		 * @param array           $prepared_args Array of arguments for WP_User_Query.
+		 * @param WP_REST_Request $request       The current request.
 		 */
 		$prepared_args = apply_filters( 'rest_user_query', $prepared_args, $request );
 
@@ -235,11 +236,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$this->update_additional_fields_for_object( $user, $request );
 
 		/**
-		 * Fires after a user is created via the REST API
+		 * Fires after a user is created via the REST API.
 		 *
-		 * @param object $user Data used to create user (not a WP_User object)
+		 * @param object          $user    Data used to create the user (not a WP_User object).
 		 * @param WP_REST_Request $request Request object.
-		 * @param bool $bool A boolean that is false.
+		 * @param bool            $bool    A boolean that is false.
+		 * @todo remove final bool = false variable, unused?
 		 */
 		do_action( 'rest_insert_user', $user, $request, false );
 
@@ -299,7 +301,15 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$this->update_additional_fields_for_object( $user, $request );
 
-		do_action( 'rest_insert_user', $user, $request, false );
+		/**
+		 * Fires after a user is updated via the REST API.
+		 *
+		 * @param object          $user    Data used to update the user (not a WP_User object).
+		 * @param WP_REST_Request $request Request object.
+		 * @param bool            $bool    A boolean that is false.
+		 * @todo remove final bool = false variable, unused?
+		 */
+		do_action( 'rest_update_user', $user, $request, false );
 
 		$response = $this->get_item( array(
 			'id'      => $user_id,
@@ -473,11 +483,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$data->add_links( $this->prepare_links( $user ) );
 
 		/**
-		 * Filter user data before returning via the REST API
+		 * Filter user data returned from the REST API.
 		 *
-		 * @param WP_REST_Response $data Response data
-		 * @param object $user User object used to create response
-		 * @param WP_REST_Request $request Request object.
+		 * @param WP_REST_Response $data    Response data.
+		 * @param object           $user    User object used to create response.
+		 * @param WP_REST_Request  $request Request object.
 		 */
 		return apply_filters( 'rest_prepare_user', $data, $user, $request );
 	}
@@ -551,10 +561,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		/**
-		 * Filter user data before inserting user via REST API
+		 * Filter user data before inserting user via the REST API.
 		 *
-		 * @param object $prepared_user User object.
-		 * @param WP_REST_Request $request Request object.
+		 * @param object          $prepared_user User object.
+		 * @param WP_REST_Request $request       Request object.
 		 */
 		return apply_filters( 'rest_pre_insert_user', $prepared_user, $request );
 	}

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -236,7 +236,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$this->update_additional_fields_for_object( $user, $request );
 
 		/**
-		 * Fires after a user is created via the REST API.
+		 * Fires after a user is created or updated via the REST API.
 		 *
 		 * @param object          $user      Data used to create the user (not a WP_User object).
 		 * @param WP_REST_Request $request   Request object.
@@ -300,14 +300,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$this->update_additional_fields_for_object( $user, $request );
 
-		/**
-		 * Fires after a user is updated via the REST API.
-		 *
-		 * @param object          $user      Data used to update the user (not a WP_User object).
-		 * @param WP_REST_Request $request   Request object.
-		 * @param bool            $bool      A boolean that is false.
-		 * @param bool            $creating  True when creating user, false when updating user.
-		 */
+		/* This action is documented in lib/endpoints/class-wp-rest-users-controller.php */
 		do_action( 'rest_insert_user', $user, $request, false );
 		$response = $this->get_item( array(
 			'id'      => $user_id,


### PR DESCRIPTION
See https://github.com/WP-API/WP-API/issues/1549.

* Add some missing hook docs
* Spacing, punctuation cleanup as per standard
* Change second do_action from `rest_insert_user` to `rest_update_user` as
its in the update function
* added some todo notes, I don’t understand what the final false
variable is for, maybe its needed?