### PR TITLE
Switch to register_post_type_args filter.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -180,26 +180,32 @@ function register_api_field( $object_type, $attribute, $args = array() ) {
  * These attributes will eventually be committed to core.
  *
  * @since 4.4.0
- *
- * @global array $wp_post_types Registered post types.
+ * 
+ * @param array  $args      Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
  */
-function _add_extra_api_post_type_arguments() {
-	global $wp_post_types;
+function _add_extra_api_post_type_arguments( $args, $post_type ) {
+	if ( 'post' === $post_type ) {
+		$args['show_in_rest'] = true;
+		$args['rest_base'] = 'posts';
+		$args['rest_controller_class'] = 'WP_REST_Posts_Controller';
+	}
 
-	$wp_post_types['post']->show_in_rest = true;
-	$wp_post_types['post']->rest_base = 'posts';
-	$wp_post_types['post']->rest_controller_class = 'WP_REST_Posts_Controller';
+	if ( 'page' === $post_type ) {
+		$args['show_in_rest'] = true;
+		$args['rest_base'] = 'pages';
+		$args['rest_controller_class'] = 'WP_REST_Posts_Controller';
+	}
 
-	$wp_post_types['page']->show_in_rest = true;
-	$wp_post_types['page']->rest_base = 'pages';
-	$wp_post_types['page']->rest_controller_class = 'WP_REST_Posts_Controller';
+	if ( 'attachment' === $post_type ) {
+		$args['show_in_rest'] = true;
+		$args['rest_base'] = 'media';
+		$args['rest_controller_class'] = 'WP_REST_Attachments_Controller';
+	}
 
-	$wp_post_types['attachment']->show_in_rest = true;
-	$wp_post_types['attachment']->rest_base = 'media';
-	$wp_post_types['attachment']->rest_controller_class = 'WP_REST_Attachments_Controller';
-
+	return $args;
 }
-add_action( 'init', '_add_extra_api_post_type_arguments', 11 );
+add_filter( 'register_post_type_args', '_add_extra_api_post_type_arguments', 10, 2 );
 
 /**
  * Adds extra taxonomy registration arguments.

--- a/plugin.php
+++ b/plugin.php
@@ -180,7 +180,7 @@ function register_api_field( $object_type, $attribute, $args = array() ) {
  * These attributes will eventually be committed to core.
  *
  * @since 4.4.0
- * 
+ *
  * @param array  $args      Array of arguments for registering a post type.
  * @param string $post_type Post type key.
  */

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -251,6 +251,24 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
 	}
 
+	public function test_add_extra_api_post_type_arguments() {
+
+		$post_type = get_post_type_object( 'post' );
+		$this->assertTrue( $post_type->show_in_rest );
+		$this->assertEquals( 'posts', $post_type->rest_base );
+		$this->assertEquals( 'WP_REST_Posts_Controller', $post_type->rest_controller_class );
+
+		$post_type = get_post_type_object( 'page' );
+		$this->assertTrue( $post_type->show_in_rest );
+		$this->assertEquals( 'pages', $post_type->rest_base );
+		$this->assertEquals( 'WP_REST_Posts_Controller', $post_type->rest_controller_class );
+
+		$post_type = get_post_type_object( 'attachment' );
+		$this->assertTrue( $post_type->show_in_rest );
+		$this->assertEquals( 'media', $post_type->rest_base );
+		$this->assertEquals( 'WP_REST_Attachments_Controller', $post_type->rest_controller_class );
+	}
+
 	/**
 	 * The get_rest_url function should return a URL consistently terminated with a "/",
 	 * whether the blog is configured with pretty permalink support or not.


### PR DESCRIPTION
WordPress 4.4 includes a 'register_post_type_args' filter
which can be used instead of directly modifying the global.
Previously, the function was hooked to `init` with a
priority of 11, but it is now set to 10 on the new filter.

Added unit tests to confirm the arguments are added
to each type.

Fixes #1588.