### PR TITLE
Remove unused `$supported` methods variable

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -829,7 +829,6 @@ class WP_REST_Server {
 		foreach ( $this->get_routes() as $route => $handlers ) {
 			foreach ( $handlers as $handler ) {
 				$callback  = $handler['callback'];
-				$supported = $handler['methods'];
 				$response = null;
 
 				if ( empty( $handler['methods'][ $method ] ) ) {


### PR DESCRIPTION
In 6388ce46530bfb2, logic was changed to rely on the handler data
directly. The capture of supported methods into a local variable
is no longer necessary.