### PR TITLE
Add `?parent=<id>` support for attachments; update Post `_link`

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -368,6 +368,22 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Get the query params for collections of attachments.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['parent']        = array(
+			'description'        => 'Limit results to attachments from a specified parent.',
+			'type'               => 'integer',
+			'default'            => null,
+			'sanitize_callback'  => 'absint',
+			);
+		return $params;
+	}
+
+	/**
 	 * Handle an upload via multipart/form-data ($_FILES)
 	 *
 	 * @param array $files Data from $_FILES

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -15,20 +15,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$base = $this->get_post_type_base( $this->post_type );
 
-		$posts_args = array(
-			'context'               => array(
-				'default'           => 'view',
-			),
-			'page'                  => array(
-				'default'           => 1,
-				'sanitize_callback' => 'absint',
-			),
-			'per_page'              => array(
-				'default'           => 10,
-				'sanitize_callback' => 'absint',
-			),
-			'filter'                => array(),
-		);
+		$posts_args = $this->get_collection_params();
 
 		register_rest_route( 'wp/v2', '/' . $base, array(
 			array(
@@ -88,6 +75,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$args                   = array();
 		$args['paged']          = $request['page'];
 		$args['posts_per_page'] = $request['per_page'];
+		$args['post_parent']    = $request['parent'];
 
 		if ( is_array( $request['filter'] ) ) {
 			$args = array_merge( $args, $request['filter'] );
@@ -1219,7 +1207,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
 			$attachments_url = rest_url( 'wp/v2/media' );
-			$attachments_url = add_query_arg( 'post_parent', $post->ID, $attachments_url );
+			$attachments_url = add_query_arg( 'parent', $post->ID, $attachments_url );
 			$links['https://api.w.org/attachment'] = array(
 				'href'       => $attachments_url,
 			);
@@ -1542,6 +1530,17 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections of attachments.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['filter'] = array();
+		return $params;
 	}
 
 }

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -164,7 +164,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( rest_url( '/wp/v2/posts/' . $this->post_id . '/revisions' ), $links['version-history'][0]['href'] );
 
 		$attachments_url = rest_url( '/wp/v2/media' );
-		$attachments_url = add_query_arg( 'post_parent', $this->post_id, $attachments_url );
+		$attachments_url = add_query_arg( 'parent', $this->post_id, $attachments_url );
 		$this->assertEquals( $attachments_url, $links['https://api.w.org/attachment'][0]['href'] );
 
 		$term_links = $links['https://api.w.org/term'];


### PR DESCRIPTION
Also stubs `get_collection_params()` abstraction for Posts controller to
make it possible for attachments controller to add `?parent=<id>` support

Fixes #1767
