### PR TITLE
Load `api-core` as a Composer dependency if it exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "forum": "https://wordpress.org/support/plugin/json-rest-api"
     },
     "require": {
-        "composer/installers": "~1.0"
+        "composer/installers": "~1.0",
+        "wp-api/api-core": "2.0-beta6"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "0.6.0"

--- a/plugin.php
+++ b/plugin.php
@@ -11,7 +11,11 @@
 
 // Do we need the compatibility repo?
 if ( ! defined( 'REST_API_VERSION' ) ) {
-	require_once dirname( __FILE__ ) . '/core/rest-api.php';
+	if ( file_exists( dirname( __FILE__ ) . '/core/rest-api.php' ) ) {
+		require_once dirname( __FILE__ ) . '/core/rest-api.php';
+	} else if ( file_exists( dirname( __FILE__ ) . '/vendor/wp-api/api-core/rest-api.php' ) ) {
+		require_once dirname( __FILE__ ) . '/vendor/wp-api/api-core/rest-api.php';
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #1736