### PR TITLE
Missing 'wp/v2' in path in Location Response header

### DIFF
--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -399,7 +399,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 
 		$response->set_status( 201 );
 		$data = $response->get_data();
-		$response->header( 'Location', rest_url( $this->parent_base . '/' . $parent_id . '/meta/' . $data['id'] ) );
+		$response->header( 'Location', rest_url( 'wp/v2' . '/' . $this->parent_base . '/' . $parent_id . '/meta/' . $data['id'] ) );
 
 		/* This action is documented in lib/endpoints/class-wp-rest-meta-controller.php */
 		do_action( 'rest_insert_meta', $data, $request, true );


### PR DESCRIPTION
When submitting a Post Meta Create request, the response contains
 a Location header with 'wp/v2' missing from the path.

Currently either `$this->parent_base` returns the wrong (empty) base,
 or `wp/v2/` is missing from the base when setting the Location header
 for a Post Meta Create response.

### Actual Location header

    c.a.w.w.v.Client.debugRequest() - Request Entity:\
        <POST http://johan-wp/wp-json/wp/v2/posts/3766/meta,\
        {key=Gomxw, value=bLfaU},\
        {Authorization=[Basic am9oYW4ubXluaGFyZHQ6d29yZHByZXNzIQ==]}>
    c.a.w.w.v.Client.debugHeaders() - Response Headers:
    ...
    c.a.w.w.v.Client.lambda$debugHeaders$8() - \
        Location -> [http://johan-wp/wp-json/posts/3766/meta/11965]
    ...

### Expected Location header

    c.a.w.w.v.Client.debugRequest() - Request Entity:\
        <POST http://johan-wp/wp-json/wp/v2/posts/3766/meta,\
        {key=Gomxw, value=bLfaU},\
        {Authorization=[Basic am9oYW4ubXluaGFyZHQ6d29yZHByZXNzIQ==]}>
    c.a.w.w.v.Client.debugHeaders() - Response Headers:
    ...
    c.a.w.w.v.Client.lambda$debugHeaders$8() - \
        Location -> [http://johan-wp/wp-json/wp/v2/posts/3766/meta/11965]
    ...