### PR TITLE
Fix misspelling of since tag in `WP_Rest_Server` docs

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -168,7 +168,7 @@ class WP_REST_Server {
 	/**
 	 * Instantiates the REST server.
 	 *
-	 * @sincd 4.4.0
+	 * @since 4.4.0
 	 * @access public
 	 */
 	public function __construct() {


### PR DESCRIPTION
s/sincd/since/