### PR TITLE
Convert parsed author back to ID in toJSON

### DIFF
--- a/wp-api.js
+++ b/wp-api.js
@@ -124,6 +124,11 @@
 				}
 			});
 
+			// Convert author User object back into ID.
+			if ( attributes.author instanceof wp.api.models.User ) {
+				attributes.author = attributes.author.id;
+			}
+
 			return attributes;
 		},
 


### PR DESCRIPTION
The `TimeStampedMixin.parse( response )` function will convert `response.author` from a ID to a `User` model object. However, the `TimeStampedMixin.toJSON()` method is not properly reversing this process to replace a `User` object with the original ID.

See also #1928.