### PR TITLE
Ignore sticky posts by default

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -527,6 +527,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$query_args['post_status'] = 'inherit';
 		}
 
+		if ( 'post' === $this->post_type && ! isset( $query_args['ignore_sticky_posts'] ) ) {
+			$query_args['ignore_sticky_posts'] = true;
+		}
+
 		return $query_args;
 	}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -527,7 +527,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$query_args['post_status'] = 'inherit';
 		}
 
-		if ( 'post' === $this->post_type && ! isset( $query_args['ignore_sticky_posts'] ) ) {
+		if ( 'post' !== $this->post_type || ! isset( $query_args['ignore_sticky_posts'] ) ) {
 			$query_args['ignore_sticky_posts'] = true;
 		}
 


### PR DESCRIPTION
Sticky posts are unrestful functionality. But, they can be re-enabled
for posts only with `filter[ignore_sticky_posts]=false`

Fixes #1623