### PR TITLE
Restore `register_api_field()` within the plugin

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -219,3 +219,45 @@ function create_initial_rest_routes() {
 	$controller = new WP_REST_Comments_Controller;
 	$controller->register_routes();
 }
+
+if ( ! function_exists( 'register_api_field' ) ) {
+	/**
+	 * Registers a new field on an existing WordPress object type.
+	 *
+	 * @global array $wp_rest_additional_fields Holds registered fields, organized
+	 *                                          by object type.
+	 *
+	 * @param string|array $object_type Object(s) the field is being registered
+	 *                                  to, "post"|"term"|"comment" etc.
+	 * @param string $attribute         The attribute name.
+	 * @param array  $args {
+	 *     Optional. An array of arguments used to handle the registered field.
+	 *
+	 *     @type string|array|null $get_callback    Optional. The callback function used to retrieve the field
+	 *                                              value. Default is 'null', the field will not be returned in
+	 *                                              the response.
+	 *     @type string|array|null $update_callback Optional. The callback function used to set and update the
+	 *                                              field value. Default is 'null', the value cannot be set or
+	 *                                              updated.
+	 *     @type string|array|null $schema          Optional. The callback function used to create the schema for
+	 *                                              this field. Default is 'null', no schema entry will be returned.
+	 * }
+	 */
+	function register_api_field( $object_type, $attribute, $args = array() ) {
+		$defaults = array(
+			'get_callback'    => null,
+			'update_callback' => null,
+			'schema'          => null,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		global $wp_rest_additional_fields;
+
+		$object_types = (array) $object_type;
+
+		foreach ( $object_types as $object_type ) {
+			$wp_rest_additional_fields[ $object_type ][ $attribute ] = $args;
+		}
+	}
+}


### PR DESCRIPTION
It won't be included in WP 4.4 because it's conceptually tied to
`WP_REST_Controller`

See https://github.com/WP-API/WP-API/issues/1321#issuecomment-157835276