### PR TITLE
Include WordPress 4.3 in the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   - php: 5.6
     env: WP_TRAVISCI=travis:phpunit WP_VERSION=latest
   - php: 5.6
+    env: WP_TRAVISCI=travis:phpunit WP_VERSION=4.3.1
+  - php: 5.6
     env: WP_TRAVISCI=travis:phpvalidate
   - php: 5.6
     env: WP_TRAVISCI=travis:codecoverage


### PR DESCRIPTION
`latest` is now WordPress 4.4. We want to ensure 4.3 support for another
beta or two, so we need to make sure tests continue to pass.

Related #1794