### PR TITLE
check that the post type has a show_in_rest property 

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -908,7 +908,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$post_type = get_post_type_object( $post_type );
 		}
 
-		if ( ! empty( $post_type ) && $post_type->show_in_rest ) {
+		if ( ! empty( $post_type ) && property_exists( $post_type, 'show_in_rest') && $post_type->show_in_rest ) {
 			return true;
 		}
 


### PR DESCRIPTION
When hitting an endpoint (not /revisions) for a post that is in the 'revision' state, we get an 
undefined property when calling check_is_post_type_allowed.

Notice: Undefined property: stdClass::$show_in_rest in rest-api/lib/endpoints/class-wp-rest-posts-controller.php on line 911