### PR TITLE
Add Periods to end comments, @params and @returns

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -14,7 +14,7 @@ abstract class WP_REST_Controller {
 	 * Get a collection of items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response.
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -24,7 +24,7 @@ abstract class WP_REST_Controller {
 	 * Get one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response.
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -34,7 +34,7 @@ abstract class WP_REST_Controller {
 	 * Create one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response.
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function create_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -44,7 +44,7 @@ abstract class WP_REST_Controller {
 	 * Update one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response.
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -54,7 +54,7 @@ abstract class WP_REST_Controller {
 	 * Delete one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response.
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function delete_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -64,7 +64,7 @@ abstract class WP_REST_Controller {
 	 * Check if a given request has access to get items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool.
+	 * @return WP_Error|bool
 	 */
 	public function get_items_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -74,7 +74,7 @@ abstract class WP_REST_Controller {
 	 * Check if a given request has access to get a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool.
+	 * @return WP_Error|bool
 	 */
 	public function get_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -84,7 +84,7 @@ abstract class WP_REST_Controller {
 	 * Check if a given request has access to create items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool.
+	 * @return WP_Error|bool
 	 */
 	public function create_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -94,7 +94,7 @@ abstract class WP_REST_Controller {
 	 * Check if a given request has access to update a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool.
+	 * @return WP_Error|bool
 	 */
 	public function update_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -104,7 +104,7 @@ abstract class WP_REST_Controller {
 	 * Check if a given request has access to delete a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool.
+	 * @return WP_Error|bool
 	 */
 	public function delete_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -114,7 +114,7 @@ abstract class WP_REST_Controller {
 	 * Prepare the item for create or update operation.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_Error|object $prepared_item.
+	 * @return WP_Error|object $prepared_item
 	 */
 	protected function prepare_item_for_database( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -125,7 +125,7 @@ abstract class WP_REST_Controller {
 	 *
 	 * @param mixed $item WordPress representation of the item.
 	 * @param WP_REST_Request $request Request object.
-	 * @return mixed.
+	 * @return mixed
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -154,9 +154,9 @@ abstract class WP_REST_Controller {
 	/**
 	 * Filter a response based on the context defined in the schema.
 	 *
-	 * @param array $data.
-	 * @param string $context.
-	 * @return array.
+	 * @param array $data
+	 * @param string $context
+	 * @return array
 	 */
 	public function filter_response_by_context( $data, $context ) {
 
@@ -188,7 +188,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the item's schema, conforming to JSON Schema.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	public function get_item_schema() {
 		return $this->add_additional_fields_schema( array() );
@@ -197,7 +197,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the item's schema for display / public consumption purposes.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	public function get_public_item_schema() {
 
@@ -215,7 +215,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the query params for collections.
 	 *
-	 * @return array.
+	 * @return array
 	 */
 	public function get_collection_params() {
 		return array(
@@ -242,8 +242,8 @@ abstract class WP_REST_Controller {
 	/**
 	 * Add the values from additional fields to a data object.
 	 *
-	 * @param array  $object.
-	 * @param WP_REST_Request $request.
+	 * @param array  $object
+	 * @param WP_REST_Request $request
 	 * @return array modified object with additional fields.
 	 */
 	protected function add_additional_fields_to_object( $object, $request ) {
@@ -265,8 +265,8 @@ abstract class WP_REST_Controller {
 	/**
 	 * Update the values of additional fields added to a data object.
 	 *
-	 * @param array  $object.
-	 * @param WP_REST_Request $request.
+	 * @param array  $object
+	 * @param WP_REST_Request $request
 	 */
 	protected function update_additional_fields_for_object( $object, $request ) {
 
@@ -320,8 +320,8 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get all the registered additional fields for a given object-type.
 	 *
-	 * @param  string $object_type.
-	 * @return array.
+	 * @param  string $object_type
+	 * @return array
 	 */
 	protected function get_additional_fields( $object_type = null ) {
 
@@ -345,7 +345,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the object type this controller is responsible for managing.
 	 *
-	 * @return string.
+	 * @return string
 	 */
 	protected function get_object_type() {
 		$schema = $this->get_item_schema();
@@ -365,7 +365,7 @@ abstract class WP_REST_Controller {
 	 *                       values and may fall-back to a given default, this
 	 *                       is not done on `EDITABLE` requests. Default is
 	 *                       WP_REST_Server::CREATABLE.
-	 * @return array $endpoint_args.
+	 * @return array $endpoint_args
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
@@ -411,10 +411,10 @@ abstract class WP_REST_Controller {
 	/**
 	 * Validate an parameter value that's based on a property from the item schema.
 	 *
-	 * @param  mixed $value.
-	 * @param  WP_REST_Request $request.
-	 * @param  string $parameter.
-	 * @return WP_Error|bool.
+	 * @param  mixed $value
+	 * @param  WP_REST_Request $request
+	 * @param  string $parameter
+	 * @return WP_Error|bool
 	 */
 	public function validate_schema_property( $value, $request, $parameter ) {
 
@@ -471,10 +471,10 @@ abstract class WP_REST_Controller {
 	/**
 	 * Sanitize an parameter value that's based on a property from the item schema.
 	 *
-	 * @param  mixed $value.
-	 * @param  WP_REST_Request $request.
-	 * @param  string $parameter.
-	 * @return WP_Error|bool.
+	 * @param  mixed $value
+	 * @param  WP_REST_Request $request
+	 * @param  string $parameter
+	 * @return WP_Error|bool
 	 */
 	public function sanitize_schema_property( $value, $request, $parameter ) {
 

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -11,121 +11,121 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Get a collection of items
+	 * Get a collection of items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response.
 	 */
 	public function get_items( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Get one item from the collection
+	 * Get one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response.
 	 */
 	public function get_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Create one item from the collection
+	 * Create one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response.
 	 */
 	public function create_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Update one item from the collection
+	 * Update one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response.
 	 */
 	public function update_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Delete one item from the collection
+	 * Delete one item from the collection.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response.
 	 */
 	public function delete_item( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Check if a given request has access to get items
+	 * Check if a given request has access to get items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return WP_Error|bool.
 	 */
 	public function get_items_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Check if a given request has access to get a specific item
+	 * Check if a given request has access to get a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return WP_Error|bool.
 	 */
 	public function get_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Check if a given request has access to create items
+	 * Check if a given request has access to create items.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return WP_Error|bool.
 	 */
 	public function create_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Check if a given request has access to update a specific item
+	 * Check if a given request has access to update a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return WP_Error|bool.
 	 */
 	public function update_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Check if a given request has access to delete a specific item
+	 * Check if a given request has access to delete a specific item.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return WP_Error|bool.
 	 */
 	public function delete_item_permissions_check( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Prepare the item for create or update operation
+	 * Prepare the item for create or update operation.
 	 *
-	 * @param WP_REST_Request $request Request object
-	 * @return WP_Error|object $prepared_item
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_Error|object $prepared_item.
 	 */
 	protected function prepare_item_for_database( $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 
 	/**
-	 * Prepare the item for the REST response
+	 * Prepare the item for the REST response.
 	 *
 	 * @param mixed $item WordPress representation of the item.
 	 * @param WP_REST_Request $request Request object.
-	 * @return mixed
+	 * @return mixed.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
@@ -152,11 +152,11 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Filter a response based on the context defined in the schema
+	 * Filter a response based on the context defined in the schema.
 	 *
-	 * @param array $data
-	 * @param string $context
-	 * @return array
+	 * @param array $data.
+	 * @param string $context.
+	 * @return array.
 	 */
 	public function filter_response_by_context( $data, $context ) {
 
@@ -186,9 +186,9 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Get the item's schema, conforming to JSON Schema
+	 * Get the item's schema, conforming to JSON Schema.
 	 *
-	 * @return array
+	 * @return array.
 	 */
 	public function get_item_schema() {
 		return $this->add_additional_fields_schema( array() );
@@ -197,7 +197,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the item's schema for display / public consumption purposes.
 	 *
-	 * @return array
+	 * @return array.
 	 */
 	public function get_public_item_schema() {
 
@@ -213,9 +213,9 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Get the query params for collections
+	 * Get the query params for collections.
 	 *
-	 * @return array
+	 * @return array.
 	 */
 	public function get_collection_params() {
 		return array(
@@ -240,11 +240,11 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Add the values from additional fields to a data object
+	 * Add the values from additional fields to a data object.
 	 *
-	 * @param array  $object
-	 * @param WP_REST_Request $request
-	 * @return array modified object with additional fields
+	 * @param array  $object.
+	 * @param WP_REST_Request $request.
+	 * @return array modified object with additional fields.
 	 */
 	protected function add_additional_fields_to_object( $object, $request ) {
 
@@ -265,8 +265,8 @@ abstract class WP_REST_Controller {
 	/**
 	 * Update the values of additional fields added to a data object.
 	 *
-	 * @param array  $object
-	 * @param WP_REST_Request $request
+	 * @param array  $object.
+	 * @param WP_REST_Request $request.
 	 */
 	protected function update_additional_fields_for_object( $object, $request ) {
 
@@ -278,7 +278,7 @@ abstract class WP_REST_Controller {
 				continue;
 			}
 
-			// Don't run the update callbacks if the data wasn't passed in the request
+			// Don't run the update callbacks if the data wasn't passed in the request.
 			if ( ! isset( $request[ $field_name ] ) ) {
 				continue;
 			}
@@ -288,11 +288,11 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Add the schema from additional fields to an schema array
+	 * Add the schema from additional fields to an schema array.
 	 *
 	 * The type of object is inferred from the passed schema.
 	 *
-	 * @param array $schema Schema array
+	 * @param array $schema Schema array.
 	 */
 	protected function add_additional_fields_schema( $schema ) {
 		if ( ! $schema || ! isset( $schema['title'] ) ) {
@@ -300,7 +300,7 @@ abstract class WP_REST_Controller {
 		}
 
 		/**
-		 * Can't use $this->get_object_type otherwise we cause an inf loop
+		 * Can't use $this->get_object_type otherwise we cause an inf loop.
 		 */
 		$object_type = $schema['title'];
 
@@ -318,10 +318,10 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Get all the registered additional fields for a given object-type
+	 * Get all the registered additional fields for a given object-type.
 	 *
-	 * @param  string $object_type
-	 * @return array
+	 * @param  string $object_type.
+	 * @return array.
 	 */
 	protected function get_additional_fields( $object_type = null ) {
 
@@ -345,7 +345,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the object type this controller is responsible for managing.
 	 *
-	 * @return string
+	 * @return string.
 	 */
 	protected function get_object_type() {
 		$schema = $this->get_item_schema();
@@ -365,7 +365,7 @@ abstract class WP_REST_Controller {
 	 *                       values and may fall-back to a given default, this
 	 *                       is not done on `EDITABLE` requests. Default is
 	 *                       WP_REST_Server::CREATABLE.
-	 * @return array $endpoint_args
+	 * @return array $endpoint_args.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
@@ -411,10 +411,10 @@ abstract class WP_REST_Controller {
 	/**
 	 * Validate an parameter value that's based on a property from the item schema.
 	 *
-	 * @param  mixed $value
-	 * @param  WP_REST_Request $request
-	 * @param  string $parameter
-	 * @return WP_Error|bool
+	 * @param  mixed $value.
+	 * @param  WP_REST_Request $request.
+	 * @param  string $parameter.
+	 * @return WP_Error|bool.
 	 */
 	public function validate_schema_property( $value, $request, $parameter ) {
 
@@ -471,10 +471,10 @@ abstract class WP_REST_Controller {
 	/**
 	 * Sanitize an parameter value that's based on a property from the item schema.
 	 *
-	 * @param  mixed $value
-	 * @param  WP_REST_Request $request
-	 * @param  string $parameter
-	 * @return WP_Error|bool
+	 * @param  mixed $value.
+	 * @param  WP_REST_Request $request.
+	 * @param  string $parameter.
+	 * @return WP_Error|bool.
 	 */
 	public function sanitize_schema_property( $value, $request, $parameter ) {
 
@@ -497,7 +497,7 @@ abstract class WP_REST_Controller {
 
 				case 'email' :
 					// as sanitize_email is very lossy, we just want to
-					// make sure the string is safe
+					// make sure the string is safe.
 					if ( sanitize_email( $value ) ) {
 						return sanitize_email( $value );
 					}


### PR DESCRIPTION
In accordance with WP PHP documentation standards Add Periods to end comments, @params and @returns