### PR TITLE
Compat shim for `wp_is_numeric_array()`

### DIFF
--- a/extras.php
+++ b/extras.php
@@ -132,3 +132,23 @@ function rest_get_avatar_url( $email ) {
 
 	return '';
 }
+
+if ( ! function_exists( 'wp_is_numeric_array' ) ) {
+	/**
+	 * Determines if the variable is a numeric-indexed array.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param mixed $data Variable to check.
+	 * @return bool Whether the variable is a list.
+	 */
+	function wp_is_numeric_array( $data ) {
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+
+		$keys = array_keys( $data );
+		$string_keys = array_filter( $keys, 'is_string' );
+		return count( $string_keys ) === 0;
+	}
+}


### PR DESCRIPTION
This function is included in WP 4.4, but we need to maintain support for
4.3