### PR TITLE
Only process `filter` when it's an array

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -89,7 +89,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$args['paged']          = $request['page'];
 		$args['posts_per_page'] = $request['per_page'];
 
-		if ( isset( $request['filter'] ) ) {
+		if ( is_array( $request['filter'] ) ) {
 			$args = array_merge( $args, $request['filter'] );
 			unset( $args['filter'] );
 		}


### PR DESCRIPTION
The value is still set if `&filter` is passed, but `array_merge()` will
error if `$request['filter']` isn't an array.

From #1733