### PR TITLE
Introduce `get_context_param()` for getting the magical context param

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -33,11 +33,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'callback' => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'     => array(
-					'context'          => array(
-						'default'      => 'view',
-						'type'         => 'string',
-						'enum'         => array( 'embed', 'view', 'edit' ),
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -218,7 +218,7 @@ abstract class WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = array(
+		return array(
 			'context'                => $this->get_context_param(),
 			'page'                   => array(
 				'description'        => 'Current page of the collection.',

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -266,6 +266,7 @@ abstract class WP_REST_Controller {
 		}
 		if ( ! empty( $contexts ) ) {
 			$param_details['enum'] = array_unique( $contexts );
+			rsort( $param_details['enum'] );
 		}
 		return array_merge( $param_details, $args );
 	}

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -219,10 +219,7 @@ abstract class WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$params = array(
-			'context'                => array(
-				'description'        => 'Scope under which the request is made; determines fields present in response.',
-				'type'               => 'string',
-				),
+			'context'                => $this->get_context_param(),
 			'page'                   => array(
 				'description'        => 'Current page of the collection.',
 				'type'               => 'integer',
@@ -241,19 +238,34 @@ abstract class WP_REST_Controller {
 				'sanitize_callback'  => 'sanitize_text_field',
 			),
 		);
+	}
+
+	/**
+	 * Get the magical context param.
+	 *
+	 * @param array     $args
+	 * @return array
+	 */
+	public function get_context_param( $args = array() ) {
+		$param_details = array(
+			'description'        => 'Scope under which the request is made; determines fields present in response.',
+			'type'               => 'string',
+		);
 		$schema = $this->get_item_schema();
 		$contexts = array();
-		if ( ! empty( $schema['properties'] ) ) {
-			foreach ( $schema['properties'] as $key => $attributes ) {
-				if ( ! empty( $attributes['context'] ) ) {
-					$contexts = array_merge( $contexts, $attributes['context'] );
-				}
+		if ( empty( $schema['properties'] ) ) {
+			return array_merge( $param_details, $args );
+		}
+		$contexts = array();
+		foreach ( $schema['properties'] as $key => $attributes ) {
+			if ( ! empty( $attributes['context'] ) ) {
+				$contexts = array_merge( $contexts, $attributes['context'] );
 			}
 		}
 		if ( ! empty( $contexts ) ) {
-			$params['context']['enum'] = array_unique( $contexts );
+			$param_details['enum'] = array_unique( $contexts );
 		}
-		return $params;
+		return array_merge( $param_details, $args );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -243,6 +243,8 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get the magical context param.
 	 *
+	 * Ensures consistent description between endpoints, and populates enum from schema.
+	 *
 	 * @param array     $args
 	 * @return array
 	 */

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -57,11 +57,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
-					'context'          => array(
-						'default'      => 'edit',
-						'type'         => 'string',
-						'enum'         => array( 'edit' ),
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'edit' ) ),
 				),
 			),
 			array(

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -21,11 +21,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
 				'args'            => array(
-					'context'          => array(
-						'default'      => 'view',
-						'type'         => 'string',
-						'enum'         => array( 'view' ),
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -174,11 +170,9 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$new_params = array();
-		$new_params['context'] = $params['context'];
-		$new_params['context']['default'] = 'view';
-		return $new_params;
+		return array(
+			'context'        => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -20,6 +20,9 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
+				'args'            => array(
+					'context'     => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
 			),
 			'schema'          => array( $this, 'get_public_item_schema' ),
 		) );
@@ -149,11 +152,9 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$new_params = array();
-		$new_params['context'] = $params['context'];
-		$new_params['context']['default'] = 'view';
-		return $new_params;
+		return array(
+			'context'      => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -37,11 +37,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'            => array(
-					'context'          => array(
-						'default'      => 'view',
-						'type'         => 'string',
-						'enum'         => array( 'embed', 'view', 'edit' ),
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -34,6 +34,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array(
+					'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -290,9 +290,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function get_collection_params() {
 		$query_params = array();
-
-		$query_params['context']['default'] = 'view';
-
+		$query_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 		$query_params['order'] = array(
 			'description'        => 'Order sort attribute ascending or descending.',
 			'type'               => 'string',

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -34,9 +34,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'            => array(
-					'context'          => array(
-						'default'      => 'view',
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(
@@ -360,11 +358,9 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$new_params = array();
-		$new_params['context'] = $params['context'];
-		$new_params['context']['default'] = 'view';
-		return $new_params;
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -21,6 +21,9 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'            => array(
+					'context'     => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -188,8 +191,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
 		$new_params = array();
-		$new_params['context'] = $params['context'];
-		$new_params['context']['default'] = 'view';
+		$new_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 		$new_params['post_type'] = array(
 			'description'  => 'Limit results to taxonomies associated with a specific post type.',
 			'type'         => 'string',

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -41,6 +41,9 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
 			),
 			array(
 				'methods'    => WP_REST_Server::EDITABLE,

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -35,7 +35,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'            => array(
-					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
+					'context'          => $this->get_context_param( array( 'default' => 'embed' ) ),
 				),
 			),
 			array(
@@ -768,7 +768,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
 
-		$params['context']['default'] = 'view';
+		$query_params['context']['default'] = 'view';
 
 		$query_params['order'] = array(
 			'default'            => 'asc',

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -35,9 +35,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'            => array(
-					'context'          => array(
-						'default'      => 'embed',
-					),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(

--- a/tests/class-wp-test-rest-controller-testcase.php
+++ b/tests/class-wp-test-rest-controller-testcase.php
@@ -23,6 +23,8 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 
 	abstract public function test_register_routes();
 
+	abstract public function test_context_param();
+
 	abstract public function test_get_items();
 
 	abstract public function test_get_item();

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -35,6 +35,25 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertCount( 3, $routes['/wp/v2/media/(?P<id>[\d]+)'] );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/media' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_excerpt'   => 'A sample caption',
+		) );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/media/' . $attachment_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$attachment_id = $this->factory->attachment->create_object( $this->test_file, 0, array(
 			'post_mime_type' => 'image/jpeg',

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -66,13 +66,13 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/comments/' . $this->approved_id );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function test_get_items() {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -60,6 +60,21 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertCount( 3, $routes['/wp/v2/comments/(?P<id>[\d]+)'] );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/comments' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/comments/' . $this->approved_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$this->factory->comment->create_post_comments( $this->post_id, 6 );
 

--- a/tests/test-rest-meta-posts-controller.php
+++ b/tests/test-rest-meta-posts-controller.php
@@ -25,6 +25,23 @@ class WP_Test_REST_Meta_Posts_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertCount( 3, $routes['/wp/v2/posts/(?P<parent_id>[\d]+)/meta/(?P<id>[\d]+)'] );
 	}
 
+	public function test_context_param() {
+		$post_id = $this->factory->post->create();
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $post_id . '/meta' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$meta_id_basic = add_post_meta( $post_id, 'testkey', 'testvalue' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $post_id . '/meta/' . $meta_id_basic );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'edit', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$post_id = $this->factory->post->create();
 		$meta_id_basic = add_post_meta( $post_id, 'testkey', 'testvalue' );

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -27,6 +27,22 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/pages' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/pages/' . $page_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 
 	}

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -8,6 +8,21 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$this->assertArrayHasKey( '/wp/v2/statuses/(?P<status>[\w-]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/statuses' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/statuses/publish' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -8,6 +8,21 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertArrayHasKey( '/wp/v2/types/(?P<type>[\w-]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/types' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/types/post' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/types' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -35,6 +35,21 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 3, $routes['/wp/v2/posts/(?P<id>[\d]+)'] );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -18,6 +18,23 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$this->assertArrayHasKey( '/wp/v2/posts/(?P<post_id>[\d]+)/tags/(?P<term_id>[\d]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id . '/tags' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$tag = wp_insert_term( 'foo', 'post_tag' );
+		wp_set_object_terms( $this->post_id, 'foo', 'post_tag' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id . '/tags/' . $tag['term_id'] );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 
 		wp_set_object_terms( $this->post_id, 'test-tag', 'post_tag' );

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -37,6 +37,21 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$this->assertArrayHasKey( '/wp/v2/pages/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id . '/revisions' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_1->ID );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		wp_set_current_user( $this->editor_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions' );

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -9,6 +9,21 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertArrayHasKey( '/wp/v2/taxonomies/(?P<taxonomy>[\w-]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/taxonomies' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/taxonomies/post_tag' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -26,6 +26,22 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( '/wp/v2/tags/(?P<id>[\d]+)', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$tag1 = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags/' . $tag1 );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -35,6 +35,21 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( '/wp/v2/users/me', $routes );
 	}
 
+	public function test_context_param() {
+		// Collection
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+		// Single
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $this->user );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'embed', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
+	}
+
 	public function test_get_items() {
 		wp_set_current_user( $this->user );
 


### PR DESCRIPTION
Abstracting this to a common method lets us reuse it between `GET`
collection and `GET` single instance

See #1706