### PR TITLE
Fix link relations for individual types and taxonomies

### DIFF
--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -86,6 +86,9 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 		$base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
 		$response->add_links( array(
 			'collection'     => array(
+				'href'       => rest_url( 'wp/v2/types' ),
+			),
+			'item'           => array(
 				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
 			),
 		) );

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -113,6 +113,9 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		$response->add_links( array(
 			'collection'     => array(
+				'href'       => rest_url( 'wp/v2/taxonomies' ),
+			),
+			'item'     => array(
 				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
 			),
 		) );

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -107,7 +107,8 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( $post_type_obj->name, $data['slug'] );
 		$this->assertEquals( $post_type_obj->description, $data['description'] );
 		$this->assertEquals( $post_type_obj->hierarchical, $data['hierarchical'] );
-		$this->assertArrayHasKey( 'collection', $links );
+		$this->assertEquals( rest_url( 'wp/v2/types' ), $links['collection'][0]['href'] );
+		$this->assertArrayHasKey( 'item', $links );
 	}
 
 	protected function check_post_type_object_response( $response ) {

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -110,7 +110,8 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( $tax_obj->description, $data['description'] );
 		$this->assertEquals( $tax_obj->show_tagcloud, $data['show_cloud'] );
 		$this->assertEquals( $tax_obj->hierarchical, $data['hierarchical'] );
-		$this->assertArrayHasKey( 'collection', $links );
+		$this->assertEquals( rest_url( 'wp/v2/taxonomies' ), $links['collection'][0]['href'] );
+		$this->assertArrayHasKey( 'item', $links );
 	}
 
 	protected function check_taxonomy_object_response( $response ) {


### PR DESCRIPTION
`collection` should go to the collection of types and taxonomies,
respectively. While imperfect, `item` is the best definition we have for
the link to the collection of items.

From https://github.com/WP-API/WP-API/pull/1829#issuecomment-163777701