### PR TITLE
Fix failing test

### DIFF
--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -148,6 +148,7 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 	 * The rest_route query variable should be registered.
 	 */
 	function test_rest_route_query_var() {
+		rest_api_init();
 		global $wp;
 		$this->assertTrue( in_array( 'rest_route', $wp->public_query_vars ) );
 	}


### PR DESCRIPTION
Core's test suite began backing up and restoring public and private
query vars in https://core.trac.wordpress.org/changeset/35258/ This
means we need to register our custom query var each time we want to
reference it.