### PR TITLE
Don't include method and URL in internal `WP_REST_Request` (Comments)

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -300,7 +300,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		 */
 		$supports_trash = apply_filters( 'rest_comment_trashable', ( EMPTY_TRASH_DAYS > 0 ), $comment );
 
-		$get_request = new WP_REST_Request( 'GET', rest_url( '/wp/v2/comments/' . $id ) );
+		$get_request = new WP_REST_Request;
+		$get_request->set_param( 'id', $id );
 		$get_request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $comment, $get_request );
 


### PR DESCRIPTION
While this change doesn't have any functional changes, it's in line with
our pattern throughout the rest of the codebase.

See https://github.com/WP-API/WP-API/pull/1932#discussion_r48764666