### PR TITLE
Don't permit requesting terms cross routes

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -138,7 +138,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	public function get_item( $request ) {
 
 		$term = get_term_by( 'term_taxonomy_id', (int) $request['id'], $this->taxonomy );
-		if ( ! $term ) {
+		if ( ! $term || $term->taxonomy !== $this->taxonomy ) {
 			return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
 		}
 		if ( is_wp_error( $term ) ) {

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -323,6 +323,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
+	public function test_get_item_incorrect_taxonomy() {
+		register_taxonomy( 'robin', 'post' );
+		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'robin' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/' . $term1 );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( $this->administrator );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );


### PR DESCRIPTION
Clients should only be able to request categories from the category route, and tags from the tag route

Fixes #1763