### PR TITLE
Include `full` image size in attachment `sizes` attribute

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -192,6 +192,18 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 				$size_data['source_url'] = $image_src[0];
 			}
+
+			$full_src = wp_get_attachment_image_src( $post->ID, 'full' );
+			if ( ! empty( $full_src ) ) {
+				$data['media_details']['sizes']['full'] = array(
+					'file'          => wp_basename( $full_src[0] ),
+					'width'         => $full_src[1],
+					'height'        => $full_src[2],
+					'mime_type'     => $post->post_mime_type,
+					'source_url'    => $full_src[0],
+					);
+			}
+
 		} else {
 			$data['media_details']['sizes'] = new stdClass;
 		}

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -203,7 +203,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					'source_url'    => $full_src[0],
 					);
 			}
-
 		} else {
 			$data['media_details']['sizes'] = new stdClass;
 		}

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -106,9 +106,11 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$image_src = wp_get_attachment_image_src( $attachment_id, 'rest-api-test' );
+		$original_image_src = wp_get_attachment_image_src( $attachment_id, 'full' );
 		remove_image_size( 'rest-api-test' );
 
 		$this->assertEquals( $image_src[0], $data['media_details']['sizes']['rest-api-test']['source_url'] );
+		$this->assertEquals( $original_image_src[0], $data['media_details']['sizes']['full']['source_url'] );
 	}
 
 	public function test_get_item_sizes_with_no_url() {


### PR DESCRIPTION
Fixes #365