### PR TITLE
Sanitize per_page with intval to allow for -1

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -230,7 +230,7 @@ abstract class WP_REST_Controller {
 				'description'        => 'Maximum number of items to be returned in result set.',
 				'type'               => 'integer',
 				'default'            => 10,
-				'sanitize_callback'  => 'absint',
+				'sanitize_callback'  => 'intval',
 			),
 			'search'                 => array(
 				'description'        => 'Limit results to those matching a string.',


### PR DESCRIPTION
Sanitize `per_page` with `intval` to allow for `-1` value. See [WP_Query:Pagination Parameters](https://codex.wordpress.org/Class_Reference/WP_Query#Pagination_Parameters). Obviously, this is less than ideal for any REST request but since it is allowable in core on page render, why not allow it for REST API?