### PR TITLE
Avoid calling sanitize_title directly

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -923,7 +923,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$query_params['post_slug'] = array(
 			'default'           => null,
 			'description'       => 'Limit result set to comments associated with posts of a specific post slug.',
-			'sanitize_callback' => 'sanitize_title',
+			'sanitize_callback' => array( $this, 'sanitize_slug' ),
 			'type'              => 'string',
 		);
 		$query_params['post_parent'] = array(

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -510,4 +510,19 @@ abstract class WP_REST_Controller {
 
 		return $value;
 	}
+
+	/**
+	 * Sanitize the slug value.
+	 *
+	 * @internal We can't use {@see sanitize_title} directly, as the second
+	 * parameter is the fallback title, which would end up being set to the
+	 * request object.
+	 * @see https://github.com/WP-API/WP-API/issues/1585
+	 *
+	 * @param mixed $title Title value passed in request.
+	 * @return string Sanitized value for the slug.
+	 */
+	public function sanitize_slug( $title ) {
+		return sanitize_title( $title );
+	}
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1340,7 +1340,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'status'          => array(

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -548,7 +548,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed' ),
 					'arg_options'  => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'taxonomy'         => array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -733,7 +733,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'url'         => array(


### PR DESCRIPTION
Fixes #1585.

@WP-API/amigos Question: should we do this, or use `create_function( '$a', 'return sanitize_title($a);' )` ? I'm looking through, and it seems like there might be other places we need to do this too (`sanitize_user` e.g. takes a `$strict` parameter as second param).