### PR TITLE
Fix link relations for individual types and taxonomies, part 2

### DIFF
--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -88,11 +88,11 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 
 		$base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
 		$response->add_links( array(
-			'collection'     => array(
-				'href'       => rest_url( 'wp/v2/types' ),
+			'collection'              => array(
+				'href'                => rest_url( 'wp/v2/types' ),
 			),
-			'item'           => array(
-				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
+			'https://api.w.org/items' => array(
+				'href'                => rest_url( sprintf( 'wp/v2/%s', $base ) ),
 			),
 		) );
 

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -115,11 +115,11 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 
 		$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		$response->add_links( array(
-			'collection'     => array(
-				'href'       => rest_url( 'wp/v2/taxonomies' ),
+			'collection'                => array(
+				'href'                  => rest_url( 'wp/v2/taxonomies' ),
 			),
-			'item'     => array(
-				'href'       => rest_url( sprintf( 'wp/v2/%s', $base ) ),
+			'https://api.w.org/items'   => array(
+				'href'                  => rest_url( sprintf( 'wp/v2/%s', $base ) ),
 			),
 		) );
 

--- a/tests/test-rest-post-types-controller.php
+++ b/tests/test-rest-post-types-controller.php
@@ -123,7 +123,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( $post_type_obj->description, $data['description'] );
 		$this->assertEquals( $post_type_obj->hierarchical, $data['hierarchical'] );
 		$this->assertEquals( rest_url( 'wp/v2/types' ), $links['collection'][0]['href'] );
-		$this->assertArrayHasKey( 'item', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/items', $links );
 	}
 
 	protected function check_post_type_object_response( $response ) {

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -126,7 +126,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( $tax_obj->show_tagcloud, $data['show_cloud'] );
 		$this->assertEquals( $tax_obj->hierarchical, $data['hierarchical'] );
 		$this->assertEquals( rest_url( 'wp/v2/taxonomies' ), $links['collection'][0]['href'] );
-		$this->assertArrayHasKey( 'item', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/items', $links );
 	}
 
 	protected function check_taxonomy_object_response( $response ) {


### PR DESCRIPTION
Use custom `https://api.w.org/items` relation instead of incorrect
`item` relation.

See https://github.com/WP-API/WP-API/pull/1846#issuecomment-164086269