### PR TITLE
Ensure `attachment.sizes[]` use `mime_type` instead of `mime-type`

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -183,9 +183,14 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$img_url_basename = wp_basename( $data['source_url'] );
 
 			foreach ( $data['media_details']['sizes'] as $size => &$size_data ) {
+
+				if ( isset( $size_data['mime-type'] ) ) {
+					$size_data['mime_type'] = $size_data['mime-type'];
+					unset( $size_data['mime-type'] );
+				}
+
 				// Use the same method image_downsize() does
 				$image_src = wp_get_attachment_image_src( $post->ID, $size );
-
 				if ( ! $image_src ) {
 					continue;
 				}

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -110,7 +110,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		remove_image_size( 'rest-api-test' );
 
 		$this->assertEquals( $image_src[0], $data['media_details']['sizes']['rest-api-test']['source_url'] );
+		$this->assertEquals( 'image/jpeg', $data['media_details']['sizes']['rest-api-test']['mime_type'] );
 		$this->assertEquals( $original_image_src[0], $data['media_details']['sizes']['full']['source_url'] );
+		$this->assertEquals( 'image/jpeg', $data['media_details']['sizes']['full']['mime_type'] );
 	}
 
 	public function test_get_item_sizes_with_no_url() {


### PR DESCRIPTION
Underscored keys are easier to access in some languages (e.g. JS)

Fixes #1807