### PR TITLE
Change int to integer for WP_REST_Controller::validate_schema_property()

### DIFF
--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -103,7 +103,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 			'properties' => array(
 				'id' => array(
 					'description' => 'Unique identifier for the object.',
-					'type'        => 'int',
+					'type'        => 'integer',
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
Typo bug.