### PR TITLE
Remove admin.php include

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -71,6 +71,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $id;
 		}
 
+		/** Include admin functions to get access to wp_generate_attachment_metadata() */
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $file ) );
 
 		if ( isset( $request['alt_text'] ) ) {

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -890,7 +890,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @param integer $post_id
 	 */
 	public function handle_template( $template, $post_id ) {
-		if ( in_array( $template, array_values( get_page_templates() ) ) ) {
+		if ( in_array( $template, array_keys( wp_get_theme()->get_page_templates( get_post( $post_id ) ) ) ) ) {
 			update_post_meta( $post_id, '_wp_page_template', $template );
 		} else {
 			update_post_meta( $post_id, '_wp_page_template', '' );
@@ -1529,7 +1529,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$schema['properties']['template'] = array(
 				'description' => 'The theme file to use to display the object.',
 				'type'        => 'string',
-				'enum'        => array_values( get_page_templates() ),
+				'enum'        => array_keys( wp_get_theme()->get_page_templates() ),
 				'context'     => array( 'view', 'edit' ),
 			);
 		}

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -583,6 +583,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		// Multisite super admins can freely edit their blog roles -- they possess all caps.
 		if ( ( is_multisite() && current_user_can( 'manage_sites' ) ) || get_current_user_id() !== $user_id || $potential_role->has_cap( 'edit_users' ) ) {
 			// The new role must be editable by the logged-in user.
+
+			/** Include admin functions to get access to get_editable_roles() */
+			require_once ABSPATH . 'wp-admin/includes/admin.php';
+
 			$editable_roles = get_editable_roles();
 			if ( empty( $editable_roles[ $role ] ) ) {
 				return new WP_Error( 'rest_user_invalid_role', __( 'You cannot give users that role.' ), array( 'status' => 403 ) );

--- a/plugin.php
+++ b/plugin.php
@@ -14,9 +14,6 @@ if ( ! defined( 'REST_API_VERSION' ) ) {
 	require_once dirname( __FILE__ ) . '/core/rest-api.php';
 }
 
-/** Include admin functions that are used in the endpoints, such as get_page_templates() */
-require_once ABSPATH . 'wp-admin/includes/admin.php';
-
 /** v1 Compatibility */
 include_once( dirname( __FILE__ ) . '/compatibility-v1.php' );
 

--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,9 @@ if ( ! defined( 'REST_API_VERSION' ) ) {
 	require_once dirname( __FILE__ ) . '/core/rest-api.php';
 }
 
+/** v1 Compatibility */
+include_once( dirname( __FILE__ ) . '/compatibility-v1.php' );
+
 /**
  * WP_REST_Controller class.
  */


### PR DESCRIPTION
As this was removed from core, we hastily added it back, however I dug through all the places where we actually need any functions only loaded in the admin in #1686 and it's not so bad.