### PR TITLE
Move tags and categories to top-level endpoints

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1233,7 +1233,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				}
 
 				$tax_base = ! empty( $taxonomy_obj->rest_base ) ? $taxonomy_obj->rest_base : $tax;
-				$terms_url = rest_url( trailingslashit( $base ) . $post->ID . '/terms/' . $tax_base );
+				$terms_url = rest_url( trailingslashit( $base ) . $post->ID . '/' . $tax_base );
 
 				$links['https://api.w.org/term'][] = array(
 					'href'       => $terms_url,

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -20,7 +20,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$tax_base = $this->terms_controller->get_taxonomy_base( $this->taxonomy );
 
 		$query_params = $this->get_collection_params();
-		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s', $base, $tax_base ), array(
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/%s', $base, $tax_base ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -30,7 +30,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
-		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/terms/%s/(?P<term_id>[\d]+)', $base, $tax_base ), array(
+		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/%s/(?P<term_id>[\d]+)', $base, $tax_base ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -21,7 +21,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$base = $this->get_taxonomy_base( $this->taxonomy );
 		$query_params = $this->get_collection_params();
-		register_rest_route( 'wp/v2', '/terms/' . $base, array(
+		register_rest_route( 'wp/v2', '/' . $base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -37,7 +37,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 			'schema' => array( $this, 'get_public_item_schema' ),
 		));
-		register_rest_route( 'wp/v2', '/terms/' . $base . '/(?P<id>[\d]+)', array(
+		register_rest_route( 'wp/v2', '/' . $base . '/(?P<id>[\d]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -111,7 +111,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$max_pages = ceil( $total_terms / $request['per_page'] );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );
 
-		$base = add_query_arg( $request->get_query_params(), rest_url( '/wp/v2/terms/' . $this->get_taxonomy_base( $this->taxonomy ) ) );
+		$base = add_query_arg( $request->get_query_params(), rest_url( '/wp/v2/' . $this->get_taxonomy_base( $this->taxonomy ) ) );
 		if ( $request['page'] > 1 ) {
 			$prev_page = $request['page'] - 1;
 			if ( $prev_page > $max_pages ) {
@@ -204,7 +204,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/v2/terms/' . $this->get_taxonomy_base( $this->taxonomy ) . '/' . $term['term_taxonomy_id'] ) );
+		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_taxonomy_base( $this->taxonomy ) . '/' . $term['term_taxonomy_id'] ) );
 		return $response;
 	}
 
@@ -273,7 +273,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		// Get the actual term_id
 		$term = get_term_by( 'term_taxonomy_id', (int) $request['id'], $this->taxonomy );
-		$get_request = new WP_REST_Request( 'GET', rest_url( 'wp/v2/terms/' . $this->get_taxonomy_base( $term->taxonomy ) . '/' . (int) $request['id'] ) );
+		$get_request = new WP_REST_Request( 'GET', rest_url( 'wp/v2/' . $this->get_taxonomy_base( $term->taxonomy ) . '/' . (int) $request['id'] ) );
 		$get_request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $term, $get_request );
 
@@ -476,7 +476,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return array Links for the given term.
 	 */
 	protected function prepare_links( $term ) {
-		$base = '/wp/v2/terms/' . $this->get_taxonomy_base( $term->taxonomy );
+		$base = '/wp/v2/' . $this->get_taxonomy_base( $term->taxonomy );
 		$links = array(
 			'self'       => array(
 				'href'       => rest_url( trailingslashit( $base ) . $term->term_taxonomy_id ),
@@ -490,7 +490,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$parent_term = get_term_by( 'id', (int) $term->parent, $term->taxonomy );
 			if ( $parent_term ) {
 				$links['up'] = array(
-					'href'       => rest_url( sprintf( 'wp/v2/terms/%s/%d', $this->get_taxonomy_base( $parent_term->taxonomy ), $parent_term->term_taxonomy_id ) ),
+					'href'       => rest_url( sprintf( 'wp/v2/%s/%d', $this->get_taxonomy_base( $parent_term->taxonomy ), $parent_term->term_taxonomy_id ) ),
 					'embeddable' => true,
 				);
 			}

--- a/plugin.php
+++ b/plugin.php
@@ -133,13 +133,13 @@ function _add_extra_api_taxonomy_arguments() {
 
 	if ( isset( $wp_taxonomies['category'] ) ) {
 		$wp_taxonomies['category']->show_in_rest = true;
-		$wp_taxonomies['category']->rest_base = 'category';
+		$wp_taxonomies['category']->rest_base = 'categories';
 		$wp_taxonomies['category']->rest_controller_class = 'WP_REST_Terms_Controller';
 	}
 
 	if ( isset( $wp_taxonomies['post_tag'] ) ) {
 		$wp_taxonomies['post_tag']->show_in_rest = true;
-		$wp_taxonomies['post_tag']->rest_base = 'tag';
+		$wp_taxonomies['post_tag']->rest_base = 'tags';
 		$wp_taxonomies['post_tag']->rest_controller_class = 'WP_REST_Terms_Controller';
 	}
 }

--- a/tests/test-rest-plugin.php
+++ b/tests/test-rest-plugin.php
@@ -243,12 +243,12 @@ class WP_Test_REST_Plugin extends WP_UnitTestCase {
 
 		$taxonomy = get_taxonomy( 'category' );
 		$this->assertTrue( $taxonomy->show_in_rest );
-		$this->assertEquals( 'category', $taxonomy->rest_base );
+		$this->assertEquals( 'categories', $taxonomy->rest_base );
 		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
 
 		$taxonomy = get_taxonomy( 'post_tag' );
 		$this->assertTrue( $taxonomy->show_in_rest );
-		$this->assertEquals( 'tag', $taxonomy->rest_base );
+		$this->assertEquals( 'tags', $taxonomy->rest_base );
 		$this->assertEquals( 'WP_REST_Terms_Controller', $taxonomy->rest_controller_class );
 	}
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -230,10 +230,10 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertNotEmpty( $tag_link );
 		$this->assertNotEmpty( $cat_link );
 
-		$tags_url = rest_url( '/wp/v2/posts/' . $this->post_id . '/terms/tag' );
+		$tags_url = rest_url( '/wp/v2/posts/' . $this->post_id . '/tags' );
 		$this->assertEquals( $tags_url, $tag_link['href'] );
 
-		$category_url = rest_url( '/wp/v2/posts/' . $this->post_id . '/terms/category' );
+		$category_url = rest_url( '/wp/v2/posts/' . $this->post_id . '/categories' );
 		$this->assertEquals( $category_url, $cat_link['href'] );
 
 		$meta_links = $links['https://api.w.org/meta'];

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -14,14 +14,14 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/terms/tag', $routes );
-		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/terms/tag/(?P<term_id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/tags', $routes );
+		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/tags/(?P<term_id>[\d]+)', $routes );
 	}
 
 	public function test_get_items() {
 
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertFalse( $response->is_error() );
@@ -30,7 +30,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_items_invalid_post() {
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', 9999 ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', 9999 ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -38,7 +38,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_items_invalid_taxonomy() {
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/%s', $this->public_taxonomy_pages, $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/%s', $this->public_taxonomy_pages, $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
@@ -46,14 +46,14 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_items_orderby() {
 		wp_set_object_terms( $this->post_id, array( 'Banana', 'Carrot', 'Apple' ), 'post_tag' );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $this->post_id ) );
 		$request->set_param( 'orderby', 'term_order' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'Banana', $data[0]['name'] );
 		$this->assertEquals( 'Carrot', $data[1]['name'] );
 		$this->assertEquals( 'Apple', $data[2]['name'] );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $this->post_id ) );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'asc' );
 		$response = $this->server->dispatch( $request );
@@ -61,7 +61,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 'Apple', $data[0]['name'] );
 		$this->assertEquals( 'Banana', $data[1]['name'] );
 		$this->assertEquals( 'Carrot', $data[2]['name'] );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', $this->post_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $this->post_id ) );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'desc' );
 		$response = $this->server->dispatch( $request );
@@ -75,7 +75,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertFalse( $response->is_error() );
 
@@ -86,7 +86,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -96,21 +96,21 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		$page = $this->factory->post->create( array( 'post_type' => 'page' ) );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag', $page ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $page ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
 	}
 
 	public function test_get_item_invalid_taxonomy() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, 123 ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, 123 ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
 	public function test_get_item_invalid_taxonomy_term() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, 9999 ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, 9999 ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -120,7 +120,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		$term = wp_insert_term( 'some-term', $this->public_taxonomy_pages );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $term['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $term['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -130,7 +130,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
@@ -138,7 +138,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_item_term_id_not_added() {
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
@@ -148,7 +148,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 201, $response->get_status() );
@@ -158,7 +158,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_create_item_invalid_permission() {
 
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -168,7 +168,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -178,7 +178,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
@@ -187,7 +187,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_create_item_invalid_taxonomy_term() {
 
 		wp_set_current_user( $this->admin_id );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, 9999 ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, 9999 ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -198,7 +198,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -210,7 +210,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -222,7 +222,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -234,7 +234,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -246,7 +246,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -262,7 +262,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 		$term = get_term( $tag['term_id'], 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
@@ -270,7 +270,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', sprintf( '/wp/v2/posts/%d/terms/tag', $this->post_id ) );
+		$request = new WP_REST_Request( 'OPTIONS', sprintf( '/wp/v2/posts/%d/tags', $this->post_id ) );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -20,14 +20,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/v2/terms/category', $routes );
-		$this->assertArrayHasKey( '/wp/v2/terms/category/(?P<id>[\d]+)', $routes );
-		$this->assertArrayHasKey( '/wp/v2/terms/tag', $routes );
-		$this->assertArrayHasKey( '/wp/v2/terms/tag/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/categories', $routes );
+		$this->assertArrayHasKey( '/wp/v2/categories/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wp/v2/tags', $routes );
+		$this->assertArrayHasKey( '/wp/v2/tags/(?P<id>[\d]+)', $routes );
 	}
 
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_terms_response( $response );
 	}
@@ -37,7 +37,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$tag1 = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
 		$tag2 = $this->factory->tag->create( array( 'name' => 'The Be Sharps' ) );
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'hide_empty', true );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
@@ -61,7 +61,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 				'parent' => $parent2,
 			)
 		);
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'parent', 0 );
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
@@ -92,7 +92,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 				'parent' => $parent2,
 			)
 		);
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'parent', '0' );
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
@@ -111,7 +111,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_by_parent_non_found() {
 		$parent1 = $this->factory->category->create( array( 'name' => 'Homer' ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'parent', $parent1 );
 		$response = $this->server->dispatch( $request );
 		$response = rest_ensure_response( $response );
@@ -131,7 +131,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		 * - order
 		 * - per_page
 		 */
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'desc' );
 		$request->set_param( 'per_page', 1 );
@@ -140,7 +140,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'Banana', $data[0]['name'] );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'orderby', 'name' );
 		$request->set_param( 'order', 'asc' );
 		$request->set_param( 'per_page', 2 );
@@ -157,7 +157,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$tag2 = $this->factory->tag->create( array( 'name' => 'Marvel' ) );
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -193,14 +193,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		 * Tests:
 		 * - search
 		 */
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'search', 'App' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'Apple', $data[0]['name'] );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'search', 'Garbage' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -211,7 +211,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_terms_parent_arg() {
 		$category1 = $this->factory->category->create( array( 'name' => 'Parent' ) );
 		$category2 = $this->factory->category->create( array( 'name' => 'Child', 'parent' => $category1 ) );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'parent', $category1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
@@ -242,21 +242,21 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 				'name'   => "Tag {$i}",
 				) );
 		}
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$response = $this->server->dispatch( $request );
 		$headers = $response->get_headers();
 		$this->assertEquals( 50, $headers['X-WP-Total'] );
 		$this->assertEquals( 5, $headers['X-WP-TotalPages'] );
 		$next_link = add_query_arg( array(
 			'page'    => 2,
-			), rest_url( '/wp/v2/terms/tag' ) );
+			), rest_url( '/wp/v2/tags' ) );
 		$this->assertFalse( stripos( $headers['Link'], 'rel="prev"' ) );
 		$this->assertContains( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 		// 3rd page
 		$this->factory->tag->create( array(
 				'name'   => 'Tag 51',
 				) );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'page', 3 );
 		$response = $this->server->dispatch( $request );
 		$headers = $response->get_headers();
@@ -264,14 +264,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
 		$prev_link = add_query_arg( array(
 			'page'    => 2,
-			), rest_url( '/wp/v2/terms/tag' ) );
+			), rest_url( '/wp/v2/tags' ) );
 		$this->assertContains( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
 		$next_link = add_query_arg( array(
 			'page'    => 4,
-			), rest_url( '/wp/v2/terms/tag' ) );
+			), rest_url( '/wp/v2/tags' ) );
 		$this->assertContains( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 		// Last page
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'page', 6 );
 		$response = $this->server->dispatch( $request );
 		$headers = $response->get_headers();
@@ -279,11 +279,11 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
 		$prev_link = add_query_arg( array(
 			'page'    => 5,
-			), rest_url( '/wp/v2/terms/tag' ) );
+			), rest_url( '/wp/v2/tags' ) );
 		$this->assertContains( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
 		$this->assertFalse( stripos( $headers['Link'], 'rel="next"' ) );
 		// Out of bounds
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'page', 8 );
 		$response = $this->server->dispatch( $request );
 		$headers = $response->get_headers();
@@ -291,13 +291,13 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
 		$prev_link = add_query_arg( array(
 			'page'    => 6,
-			), rest_url( '/wp/v2/terms/tag' ) );
+			), rest_url( '/wp/v2/tags' ) );
 		$this->assertContains( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
 		$this->assertFalse( stripos( $headers['Link'], 'rel="next"' ) );
 	}
 
 	public function test_get_item() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/1' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/1' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_term_response( $response );
 	}
@@ -309,7 +309,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_term_invalid_term() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
 	}
@@ -326,14 +326,14 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_item_incorrect_taxonomy() {
 		register_taxonomy( 'robin', 'post' );
 		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'robin' ) );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/' . $term1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/' . $term1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
 	}
 
 	public function test_create_item() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'description', 'This term is so awesome.' );
 		$request->set_param( 'slug', 'so-awesome' );
@@ -341,7 +341,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 201, $response->get_status() );
 		$headers = $response->get_headers();
 		$data = $response->get_data();
-		$this->assertContains( '/wp/v2/terms/category/' . $data['id'], $headers['Location'] );
+		$this->assertContains( '/wp/v2/categories/' . $data['id'], $headers['Location'] );
 		$this->assertEquals( 'My Awesome Term', $data['name'] );
 		$this->assertEquals( 'This term is so awesome.', $data['description'] );
 		$this->assertEquals( 'so-awesome', $data['slug'] );
@@ -357,7 +357,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_create_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$request->set_param( 'name', 'Incorrect permissions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -365,7 +365,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_create_item_missing_arguments() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
 	}
@@ -373,7 +373,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_create_item_with_parent() {
 		wp_set_current_user( $this->administrator );
 		$parent = wp_insert_term( 'test-category', 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'parent', $parent['term_taxonomy_id'] );
 		$response = $this->server->dispatch( $request );
@@ -386,7 +386,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
@@ -396,7 +396,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_create_item_parent_non_hierarchical_taxonomy() {
 		wp_set_current_user( $this->administrator );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tags' );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
@@ -411,7 +411,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'original-slug',
 			);
 		$term = get_term_by( 'id', $this->factory->category->create( $orig_args ), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$request->set_param( 'name', 'New Name' );
 		$request->set_param( 'description', 'New Description' );
 		$request->set_param( 'slug', 'new-slug' );
@@ -433,7 +433,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_update_item_invalid_term() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/9999999' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/9999999' );
 		$request->set_param( 'name', 'Invalid Term' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -442,7 +442,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$request->set_param( 'name', 'Incorrect permissions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -453,7 +453,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$parent = get_term_by( 'id', $this->factory->category->create(), 'category' );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$request->set_param( 'parent', $parent->term_taxonomy_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -466,7 +466,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 400 );
@@ -476,7 +476,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/tag/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_taxonomy_id );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_not_hierarchical', $response, 400 );
@@ -485,7 +485,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item() {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
@@ -502,7 +502,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_delete_item_invalid_term() {
 		wp_set_current_user( $this->administrator );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/9999999' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/9999999' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
 	}
@@ -510,7 +510,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/terms/category/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_taxonomy_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
@@ -518,7 +518,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_prepare_item() {
 		$term = get_term( 1, 'category' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/1' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/1' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
@@ -531,7 +531,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		) );
 		$term = get_term( $child, 'category' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/category/' . $child );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/' . $child );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
@@ -540,11 +540,11 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 1, $data['parent'] );
 
 		$links = $response->get_links();
-		$this->assertEquals( rest_url( '/wp/v2/terms/category/1' ), $links['up'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/categories/1' ), $links['up'][0]['href'] );
 	}
 
 	public function test_get_item_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/terms/category' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
@@ -561,7 +561,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_schema_non_hierarchical() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/terms/tag' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -176,7 +176,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/terms/batman' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/batman' );
 		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );


### PR DESCRIPTION
Tags are now accessible at `/wp/v2/tags`, and categories accessible at
`/wp/v2/categories`. Post terms reside at `/wp/v2/posts/<id>/tags` and
`/wp/v2/<id>/categories`

Although this introduces the risk of collision between custom post types
and custom taxonomies, said collision isn't currently handled in
WordPress core. Developers can use `rest_base` to ensure CPTs and
taxomonies have distinct slugs.

Fixes #829