### PR TITLE
Fix PHP docs. get_item is passed an array as opposed to a WP_REST_Request in several places.

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -110,7 +110,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	/**
 	 * Get a comment.
 	 *
-	 * @param  WP_REST_Request $request Full details about the request.
+	 * @param  WP_REST_Request|array $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -23,7 +23,7 @@ abstract class WP_REST_Controller {
 	/**
 	 * Get one item from the collection.
 	 *
-	 * @param WP_REST_Request $request Full data about the request.
+	 * @param WP_REST_Request|array $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -187,7 +187,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieve custom field object.
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request|array $request
 	 * @return WP_REST_Request|WP_Error Meta object data on success, WP_Error otherwise
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -54,7 +54,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	/**
 	 * Get a specific post status
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request|array $request
 	 * @return array|WP_Error
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -49,7 +49,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	/**
 	 * Get a specific post type
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request|array $request
 	 * @return array|WP_Error
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -150,7 +150,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	/**
 	 * Get a single post.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @param WP_REST_Request|array $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -92,7 +92,7 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	/**
 	 * Get a term that is attached to a post
 	 *
-	 * @param WP_REST_Request $request Full details about the request
+	 * @param WP_REST_Request|array $request Full details about the request
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -94,7 +94,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	/**
 	 * Get one revision from the collection
 	 *
-	 * @param WP_REST_Request $request Full data about the request.
+	 * @param WP_REST_Request|array $request Full data about the request.
 	 * @return WP_Error|array
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -56,7 +56,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	/**
 	 * Get a specific taxonomy
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request|array $request
 	 * @return array|WP_Error
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -133,7 +133,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	/**
 	 * Get a single term from a taxonomy
 	 *
-	 * @param WP_REST_Request $request Full details about the request
+	 * @param WP_REST_Request|array $request Full details about the request
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function get_item( $request ) {

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -160,7 +160,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	/**
 	 * Get a single user
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @param WP_REST_Request|array $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {


### PR DESCRIPTION
`get_item` is passed an array as opposed to a `WP_REST_Request` in several places (NOTE, line numbers may change but are correct at the time of submission):
* class-wp-rest-attachments-controller.php, line [85](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-attachments-controller.php#L85), [125](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-attachments-controller.php#L125)
* class-wp-rest-comments-controller.php, line [203](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-comments-controller.php#L203), [267](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-comments-controller.php#L267)
* class-wp-rest-posts-controller.php, line [235](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-posts-controller.php#L235), [309](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-posts-controller.php#L309)
* class-wp-rest-terms-controller.php, line [202](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-terms-controller.php#L202), [260](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-terms-controller.php#L260)
* class-wp-rest-users-controller.php, line [192](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-users-controller.php#L192), [258](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-users-controller.php#L258), [316](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-users-controller.php#L316)

The way I see it there are 3 different possible fixes:
1.  The documentation (this PR) needs to be corrected to allow for a generic array.
2. Each of these instances need to instantiate and use a `WP_REST_Request`
3. Refactor `get_item` to use a helper function to maintain type integrity though I am not sure what this would look like per se.