### PR TITLE
Remove page template from schema

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1529,7 +1529,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$schema['properties']['template'] = array(
 				'description' => 'The theme file to use to display the object.',
 				'type'        => 'string',
-				'enum'        => array_values( get_page_templates() ),
 				'context'     => array( 'view', 'edit' ),
 			);
 		}


### PR DESCRIPTION
This function is no longer available via the API, see https://core.trac.wordpress.org/changeset/35353

Need to work out what to do on https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-posts-controller.php#L892