### PR TITLE
Add the embed context to Users collection query params

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -752,7 +752,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$query_params['context'] = array(
 			'default'            => 'view',
 			'description'        => 'Change the response format based on request context.',
-			'enum'               => array( 'view', 'edit' ),
+			'enum'               => array( 'embed', 'view', 'edit' ),
 			'sanitize_callback'  => 'sanitize_key',
 			'type'               => 'string',
 		);


### PR DESCRIPTION
The default context for a single user request is `embed`.  Whereas the default context for the users collection is `view`.  

This just adds the `embed` context as a specified option for users collection requests.