### PR TITLE
Include `media_details` attribute for attachments in embed context

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -246,7 +246,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['media_details'] = array(
 			'description'     => 'Details about the attachment file, specific to its type.',
 			'type'            => 'object',
-			'context'         => array( 'view', 'edit' ),
+			'context'         => array( 'view', 'edit', 'embed' ),
 			'readonly'        => true,
 			);
 		$schema['properties']['post'] = array(

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -333,6 +333,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->check_post_data( $attachment, $data, 'view' );
+		$this->check_post_data( $attachment, $data, 'embed' );
 	}
 
 	public function test_get_item_schema() {
@@ -417,6 +418,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ), $data['alt_text'] );
 		$this->assertEquals( $attachment->post_excerpt, $data['caption'] );
 		$this->assertEquals( $attachment->post_content, $data['description'] );
+		$this->assertTrue( isset( $data['media_details']) );
 
 		if ( $attachment->post_parent ) {
 			$this->assertEquals( $attachment->post_parent, $data['post'] );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -418,7 +418,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ), $data['alt_text'] );
 		$this->assertEquals( $attachment->post_excerpt, $data['caption'] );
 		$this->assertEquals( $attachment->post_content, $data['description'] );
-		$this->assertTrue( isset( $data['media_details']) );
+		$this->assertTrue( isset( $data['media_details'] ) );
 
 		if ( $attachment->post_parent ) {
 			$this->assertEquals( $attachment->post_parent, $data['post'] );


### PR DESCRIPTION
For image attachments, `media_details` includes a `sizes` array of image
sizes, which is useful for templating.

Previously #1582