### PR TITLE
Return object for requests to `/wp/v2/taxonomies`

### DIFF
--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -49,7 +49,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				continue;
 			}
 			$tax = $this->prepare_response_for_collection( $tax );
-			$data[] = $tax;
+			$data[ $tax_type ] = $tax;
 		}
 		return $data;
 	}

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -15,13 +15,14 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$data = $response->get_data();
 		$taxonomies = $this->get_public_taxonomies( get_taxonomies( '', 'objects' ) );
 		$this->assertEquals( count( $taxonomies ), count( $data ) );
-		// Check each key in $data against those in $taxonomies
-		foreach ( array_keys( $data ) as $key ) {
-			$this->assertEquals( $taxonomies[ $key ]->label, $data[ $key ]['name'] );
-			$this->assertEquals( $taxonomies[ $key ]->name, $data[ $key ]['slug'] );
-			$this->assertEquals( $taxonomies[ $key ]->hierarchical, $data[ $key ]['hierarchical'] );
-			$this->assertEquals( $taxonomies[ $key ]->show_tagcloud, $data[ $key ]['show_cloud'] );
-		}
+		$this->assertEquals( 'Categories', $data['category']['name'] );
+		$this->assertEquals( 'category', $data['category']['slug'] );
+		$this->assertEquals( true, $data['category']['hierarchical'] );
+		$this->assertEquals( true, $data['category']['show_cloud'] );
+		$this->assertEquals( 'Tags', $data['post_tag']['name'] );
+		$this->assertEquals( 'post_tag', $data['post_tag']['slug'] );
+		$this->assertEquals( false, $data['post_tag']['hierarchical'] );
+		$this->assertEquals( true, $data['post_tag']['show_cloud'] );
 	}
 
 	public function test_get_taxonomies_with_types() {


### PR DESCRIPTION
This is consistent with `/wp/v2/types` and `/wp/v2/statuses`

Fixes #1819