### PR TITLE
Prevent error notice when `show_in_rest` isn't set for a post type

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -908,7 +908,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$post_type = get_post_type_object( $post_type );
 		}
 
-		if ( ! empty( $post_type ) && $post_type->show_in_rest ) {
+		if ( ! empty( $post_type ) && ! empty( $post_type->show_in_rest ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes #1850