### PR TITLE
Add Terms Controller Collection Args Details

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -615,7 +615,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$query_params['parent'] = array(
 				'description'        => 'Limit result set to terms assigned to a specific parent term.',
 				'type'               => 'integer',
-				'sanitize_callback'  => 'absint',
 			);
 		}
 		return $query_params;

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -564,11 +564,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
-		$query_params['order'] = array(
-			'description'        => 'Order sort attribute ascending or descending.',
-			'type'               => 'string',
-			'default'            => 'asc',
-			'enum'               => array( 'asc', 'desc' ),
+		$query_params['order']      = array(
+			'description'           => 'Order sort attribute ascending or descending.',
+			'type'                  => 'string',
+			'sanitize_callback'     => 'sanitize_key',
+			'default'               => 'asc',
+			'enum'                  => array( 'asc', 'desc' ),
 		);
 		$query_params['orderby'] = array(
 			'description'        => 'Sort collection by object attribute.',

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -603,7 +603,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$query_params['hide_empty'] = array(
 			'description'           => 'Whether to hide terms not assigned to any posts.',
 			'type'                  => 'boolean',
-			'default'               => true,
+			'default'               => false,
 		);
 		$query_params['search']     = array(
 			'description'           => 'Search keyword.',

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -571,14 +571,19 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'default'               => 'asc',
 			'enum'                  => array( 'asc', 'desc' ),
 		);
-		$query_params['orderby'] = array(
-			'description'        => 'Sort collection by object attribute.',
-			'type'               => 'string',
-			'default'            => 'name',
-			'enum'               => array(
+		$query_params['orderby']    = array(
+			'description'           => 'Sort collection by object attribute.',
+			'type'                  => 'string',
+			'sanitize_callback'     => 'sanitize_key',
+			'default'               => 'name',
+			'enum'                  => array(
 				'id',
 				'name',
 				'slug',
+				'term_group',
+				'term_id',
+				'description',
+				'count',
 			),
 		);
 		$query_params['per_page']   = array(

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -66,13 +66,15 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_items( $request ) {
-		$prepared_args = array( 'hide_empty' => false );
+		$prepared_args = array(
+			'order'      => $request['order'],
+			'orderby'    => $request['orderby'],
+			'hide_empty' => $request['hide_empty'],
+			'number'     => $request['per_page'],
+			'search'     => $request['search'],
+		);
 
-		$prepared_args['number']  = $request['per_page'];
 		$prepared_args['offset']  = ( $request['page'] - 1 ) * $prepared_args['number'];
-		$prepared_args['search']  = $request['search'];
-		$prepared_args['order']   = $request['order'];
-		$prepared_args['orderby'] = $request['orderby'];
 
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy_obj->hierarchical && isset( $request['parent'] ) ) {

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -566,12 +566,25 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
+		$query_params['context'] = array(
+			'description'        => 'Change the response format based on request context.',
+			'default'            => 'view',
+			'sanitize_callback'  => 'sanitize_key',
+			'type'               => 'string',
+			'enum'               => array(
+				'embed',
+				'view',
+			),
+		);
 		$query_params['order']      = array(
 			'description'           => 'Order sort attribute ascending or descending.',
 			'type'                  => 'string',
 			'sanitize_callback'     => 'sanitize_key',
 			'default'               => 'asc',
-			'enum'                  => array( 'asc', 'desc' ),
+			'enum'                  => array(
+				'asc',
+				'desc',
+			),
 		);
 		$query_params['orderby']    = array(
 			'description'           => 'Sort collection by object attribute.',

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -580,6 +580,28 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'slug',
 			),
 		);
+		$query_params['per_page']   = array(
+			'description'           => 'Number of terms to query at a time with pagination.',
+			'type'                  => 'integer',
+			'sanitize_callback'     => 'absint',
+			'default'               => 10,
+		);
+		$query_params['page']     = array(
+			'description'           => 'Number of the desired page within the paginated query results.',
+			'type'                  => 'integer',
+			'sanitize_callback'     => 'absint',
+			'default'               => 1,
+		);
+		$query_params['hide_empty'] = array(
+			'description'           => 'Whether to hide terms not assigned to any posts.',
+			'type'                  => 'boolean',
+			'default'               => true,
+		);
+		$query_params['search']     = array(
+			'description'           => 'Search keyword.',
+			'type'                  => 'string',
+			'sanitize_callback'     => 'sanitize_text_field',
+		);
 		$taxonomy = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy->hierarchical ) {
 			$query_params['parent'] = array(

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -32,6 +32,20 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->check_get_taxonomy_terms_response( $response );
 	}
 
+	public function test_get_items_hide_empty_arg() {
+		$post_id = $this->factory->post->create();
+		$tag1 = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
+		$tag2 = $this->factory->tag->create( array( 'name' => 'The Be Sharps' ) );
+		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request->set_param( 'hide_empty', true );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( 'Season 5', $data[0]['name'] );
+		$this->assertEquals( 'The Be Sharps', $data[1]['name'] );
+	}
+
 	public function test_get_items_orderby_args() {
 		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
 		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );


### PR DESCRIPTION
 * Add missing collection args details to the Terms Controller
     * fill-in details for the `per_page`, `page`, `hide_empty`, and `search` args that are already handled in the get_items method
     * add a `sanitize_callback` to the `order` arg
     * add a `sanitize_callback` and add missing valid values to the enum array for the `orderby` arg
 * Don't hardcode the `hide_empty` collection arg to being false in `get_items` method
    
