### PR TITLE
Correct methods in WP_REST_SERVER::EDITABLE description

### DIFF
--- a/lib/infrastructure/class-wp-rest-server.php
+++ b/lib/infrastructure/class-wp-rest-server.php
@@ -74,7 +74,7 @@ class WP_REST_Server {
 	const CREATABLE = 'POST';
 
 	/**
-	 * Alias for GET, PUT, PATCH transport methods together.
+	 * Alias for POST, PUT, PATCH transport methods together.
 	 *
 	 * @since 4.4.0
 	 * @var string


### PR DESCRIPTION
`EDITABLE` is an alias for POST, PUT, and PATCH, not GET