### PR TITLE
Remove compatibility repo for WordPress 4.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "core"]
-	path = core
-	url = https://github.com/WP-API/api-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
   - php: 5.6
     env: WP_TRAVISCI=travis:phpunit WP_VERSION=latest
   - php: 5.6
-    env: WP_TRAVISCI=travis:phpunit WP_VERSION=4.3.1
-  - php: 5.6
     env: WP_TRAVISCI=travis:phpvalidate
   - php: 5.6
     env: WP_TRAVISCI=travis:codecoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
     env: WP_TRAVISCI=travis:phpunit WP_VERSION=nightly
   allow_failures:
   - php: hhvm
-  - php: 7.0
   fast_finish: true
 
 cache:

--- a/bin/readme.txt
+++ b/bin/readme.txt
@@ -1,8 +1,8 @@
 === WordPress REST API (Version 2) ===
 Contributors: rmccue, rachelbaker, danielbachhuber, joehoyle
 Tags: json, rest, api, rest-api
-Requires at least: 4.3
-Tested up to: 4.4
+Requires at least: 4.4
+Tested up to: 4.5-alpha
 Stable tag: 2.0-beta9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/plugin.php
+++ b/plugin.php
@@ -9,11 +9,6 @@
  * License: GPL2+
  */
 
-// Do we need the compatibility repo?
-if ( ! defined( 'REST_API_VERSION' ) ) {
-	require_once dirname( __FILE__ ) . '/core/rest-api.php';
-}
-
 /**
  * WP_REST_Controller class.
  */


### PR DESCRIPTION
WordPress 4.4 is now the latest stable release

Fixes #1794