### PR TITLE
Modify get_endpoint_args_for_item_schema to handle required/default

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'methods'  => WP_REST_Server::CREATABLE,
 				'callback' => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'     => $this->get_endpoint_args_for_item_schema( true ),
+				'args'     => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -43,7 +43,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'methods'  => WP_REST_Server::EDITABLE,
 				'callback' => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'     => $this->get_endpoint_args_for_item_schema( false ),
+				'args'     => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 			array(
 				'methods'  => WP_REST_Server::DELETABLE,

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -443,7 +443,7 @@ abstract class WP_REST_Controller {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $parameter, 'integer' ) );
 		}
 
-		if ( 'string' === $property['type']&& ! is_string( $value ) ) {
+		if ( 'string' === $property['type'] && ! is_string( $value ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $parameter, 'string' ) );
 		}
 

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -365,7 +365,7 @@ abstract class WP_REST_Controller {
 	 *                           Where as create requests will.
 	 * @return array
 	 */
-	public function get_endpoint_args_for_item_schema( $add_required_flag = true ) {
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
 		$schema                = $this->get_item_schema();
 		$schema_properties     = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
@@ -383,16 +383,22 @@ abstract class WP_REST_Controller {
 				'sanitize_callback' => array( $this, 'sanitize_schema_property' ),
 			);
 
-			if ( isset( $params['default'] ) ) {
+			if ( WP_REST_Server::CREATABLE && isset( $params['default'] ) ) {
 				$endpoint_args[ $field_id ]['default'] = $params['default'];
 			}
 
-			if ( $add_required_flag && ! empty( $params['required'] ) ) {
+			if ( WP_REST_Server::CREATABLE && ! empty( $params['required'] ) ) {
 				$endpoint_args[ $field_id ]['required'] = true;
 			}
 
 			// Merge in any options provided by the schema property
 			if ( isset( $params['arg_options'] ) ) {
+
+				// Only use required / default from arg_options on CREATE endpoints
+				if ( $method !== WP_REST_Server::CREATABLE ) {
+					$params['arg_options'] = array_diff_key( $params['arg_options'], array( 'required' => '', 'default' => '' ) );
+				}
+
 				$endpoint_args[ $field_id ] = array_merge( $endpoint_args[ $field_id ], $params['arg_options'] );
 			}
 		}

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -383,19 +383,19 @@ abstract class WP_REST_Controller {
 				'sanitize_callback' => array( $this, 'sanitize_schema_property' ),
 			);
 
-			if ( WP_REST_Server::CREATABLE && isset( $params['default'] ) ) {
+			if ( WP_REST_Server::CREATABLE === $method && isset( $params['default'] ) ) {
 				$endpoint_args[ $field_id ]['default'] = $params['default'];
 			}
 
-			if ( WP_REST_Server::CREATABLE && ! empty( $params['required'] ) ) {
+			if ( WP_REST_Server::CREATABLE === $method && ! empty( $params['required'] ) ) {
 				$endpoint_args[ $field_id ]['required'] = true;
 			}
 
-			// Merge in any options provided by the schema property
+			// Merge in any options provided by the schema property.
 			if ( isset( $params['arg_options'] ) ) {
 
-				// Only use required / default from arg_options on CREATE endpoints
-				if ( $method !== WP_REST_Server::CREATABLE ) {
+				// Only use required / default from arg_options on CREATABLE endpoints.
+				if ( WP_REST_Server::CREATABLE !== $method ) {
 					$params['arg_options'] = array_diff_key( $params['arg_options'], array( 'required' => '', 'default' => '' ) );
 				}
 

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -360,10 +360,12 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get an array of endpoint arguments from the item schema for the controller.
 	 *
-	 * @param $add_required_flag Whether to use the 'required' flag from the schema proprties.
-	 *                           This is because update requests will not have any required params
-	 *                           Where as create requests will.
-	 * @return array
+	 * @param string $method HTTP method of the request. The arguments
+	 *                       for `CREATABLE` requests are checked for required
+	 *                       values and may fall-back to a given default, this
+	 *                       is not done on `EDITABLE` requests. Default is
+	 *                       WP_REST_Server::CREATABLE.
+	 * @return array $endpoint_args
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
@@ -373,7 +375,7 @@ abstract class WP_REST_Controller {
 
 		foreach ( $schema_properties as $field_id => $params ) {
 
-			// Anything marked as readonly should not be a arg
+			// Arguments specified as `readonly` are not allowed to be set.
 			if ( ! empty( $params['readonly'] ) ) {
 				continue;
 			}

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -50,7 +50,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( true ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -41,7 +41,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::CREATABLE,
 				'callback'        => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'            => $this->get_endpoint_args_for_item_schema( true ),
+				'args'            => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -61,7 +61,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::EDITABLE,
 				'callback'        => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'            => $this->get_endpoint_args_for_item_schema( false ),
+				'args'            => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 			array(
 				'methods'  => WP_REST_Server::DELETABLE,

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -32,7 +32,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'     => WP_REST_Server::CREATABLE,
 				'callback'    => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'        => $this->get_endpoint_args_for_item_schema( true ),
+				'args'        => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -47,7 +47,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'    => WP_REST_Server::EDITABLE,
 				'callback'   => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'        => $this->get_endpoint_args_for_item_schema( false ),
+				'args'        => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 			array(
 				'methods'    => WP_REST_Server::DELETABLE,

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -21,7 +21,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::CREATABLE,
 				'callback'        => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( true ), array(
+				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
 					'password'    => array(
 						'required' => true,
 					),
@@ -45,7 +45,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::EDITABLE,
 				'callback'        => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( false ), array(
+				'args'            => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), array(
 					'password'    => array(),
 				) ),
 			),

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -608,6 +608,33 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 1, $updated->comment_approved );
 	}
 
+	public function test_update_comment_field_does_not_use_default_values() {
+		wp_set_current_user( $this->admin_id );
+
+		$comment_id = $this->factory->comment->create( array(
+			'comment_approved' => 0,
+			'comment_post_ID'  => $this->post_id,
+			'comment_content'  => 'some content'
+		));
+
+		$params = array(
+			'status' => 'approve',
+		);
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = $this->server->dispatch( $request );
+		$response = rest_ensure_response( $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$comment = $response->get_data();
+		$updated = get_comment( $comment_id );
+		$this->assertEquals( 'approved', $comment['status'] );
+		$this->assertEquals( 1, $updated->comment_approved );
+		$this->assertEquals( 'some content', $updated->comment_content );
+	}
+
 	public function test_update_comment_date_gmt() {
 		wp_set_current_user( $this->admin_id );
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -614,7 +614,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$comment_id = $this->factory->comment->create( array(
 			'comment_approved' => 0,
 			'comment_post_ID'  => $this->post_id,
-			'comment_content'  => 'some content'
+			'comment_content'  => 'some content',
 		));
 
 		$params = array(


### PR DESCRIPTION
Now get_endpoint_args_for_item_schema() will take a $method param which is used to determin if the endpoint args should include the `required` and `default` parameters.

We could have potentially handled this at the WP_REST_Server level, however the "incorrect" part here is generating the args from the schema. `get_endpoint_args_for_item_schema` is really shorthand for writing out the args for the endpoint - in the case we were writing those by hand, we wouldn't be passing `default` and `required` in the case of `EDITABLE` endpoint args.