### PR TITLE
Explicitly require `post` argument when creating a comment

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -859,6 +859,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'description'  => 'The ID of the associated post object.',
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
 				),
 				'status'           => array(
 					'description'  => 'State of the object.',


### PR DESCRIPTION
Because the internals require `post` when creating a comment, explicitly
marking it as required will provide a more helpful error message when
the argument isn't provided in the request.

Discovered in #1453