### PR TITLE
Fix invalid capability for comments get items permissions callback

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -358,7 +358,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( 'manage_comments' ) ) {
+		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( 'moderate_comments' ) ) {
 			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot view comments with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -96,6 +96,14 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
+	public function test_get_items_edit_context() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_get_items_for_post() {
 		$second_post_id = $this->factory->post->create();
 		$this->factory->comment->create_post_comments( $second_post_id, 2 );


### PR DESCRIPTION
`manage_comments` doesn't exist; `moderate_comments` does