### PR TITLE
Update get items to allow filter for users collection

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -80,9 +80,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 
 		$prepared_args = array();
+
 		$prepared_args['order'] = $request['order'];
-		$prepared_args['number'] = $request['per_page'];
-		$prepared_args['offset'] = ( $request['page'] - 1 ) * $prepared_args['number'];
+		$prepared_args['per_page'] = $request['per_page'];
 		$orderby_possibles = array(
 			'id'              => 'ID',
 			'name'            => 'display_name',
@@ -90,6 +90,14 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		);
 		$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
 		$prepared_args['search'] = $request['search'];
+		
+		if ( isset( $request['filter'] ) ) {
+			$prepared_args = array_merge( $prepared_args, $request['filter'] );
+			unset( $prepared_args['filter'] );
+		}
+
+		$prepared_args['number'] = $prepared_args['per_page'];
+		$prepared_args['offset'] = ( $request['page'] - 1 ) * $prepared_args['number'];
 
 		if ( ! current_user_can( 'list_users' ) ) {
 			$prepared_args['has_published_posts'] = true;


### PR DESCRIPTION
Currently filtering users such as ?filter[per_page]=1 does not work, as $request->get_param is matching to ['get']['per_page'] not ['get']['filter']['per_page'] this patch matches the method used to allow filtering in posts. Long term a change to get_param might be a better solution.