### PR TITLE
Defer to `edit_posts` of the custom post type

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -558,7 +558,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 */
 		$valid_vars = apply_filters( 'query_vars', $wp->public_query_vars );
 
-		if ( current_user_can( 'edit_posts' ) ) {
+		$post_type_obj = get_post_type_object( $this->post_type );
+		if ( current_user_can( $post_type_obj->cap->edit_posts ) ) {
 			/**
 			 * Filter the allowed 'private' query vars for authorized users.
 			 *

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -47,6 +47,23 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	}
 
+	public function test_get_items_private_filter_query_var() {
+		// Private query vars inaccessible to unauthorized users
+		wp_set_current_user( 0 );
+		$page_id = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page' ) );
+		$draft_id = $this->factory->post->create( array( 'post_status' => 'draft', 'post_type' => 'page' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'filter', array( 'post_status' => 'draft' ) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $page_id, $data[0]['id'] );
+		// But they are accessible to authorized users
+		wp_set_current_user( $this->editor_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $draft_id, $data[0]['id'] );
+	}
+
 	public function test_get_item() {
 
 	}

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -56,11 +56,13 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request->set_param( 'filter', array( 'post_status' => 'draft' ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
+		$this->assertCount( 1, $data );
 		$this->assertEquals( $page_id, $data[0]['id'] );
 		// But they are accessible to authorized users
 		wp_set_current_user( $this->editor_id );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
+		$this->assertCount( 1, $data );
 		$this->assertEquals( $draft_id, $data[0]['id'] );
 	}
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -248,11 +248,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request->set_param( 'filter', array( 'post_status' => 'draft' ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
+		$this->assertCount( 1, $data );
 		$this->assertEquals( $this->post_id, $data[0]['id'] );
 		// But they are accessible to authorized users
 		wp_set_current_user( $this->editor_id );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
+		$this->assertCount( 1, $data );
 		$this->assertEquals( $draft_id, $data[0]['id'] );
 	}
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -240,6 +240,22 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertContains( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 	}
 
+	public function test_get_items_private_filter_query_var() {
+		// Private query vars inaccessible to unauthorized users
+		wp_set_current_user( 0 );
+		$draft_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'filter', array( 'post_status' => 'draft' ) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $this->post_id, $data[0]['id'] );
+		// But they are accessible to authorized users
+		wp_set_current_user( $this->editor_id );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $draft_id, $data[0]['id'] );
+	}
+
 	public function test_get_item() {
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
These private query variables should be accessible to CPTs when a user
can't create normal posts.