### PR TITLE
Cast integer with (int) over intval for speed

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -519,7 +519,7 @@ abstract class WP_REST_Controller {
 		$property = $schema['properties'][ $parameter ];
 
 		if ( 'integer' === $property['type'] ) {
-			return intval( $value );
+			return (int) $value;
 		}
 
 		if ( isset( $property['format'] ) ) {


### PR DESCRIPTION
While probably negligible, casting the integer `(int)` is faster than using `intval()`. Just an idea.