### PR TITLE
Change taxonomies' `post_type` argument to `type`

### DIFF
--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -33,8 +33,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_items( $request ) {
-		if ( ! empty( $request['post_type'] ) ) {
-			$taxonomies = get_object_taxonomies( $request['post_type'], 'objects' );
+		if ( ! empty( $request['type'] ) ) {
+			$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
 		} else {
 			$taxonomies = get_taxonomies( '', 'objects' );
 		}
@@ -190,7 +190,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$new_params = array();
 		$new_params['context'] = $params['context'];
 		$new_params['context']['default'] = 'view';
-		$new_params['post_type'] = array(
+		$new_params['type'] = array(
 			'description'  => 'Limit results to taxonomies associated with a specific post type.',
 			'type'         => 'string',
 		);

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -27,7 +27,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_taxonomies_with_types() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
-		$request->set_param( 'post_type', 'post' );
+		$request->set_param( 'type', 'post' );
 		$response = $this->server->dispatch( $request );
 		$this->check_taxonomies_for_type_response( 'post', $response );
 	}


### PR DESCRIPTION
It's consistent with how we're exposing post types in the API

Fixes #1836