### PR TITLE
Fix the post formats enum to be an array of strings

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1518,7 +1518,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					$schema['properties']['format'] = array(
 						'description' => 'The format for the object.',
 						'type'        => 'string',
-						'enum'        => get_post_format_slugs(),
+						'enum'        => array_values( get_post_format_slugs() ),
 						'context'     => array( 'view', 'edit' ),
 					);
 					break;


### PR DESCRIPTION
`get_post_format_slugs` returns `array( 'audio' => 'audio' )` for some odd
reason, we want it to be a numeric array of strings.