### PR TITLE
Adding Unit Tests for the `rest_url` and `rest_url_prefix` filters

### DIFF
--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -312,4 +312,36 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		return 'non-standard-prefix';
 	}
 
+	/**
+	 * Testing the `rest_url` filter
+	 *
+	 */
+	public function test_rest_url_filter() {
+
+		//test the default output
+		$this->assertSame( 'http://example.org/?rest_route=/', get_rest_url() );
+
+		//filtered
+		add_filter( 'rest_url', array( $this, 'rest_url_callback' ), 10, 4 );
+		$this->assertSame( 'http://v2.wp-api.org/?rest_route=/', get_rest_url() );
+
+		//clean up
+		remove_filter( 'rest_url', array( $this, 'rest_url_callback' ), 10, 4 );
+
+	}
+
+	/**
+	 * Callback for the rest_url filter.
+	 *
+	 * @param $url
+	 * @param $path
+	 * @param $blog_id
+	 * @param $scheme
+	 *
+	 * @return string
+	 */
+	public function rest_url_callback( $url, $path, $blog_id, $scheme ) {
+		return 'http://v2.wp-api.org/?rest_route=/';
+	}
+
 }

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -282,4 +282,31 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		update_option( 'permalink_structure', '' );
 		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/?rest_route=/', get_rest_url() );
 	}
+
+
+	/**
+	 * Testing the `rest_url_prefix` filter.
+	 *
+	 */
+	public function test_rest_get_url_prefix( ) {
+
+		//standard test
+		$this->assertSame( 'wp-json', rest_get_url_prefix() );
+
+		//filtered
+		add_filter( 'rest_url_prefix', array( $this, 'rest_url_prefix_callback' ) );
+		$this->assertSame( 'non-standard-prefix', rest_get_url_prefix() );
+	}
+
+	/**
+	 * Callback for the `rest_url_prefix` tests.
+	 *
+	 * @param $default_value
+	 *
+	 * @return string
+	 */
+	public function rest_url_prefix_callback( $default_value ) {
+		return 'non-standard-prefix';
+	}
+
 }

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -296,6 +296,9 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 		//filtered
 		add_filter( 'rest_url_prefix', array( $this, 'rest_url_prefix_callback' ) );
 		$this->assertSame( 'non-standard-prefix', rest_get_url_prefix() );
+
+		//run clean up for the filter
+		remove_filter( 'rest_url_prefix', array( $this, 'rest_url_prefix_callback' ) );
 	}
 
 	/**


### PR DESCRIPTION
I'd like to contribute some Unit Tests to the project based on https://github.com/WP-API/WP-API/issues/1549#issuecomment-141571410. I am new to the project so any direction is greatly appreciated as to expected location of tests or formatting etc.