### PR TITLE
Consistently indicate `context` argument for GET requests

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -905,7 +905,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$query_params = parent::get_collection_params();
 
 		$query_params['context']['default'] = 'view';
-		$query_params['context']['enum'] = array( 'embed', 'view', 'edit' );
 
 		$query_params['author_email'] = array(
 			'default'           => null,

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -10,13 +10,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		$query_params = $this->get_collection_params();
 		register_rest_route( 'wp/v2', '/comments', array(
 			array(
 				'methods'   => WP_REST_Server::READABLE,
 				'callback'  => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'      => $query_params,
+				'args'      => $this->get_collection_params(),
 			),
 			array(
 				'methods'  => WP_REST_Server::CREATABLE,
@@ -34,8 +33,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'callback' => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'     => array(
-					'context'  => array(
-						'default'  => 'view',
+					'context'          => array(
+						'default'      => 'view',
+						'type'         => 'string',
+						'enum'         => array( 'embed', 'view', 'edit' ),
 					),
 				),
 			),

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -218,7 +218,7 @@ abstract class WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		return array(
+		$params = array(
 			'context'                => array(
 				'description'        => 'Scope under which the request is made; determines fields present in response.',
 				'type'               => 'string',
@@ -241,6 +241,19 @@ abstract class WP_REST_Controller {
 				'sanitize_callback'  => 'sanitize_text_field',
 			),
 		);
+		$schema = $this->get_item_schema();
+		$contexts = array();
+		if ( ! empty( $schema['properties'] ) ) {
+			foreach( $schema['properties'] as $key => $attributes ) {
+				if ( ! empty( $attributes['context'] ) ) {
+					$contexts = array_merge( $contexts, $attributes['context'] );
+				}
+			}
+		}
+		if ( ! empty( $contexts ) ) {
+			$params['context']['enum'] = array_unique( $contexts );
+		}
+		return $params;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -244,7 +244,7 @@ abstract class WP_REST_Controller {
 		$schema = $this->get_item_schema();
 		$contexts = array();
 		if ( ! empty( $schema['properties'] ) ) {
-			foreach( $schema['properties'] as $key => $attributes ) {
+			foreach ( $schema['properties'] as $key => $attributes ) {
 				if ( ! empty( $attributes['context'] ) ) {
 					$contexts = array_merge( $contexts, $attributes['context'] );
 				}

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -131,14 +131,10 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		return array(
-			'context'          => array(
-				'description'  => $params['context']['description'],
-				'type'         => $params['context']['type'],
-				'default'      => 'edit',
-				'enum'         => array( 'edit' ),
-			),
-		);
+		$new_params = array();
+		$new_params['context'] = $params['context'];
+		$new_params['context']['default'] = 'edit';
+		return $new_params;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -40,11 +40,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => array(
-					'context'             => array(
-						'default'             => 'view',
-					),
-				),
+				'args'                => $this->get_collection_params(),
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
@@ -61,8 +57,10 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
-					'context'             => array(
-						'default'             => 'view',
+					'context'          => array(
+						'default'      => 'edit',
+						'type'         => 'string',
+						'enum'         => array( 'edit' ),
 					),
 				),
 			),
@@ -124,6 +122,23 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 			),
 		);
 		return $schema;
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		return array(
+			'context'          => array(
+				'description'  => $params['context']['description'],
+				'type'         => $params['context']['type'],
+				'default'      => 'edit',
+				'enum'         => array( 'edit' ),
+			),
+		);
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -26,7 +26,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 						'type'         => 'string',
 						'enum'         => array( 'view' ),
 					),
-				)
+				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -11,6 +11,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
+				'args'            => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -19,6 +20,13 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
+				'args'            => array(
+					'context'          => array(
+						'default'      => 'view',
+						'type'         => 'string',
+						'enum'         => array( 'view' ),
+					),
+				)
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -158,6 +166,23 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 				),
 			);
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		return array(
+			'context'          => array(
+				'description'  => $params['context']['description'],
+				'type'         => $params['context']['type'],
+				'default'      => 'view',
+				'enum'         => array( 'view' ),
+			),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -175,14 +175,10 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		return array(
-			'context'          => array(
-				'description'  => $params['context']['description'],
-				'type'         => $params['context']['type'],
-				'default'      => 'view',
-				'enum'         => array( 'view' ),
-			),
-		);
+		$new_params = array();
+		$new_params['context'] = $params['context'];
+		$new_params['context']['default'] = 'view';
+		return $new_params;
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -11,11 +11,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
-				'args'            => array(
-					'post_type'          => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
+				'args'            => $this->get_collection_params(),
 			),
 			'schema'          => array( $this, 'get_public_item_schema' ),
 		) );
@@ -136,6 +132,23 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 				),
 			);
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		return array(
+			'context'          => array(
+				'description'  => $params['context']['description'],
+				'type'         => $params['context']['type'],
+				'default'      => 'view',
+				'enum'         => array( 'view' ),
+			),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -141,14 +141,10 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		return array(
-			'context'          => array(
-				'description'  => $params['context']['description'],
-				'type'         => $params['context']['type'],
-				'default'      => 'view',
-				'enum'         => array( 'view' ),
-			),
-		);
+		$new_params = array();
+		$new_params['context'] = $params['context'];
+		$new_params['context']['default'] = 'view';
+		return $new_params;
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -15,14 +15,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$base = $this->get_post_type_base( $this->post_type );
 
-		$posts_args = $this->get_collection_params();
-
 		register_rest_route( 'wp/v2', '/' . $base, array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'            => $posts_args,
+				'args'            => $this->get_collection_params(),
 			),
 			array(
 				'methods'         => WP_REST_Server::CREATABLE,
@@ -41,6 +39,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'args'            => array(
 					'context'          => array(
 						'default'      => 'view',
+						'type'         => 'string',
+						'enum'         => array( 'embed', 'view', 'edit' ),
 					),
 				),
 			),

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1556,7 +1556,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$params = parent::get_collection_params();
 
 		$params['context']['default'] = 'view';
-		$params['context']['enum'] = array( 'embed', 'view', 'edit' );
 
 		if ( post_type_supports( $this->post_type, 'author' ) ) {
 			$params['author'] = array(

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -19,13 +19,12 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$base     = $this->posts_controller->get_post_type_base( $this->post_type );
 		$tax_base = $this->terms_controller->get_taxonomy_base( $this->taxonomy );
 
-		$query_params = $this->get_collection_params();
 		register_rest_route( 'wp/v2', sprintf( '/%s/(?P<post_id>[\d]+)/%s', $base, $tax_base ), array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => $query_params,
+				'args'                => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -289,7 +289,6 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		$query_params = array();
 
 		$query_params['context']['default'] = 'view';
-		$query_params['context']['enum'] = array( 'view' );
 
 		$query_params['order'] = array(
 			'description'        => 'Order sort attribute ascending or descending.',

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -361,14 +361,10 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		return array(
-			'context'          => array(
-				'description'  => $params['context']['description'],
-				'type'         => $params['context']['type'],
-				'default'      => 'view',
-				'enum'         => array( 'view' ),
-			),
-		);
+		$new_params = array();
+		$new_params['context'] = $params['context'];
+		$new_params['context']['default'] = 'view';
+		return $new_params;
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -22,11 +22,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'            => array(
-					'context'          => array(
-						'default'      => 'view',
-					),
-				),
+				'args'            => $this->get_collection_params(),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -356,6 +352,23 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		}
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		return array(
+			'context'          => array(
+				'description'  => $params['context']['description'],
+				'type'         => $params['context']['type'],
+				'default'      => 'view',
+				'enum'         => array( 'view' ),
+			),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -187,17 +187,12 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		$new_params = array(
-			'context'          => array(
-				'description'  => $params['context']['description'],
-				'type'         => $params['context']['type'],
-				'default'      => 'view',
-				'enum'         => array( 'view' ),
-			),
-			'post_type'        => array(
-				'description'  => 'Limit results to taxonomies associated with a specific post type.',
-				'type'         => 'string',
-			),
+		$new_params = array();
+		$new_params['context'] = $params['context'];
+		$new_params['context']['default'] = 'view';
+		$new_params['post_type'] = array(
+			'description'  => 'Limit results to taxonomies associated with a specific post type.',
+			'type'         => 'string',
 		);
 		return $new_params;
 	}

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -11,11 +11,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
-				'args'            => array(
-					'post_type'   => array(
-						'sanitize_callback' => 'sanitize_key',
-					),
-				),
+				'args'            => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -182,6 +178,28 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				),
 			);
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$new_params = array(
+			'context'          => array(
+				'description'  => $params['context']['description'],
+				'type'         => $params['context']['type'],
+				'default'      => 'view',
+				'enum'         => array( 'view' ),
+			),
+			'post_type'        => array(
+				'description'  => 'Limit results to taxonomies associated with a specific post type.',
+				'type'         => 'string',
+			),
+		);
+		return $new_params;
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -20,13 +20,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	public function register_routes() {
 
 		$base = $this->get_taxonomy_base( $this->taxonomy );
-		$query_params = $this->get_collection_params();
 		register_rest_route( 'wp/v2', '/' . $base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => $query_params,
+				'args'                => $this->get_collection_params(),
 			),
 			array(
 				'methods'     => WP_REST_Server::CREATABLE,

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -585,7 +585,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$query_params = parent::get_collection_params();
 
 		$query_params['context']['default'] = 'view';
-		$query_params['context']['enum'] = array( 'embed', 'view' );
 
 		$query_params['order']      = array(
 			'description'           => 'Order sort attribute ascending or descending.',

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -10,12 +10,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		$query_params = $this->get_collection_params();
 		register_rest_route( 'wp/v2', '/users', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
-				'args'            => $query_params,
+				'args'            => $this->get_collection_params(),
 			),
 			array(
 				'methods'         => WP_REST_Server::CREATABLE,

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -771,7 +771,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$query_params = parent::get_collection_params();
 
 		$params['context']['default'] = 'view';
-		$params['context']['enum'] = array( 'embed', 'view', 'edit' );
 
 		$query_params['order'] = array(
 			'default'            => 'asc',


### PR DESCRIPTION
Fixes #1706