### PR TITLE
Add filter for get_endpoint_args_for_item_schema

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -437,7 +437,14 @@ abstract class WP_REST_Controller {
 			}
 		}
 
-		return $endpoint_args;
+		/**
+		 * Filter item schema arguments for endpoint.
+		 *
+		 * @param array  $endpoint_args Array of arguments for WP_User_Query.
+		 * @param string $method        The current method.
+		 * @param array  $schema        The current item's schema, conforming to JSON Schema.
+		 */
+		return apply_filters( 'rest_get_endpoint_args_for_item_schema', $endpoint_args, $method, $schema );
 	}
 
 	/**


### PR DESCRIPTION
I would like to see a filter for `get_endpoint_args_for_item_schema` so this core code for the item schema can be extended instead of re-written and extended.