### PR TITLE
Check `assign_terms` cap for taxonomy when managing post terms

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -272,6 +272,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function manage_item_permissions_check( $request ) {
 
+		$taxonomy_obj = get_taxonomy( $this->taxonomy );
+		if ( ! current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+			return new WP_Error( 'rest_cannot_assign', __( 'Sorry, you are not allowed to assign terms.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
 		$post_request = new WP_REST_Request();
 		$post_request->set_param( 'id', $request['post_id'] );
 		$post_check = $this->posts_controller->update_item_permissions_check( $post_request );


### PR DESCRIPTION
Fixes #1921