### PR TITLE
Fix CORS bug when preflight OPTIONS request sent + Mitigate the Abusing of JSONP with Rosetta Flash

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -721,7 +721,8 @@ function json_send_cors_headers( $value ) {
 		header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
 		header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE' );
 		header( 'Access-Control-Allow-Credentials: true' );
-		header( 'Access-Control-Allow-Headers: origin, content-type, accept, X-WP-Total, X-WP-TotalPages');
+		header( 'Access-Control-Allow-Headers: origin, content-type, accept');
+		header( 'X-Content-Type-Options: nosniff');
 	}
 
 	return $value;

--- a/plugin.php
+++ b/plugin.php
@@ -721,6 +721,7 @@ function json_send_cors_headers( $value ) {
 		header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
 		header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE' );
 		header( 'Access-Control-Allow-Credentials: true' );
+		header( 'Access-Control-Allow-Headers: origin, content-type, accept, X-WP-Total, X-WP-TotalPages');
 	}
 
 	return $value;


### PR DESCRIPTION
## Fix CORS bug when preflight OPTIONS request sent

When app uses "application/json; charset=utf-8" content type when make POST request through CORS. When app use text/plain there are no preflight OPTIONS, but with "application/json; charset=utf-8" it occurs.
Bug is that preflight request finished, but POST not happends; Google Chrome outputs:
Request header field Content-Type is not allowed by Access-Control-Allow-Headers.

More Info:
- http://stackoverflow.com/questions/12630231/how-do-cors-and-access-control-allow-headers-work
- Here is described how and when preflight sends: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
## Mitigate the Abusing of JSONP with Rosetta Flash

More info  https://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/ 
