### PR TITLE
Docs/hooks lib endpoints class wp rest terms controller php

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -445,9 +445,9 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 *
 		 * Allows modification of the term data right before it is returned.
 		 *
-		 * @param array $data     Key value array of term data.
-		 * @param obj   $item     The term object.
-		 * @param WP_REST_Request $request Request used to generate the response.
+		 * @param array           $data     Key value array of term data.
+		 * @param object          $item     The term object.
+		 * @param WP_REST_Request $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_term', $data, $item, $request );
 	}

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -440,6 +440,15 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$data->add_links( $this->prepare_links( $item ) );
 
+		/**
+		 * Filter a term item returned from the API.
+		 *
+		 * Allows modification of the term data right before it is returned.
+		 *
+		 * @param array $data     Key value array of term data.
+		 * @param obj   $item     The term object.
+		 * @param WP_REST_Request $request Request used to generate the response.
+		 */
 		return apply_filters( 'rest_prepare_term', $data, $item, $request );
 	}
 

--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -415,7 +415,7 @@ class WP_REST_Server {
 	/**
 	 * Get links from a response.
 	 *
-	 * Extracts the links from a reponse into a structured hash, suitable for
+	 * Extracts the links from a response into a structured hash, suitable for
 	 * direct output.
 	 *
 	 * @param WP_REST_Response $response Response to extract links from.


### PR DESCRIPTION
*  Ad hook docs for lib/endpoints/class-wp-rest-terms-controller.php
* Unrelated typo fix 'reponse'->'response' in lib/infrastructure/class-wp-rest-server.php

See https://github.com/WP-API/WP-API/issues/1549