### PR TITLE
Link taxonomies to their associated collections

### DIFF
--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -48,6 +48,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			if ( is_wp_error( $tax ) ) {
 				continue;
 			}
+			$tax = $this->prepare_response_for_collection( $tax );
 			$data[] = $tax;
 		}
 		return $data;
@@ -110,12 +111,22 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$data = $this->filter_response_by_context( $data, $context );
 		$data = $this->add_additional_fields_to_object( $data, $request );
 
+		// Wrap the data in a response object.
+		$data = rest_ensure_response( $data );
+
+		$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+		$data->add_links( array(
+			'collection'     => array(
+				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
+				),
+			) );
+
 		/**
 		 * Filter a taxonomy returned from the API.
 		 *
 		 * Allows modification of the taxonomy data right before it is returned.
 		 *
-		 * @param array           $data     Key value array of taxonomy data.
+		 * @param array           $data     An array of taxonomy date, prepared for response.
 		 * @param object          $item     The taxonomy object.
 		 * @param WP_REST_Request $request  Request used to generate the response.
 		 */

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -118,8 +118,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$data->add_links( array(
 			'collection'     => array(
 				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
-				),
-			) );
+			),
+		) );
 
 		/**
 		 * Filter a taxonomy returned from the API.

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -66,8 +66,8 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_prepare_item() {
 		$tax = get_taxonomy( 'category' );
 		$endpoint = new WP_REST_Taxonomies_Controller;
-		$data = $endpoint->prepare_item_for_response( $tax, new WP_REST_Request );
-		$this->check_taxonomy_object( $tax, $data );
+		$response = $endpoint->prepare_item_for_response( $tax, new WP_REST_Request );
+		$this->check_taxonomy_object( $tax, $response->get_data(), $response->get_links() );
 	}
 
 	public function test_get_item_schema() {
@@ -103,12 +103,13 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		return array_values( array_filter( $taxonomies, array( $this, 'is_public' ) ) );
 	}
 
-	protected function check_taxonomy_object( $tax_obj, $data ) {
+	protected function check_taxonomy_object( $tax_obj, $data, $links ) {
 		$this->assertEquals( $tax_obj->label, $data['name'] );
 		$this->assertEquals( $tax_obj->name, $data['slug'] );
 		$this->assertEquals( $tax_obj->description, $data['description'] );
 		$this->assertEquals( $tax_obj->show_tagcloud, $data['show_cloud'] );
 		$this->assertEquals( $tax_obj->hierarchical, $data['hierarchical'] );
+		$this->assertArrayHasKey( 'collection', $links );
 	}
 
 	protected function check_taxonomy_object_response( $response ) {
@@ -117,7 +118,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$category = get_taxonomy( 'category' );
-		$this->check_taxonomy_object( $category, $data );
+		$this->check_taxonomy_object( $category, $data, $response->get_links() );
 	}
 
 	protected function check_taxonomies_for_type_response( $type, $response ) {


### PR DESCRIPTION
Changes `$data` from an array to WP_REST_Response when
supplied to `rest_prepare_taxonomy`

Fixes #1381