### PR TITLE
Add license in package.json, bump phplint package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-api",
   "version": "0.0.0",
-  "license" : "GPL-2.0",
+  "license" : "GPL-2.0+",
   "repository": {
     "type": "git",
     "url": "https://github.com/WP-API/WP-API.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wp-api",
   "version": "0.0.0",
+  "license" : "GPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/WP-API/WP-API.git"
@@ -10,6 +11,6 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-phpcs": "^0.4.0",
-    "phplint": "^1.2.0"
+    "phplint": "^1.6.1"
   }
 }


### PR DESCRIPTION
Ran `grunt phplint` before and after upgrading package and output remains the same (no linting errors).

GPL-2.0 license added to avoid NPM warning when running NPM install.