### PR TITLE
Flag sticky if password not empty instead of isset

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -747,7 +747,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Post password.
-		if ( isset( $request['password'] ) ) {
+		if ( isset( $request['password'] ) && '' !== $request['password'] ) {
 			$prepared_post->post_password = $request['password'];
 
 			if ( ! empty( $schema['properties']['sticky'] ) && ! empty( $request['sticky'] ) ) {


### PR DESCRIPTION
If attempting to submit a `password` consisting of an empty string while also submitting true value for `sticky`, the API is returning an error:

> A post can not be sticky and have a password.

I believe it should be considering an empty string to be as if the value was not set.