### PR TITLE
Rename `register_api_field()` to `register_rest_field()`

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -231,7 +231,7 @@ if ( ! function_exists( 'rest_authorization_required_code' ) ) {
 	}
 }
 
-if ( ! function_exists( 'register_api_field' ) ) {
+if ( ! function_exists( 'register_rest_field' ) ) {
 	/**
 	 * Registers a new field on an existing WordPress object type.
 	 *
@@ -254,7 +254,7 @@ if ( ! function_exists( 'register_api_field' ) ) {
 	 *                                              this field. Default is 'null', no schema entry will be returned.
 	 * }
 	 */
-	function register_api_field( $object_type, $attribute, $args = array() ) {
+	function register_rest_field( $object_type, $attribute, $args = array() ) {
 		$defaults = array(
 			'get_callback'    => null,
 			'update_callback' => null,
@@ -270,5 +270,15 @@ if ( ! function_exists( 'register_api_field' ) ) {
 		foreach ( $object_types as $object_type ) {
 			$wp_rest_additional_fields[ $object_type ][ $attribute ] = $args;
 		}
+	}
+}
+
+if ( ! function_exists( 'register_api_field' ) ) {
+	/**
+	 * Backwards compat shim
+	 */
+	function register_api_field( $object_type, $attributes, $args = array() ) {
+		_deprecated_function( 'register_api_field', 'WPAPI-2.0', 'register_rest_field' );
+		register_rest_field( $object_type, $attributes, $args );
 	}
 }

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -415,7 +415,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'attachment', 'my_custom_int', array(
+		register_rest_field( 'attachment', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 		) );

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -867,7 +867,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'comment', 'my_custom_int', array(
+		register_rest_field( 'comment', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -109,7 +109,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'status', 'my_custom_int', array(
+		register_rest_field( 'status', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -75,7 +75,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'type', 'my_custom_int', array(
+		register_rest_field( 'type', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1231,7 +1231,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'post', 'my_custom_int', array(
+		register_rest_field( 'post', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -175,7 +175,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'posts-revision', 'my_custom_int', array(
+		register_rest_field( 'posts-revision', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -816,7 +816,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_api_field( 'user', 'my_custom_int', array(
+		register_rest_field( 'user', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),


### PR DESCRIPTION
Introduces a `register_api_field()` function for backwards compat, which
calls `_doing_it_wrong()`

Fixes #1321