### PR TITLE
Docs/hooks lib endpoints class wp rest comments controller php

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -168,6 +168,15 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment['comment_agent'] = '';
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
+
+		/**
+		 * Filter a comment before it is inserted via the REST API.
+		 *
+		 * Allows modification of the comment right before it is inserted via `wp_insert_comment`.
+		 *
+		 * @param array           $prepared_comment The prepared comment data for `wp_insert_comment`.
+		 * @param WP_REST_Request $request          Request used to insert the comment.
+		 */
 		$prepared_comment = apply_filters( 'rest_pre_insert_comment', $prepared_comment, $request );
 
 		$comment_id = wp_insert_comment( $prepared_comment );
@@ -261,11 +270,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_comment_invalid_id', __( 'Invalid comment ID.' ), array( 'status' => 404 ) );
 		}
 
+
 		/**
-		 * Filter whether the comment type supports trashing.
+		 * Filter whether a comment is trashable.
 		 *
-		 * @param boolean $supports_trash Does the comment type support trashing?
-		 * @param stdClass $comment Comment we're attempting to trash.
+		 * Return false to disable trash support for the post.
+		 *
+		 * @param boolean $supports_trash Whether the post type support trashing.
+		 * @param WP_Post $comment        The comment object being considered for trashing support.
 		 */
 		$supports_trash = apply_filters( 'rest_comment_type_trashable', ( EMPTY_TRASH_DAYS > 0 ), $comment );
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -168,7 +168,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment['comment_agent'] = '';
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
-
 		/**
 		 * Filter a comment before it is inserted via the REST API.
 		 *
@@ -269,7 +268,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( empty( $comment ) ) {
 			return new WP_Error( 'rest_comment_invalid_id', __( 'Invalid comment ID.' ), array( 'status' => 404 ) );
 		}
-
 
 		/**
 		 * Filter whether a comment is trashable.

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -279,7 +279,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		 * @param boolean $supports_trash Whether the post type support trashing.
 		 * @param WP_Post $comment        The comment object being considered for trashing support.
 		 */
-		$supports_trash = apply_filters( 'rest_comment_type_trashable', ( EMPTY_TRASH_DAYS > 0 ), $comment );
+		$supports_trash = apply_filters( 'rest_comment_trashable', ( EMPTY_TRASH_DAYS > 0 ), $comment );
 
 		$get_request = new WP_REST_Request( 'GET', rest_url( '/wp/v2/comments/' . $id ) );
 		$get_request->set_param( 'context', 'edit' );


### PR DESCRIPTION
Add doc block for `rest_pre_insert_comment`

See: https://github.com/WP-API/WP-API/issues/1549

Note: Changed hook name from `rest_comment_type_trashable` to `rest_comment_trashable` as type is not part of context. Am I missing something? Made similar change in post hood doc PR.