### PR TITLE
Fix fatal error when `prepare_item_for_database` returns a WP_Error

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -146,6 +146,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$prepared_comment = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
 
 		// Setting remaining values before wp_insert_comment so we can
 		// use wp_allow_comment().
@@ -242,6 +245,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$prepared_args = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_args ) ) {
+			return $prepared_args;
+		}
 
 		if ( empty( $prepared_args ) && isset( $request['status'] ) ) {
 			// Only the comment status is being changed.


### PR DESCRIPTION
Discovered while working on #1880:
`WP_REST_Comments_Controller->prepare_item_for_database()` can return a WP_Error, but we currently assume it won't.  This can result in a Fatal error when trying to use the WP_Error object as an array.

 