### PR TITLE
Post updates should expect slashed data

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -263,8 +263,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $post ) ) {
 			return $post;
 		}
-
-		$post_id = wp_update_post( $post, true );
+		// convert the post object to an array, otherwise wp_update_post will expect non-escaped input
+		$post_id = wp_update_post( (array) $post, true );
 		if ( is_wp_error( $post_id ) ) {
 			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ) ) ) {
 				$post_id->add_data( array( 'status' => 500 ) );

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -736,7 +736,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		) );
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
-		$this->check_create_post_response( $response );
+		$new_data = $response->get_data();
+		$this->assertEquals( "Rob O'Rourke's Diary", $new_data['title']['raw'] );
 	}
 
 	public function test_update_item() {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -712,6 +712,18 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	public function test_create_post_with_quotes_in_title() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$params = $this->set_post_data( array(
+			'title' => "Rob O'Rourke's Diary",
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+		$this->check_create_post_response( $response );
+	}
+
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 
@@ -1006,6 +1018,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_field', $response, 400 );
+	}
+
+	public function test_update_post_with_quotes_in_title() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data( array(
+			'title' => "Rob O'Rourke's Diary",
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( "Rob O'Rourke's Diary", $new_data['title']['raw'] );
 	}
 
 	public function test_delete_item() {


### PR DESCRIPTION
Right now, updating posts with quotes causes slashes to be saved to the db, as
wp_update_post does `wp_slash` on already slashed data if you pass it an
object.

I'm not sure if this is the best fix, but the unit test illustrates the issue.