### PR TITLE
Amends PHPDoc and removes unneeded stuff in wp-api.js

### DIFF
--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -164,7 +164,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare the revision for the REST response
 	 *
-	 * @param mixed $item WordPress representation of the revision.
+	 * @param WP_Post $post Post revision object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */

--- a/wp-api.js
+++ b/wp-api.js
@@ -34,9 +34,6 @@
 		};
 	}
 
-
-	var origParse = Date.parse;
-
 	/**
 	 * Parse date into ISO8601 format
 	 * 
@@ -45,7 +42,7 @@
 	wp.api.utils.parseISO8601 = function( date ) {
 		var timestamp, struct, i, k,
 			minutesOffset = 0,
-			numericKeys = [ 1, 4, 5, 6, 7, 10, 11 ];;
+			numericKeys = [ 1, 4, 5, 6, 7, 10, 11 ];
 
 		// ES5 §15.9.4.2 states that the string should attempt to be parsed as a Date Time String Format string
 		// before falling back to any implementation-specific date parsing, so that’s what we do, even if native


### PR DESCRIPTION
- Amends PHPDoc for $item parameter in prepare_item_for_response method of WP_REST_Revisions_Controller class.

- Removes unnecessary semicolon in wp-api.js

- Removes unused variable origParse in wp-api.js. Seems this was used to keep a copy of original parse method, but in wp-api.js parse is not replaced so this not necessary.