### PR TITLE
Make Travis notifications less noisy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,3 +83,8 @@ after_script:
 
 git:
   depth: 1
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change


### PR DESCRIPTION
We only care to get emails when the build fails.