### PR TITLE
Pass ID via object when hydrating response.author, including embedded author object if available

### DIFF
--- a/wp-api.js
+++ b/wp-api.js
@@ -134,6 +134,7 @@
 		 * @returns {*}.
 		 */
 		parse: function( response ) {
+			var authorAttributes;
 
 			// Parse dates into native Date objects.
 			_.each( parseable_dates, function ( key ) {
@@ -147,7 +148,13 @@
 
 			// Parse the author into a User object.
 			if ( 'undefined' !== typeof response.author ) {
-				response.author = new wp.api.models.User( response.author );
+				if ( response._embedded && response._embedded.author ) {
+					authorAttributes = _.findWhere( response._embedded.author, { id: response.author } );
+				}
+				if ( ! authorAttributes ) {
+					authorAttributes = { id: response.author };
+				}
+				response.author = new wp.api.models.User( authorAttributes );
 			}
 
 			return response;


### PR DESCRIPTION
Fixes issue where a Backbone model needs an attributes object to be passed into `wp.api.models.User()`, not a bare ID, when hydrating `response.author` in `TimeStampedMixin.parse()`.

Additionally, if the request includes `_embed`, then the embedded author object is supplied instead of just `{ id: response.author }`.