### PR TITLE
Change terms endpoints to use term_id not tt_id

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -104,11 +104,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$terms = wp_get_object_terms( $post->ID, $this->taxonomy );
 
-		if ( ! in_array( $term_id, wp_list_pluck( $terms, 'term_taxonomy_id' ) ) ) {
+		if ( ! in_array( $term_id, wp_list_pluck( $terms, 'term_id' ) ) ) {
 			return new WP_Error( 'rest_post_not_in_term', __( 'Invalid taxonomy for post id.' ), array( 'status' => 404 ) );
 		}
 
-		$term = $this->terms_controller->prepare_item_for_response( get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ), $request );
+		$term = $this->terms_controller->prepare_item_for_response( get_term( $term_id, $this->taxonomy ), $request );
 
 		$response = rest_ensure_response( $term );
 
@@ -130,14 +130,14 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 			return $is_request_valid;
 		}
 
-		$term = get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy );
+		$term = get_term( $term_id, $this->taxonomy );
 		$tt_ids = wp_set_object_terms( $post->ID, $term->term_id, $this->taxonomy, true );
 
 		if ( is_wp_error( $tt_ids ) ) {
 			return $tt_ids;
 		}
 
-		$term = $this->terms_controller->prepare_item_for_response( get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy ), $request );
+		$term = $this->terms_controller->prepare_item_for_response( get_term( $term_id, $this->taxonomy ), $request );
 
 		$response = rest_ensure_response( $term );
 		$response->set_status( 201 );
@@ -224,7 +224,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 		if ( ! empty( $request['term_id'] ) ) {
 			$term_id  = absint( $request['term_id'] );
 
-			$term = get_term_by( 'term_taxonomy_id', $term_id, $this->taxonomy );
+			$term = get_term( $term_id, $this->taxonomy );
 			if ( ! $term || $term->taxonomy !== $this->taxonomy ) {
 				return new WP_Error( 'rest_term_invalid', __( "Term doesn't exist." ), array( 'status' => 404 ) );
 			}

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -83,7 +83,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				// Only query top-level terms.
 				$prepared_args['parent'] = 0;
 			} else {
-				if ( $parent ) {
+				if ( $request['parent'] ) {
 					$prepared_args['parent'] = $request['parent'];
 				}
 			}

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -73,9 +73,9 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_item() {
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
+		wp_set_object_terms( $this->post_id, $tag['term_id'], 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertFalse( $response->is_error() );
 
@@ -84,7 +84,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_item_invalid_post() {
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		wp_set_object_terms( $this->post_id, $tag['term_taxonomy_id'], 'post_tag' );
+		wp_set_object_terms( $this->post_id, $tag['term_id'], 'post_tag' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
@@ -120,7 +120,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		$term = wp_insert_term( 'some-term', $this->public_taxonomy_pages );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $term['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $term['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
@@ -130,7 +130,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
@@ -138,7 +138,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 	public function test_get_item_term_id_not_added() {
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_not_in_term', $response, 404 );
@@ -158,7 +158,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_create_item_invalid_permission() {
 
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -168,7 +168,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -178,7 +178,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
@@ -198,7 +198,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -210,7 +210,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -222,7 +222,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/invalid_taxonomy/%d', $this->post_id, $tag['term_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -246,7 +246,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 
@@ -262,7 +262,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 		$term = get_term( $tag['term_id'], 'post_tag' );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -148,7 +148,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 201, $response->get_status() );
@@ -158,7 +158,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 	public function test_create_item_invalid_permission() {
 
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', $this->post_id, $tag['term_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', $this->post_id, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -168,7 +168,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 
 		wp_set_current_user( $this->admin_id );
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
-		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_taxonomy_id'] ) );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_id'] ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
@@ -246,7 +246,7 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$tag = wp_insert_term( 'test-tag', 'post_tag' );
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/terms/tag/%d', 9999, $tag['term_id'] ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d/tags/%d', 9999, $tag['term_id'] ) );
 		$request['force'] = true;
 		$response = $this->server->dispatch( $request );
 

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -476,7 +476,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/tag/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_taxonomy_id );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_not_hierarchical', $response, 400 );

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -375,18 +375,18 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$parent = wp_insert_term( 'test-category', 'category' );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$request->set_param( 'name', 'My Awesome Term' );
-		$request->set_param( 'parent', $parent['term_taxonomy_id'] );
+		$request->set_param( 'parent', $parent['term_id'] );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 201, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( $parent['term_taxonomy_id'], $data['parent'] );
+		$this->assertEquals( $parent['term_id'], $data['parent'] );
 	}
 
 	public function test_create_item_invalid_parent() {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'My Awesome Term' );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
@@ -411,7 +411,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'original-slug',
 			);
 		$term = get_term_by( 'id', $this->factory->category->create( $orig_args ), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'New Name' );
 		$request->set_param( 'description', 'New Description' );
 		$request->set_param( 'slug', 'new-slug' );
@@ -442,7 +442,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'Incorrect permissions' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -454,19 +454,19 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
-		$request->set_param( 'parent', $parent->term_taxonomy_id );
+		$request->set_param( 'parent', $parent->term_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertEquals( $parent->term_taxonomy_id, $data['parent'] );
+		$this->assertEquals( $parent->term_id, $data['parent'] );
 	}
 
 	public function test_update_item_invalid_parent() {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 400 );
@@ -476,7 +476,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/terms/tag/' . $term->term_taxonomy_id );
 		$request->set_param( 'parent', 9999 );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_taxonomy_not_hierarchical', $response, 400 );
@@ -485,7 +485,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item() {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
@@ -510,7 +510,7 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_incorrect_permissions() {
 		wp_set_current_user( $this->subscriber );
 		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_taxonomy_id );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}


### PR DESCRIPTION
See #1628

We can now treat the term_id as unique across taxonomies, this simplifies things a good amount.