### PR TITLE
In `prepare_date_response` parse $date if available

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -629,14 +629,17 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return string|null ISO8601/RFC3339 formatted datetime.
 	 */
 	protected function prepare_date_response( $date_gmt, $date = null ) {
-		if ( '0000-00-00 00:00:00' === $date_gmt ) {
-			return null;
-		}
-
+		// Use the date if passed.
 		if ( isset( $date ) ) {
 			return mysql_to_rfc3339( $date );
 		}
 
+		// Return null if $date_gmt is empty/zeros.
+		if ( '0000-00-00 00:00:00' === $date_gmt ) {
+			return null;
+		}
+
+		// Return the formatted datetime.
 		return mysql_to_rfc3339( $date_gmt );
 	}
 

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -10,16 +10,14 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		$this->assertEquals( $post->post_name, $data['slug'] );
 		$this->assertEquals( get_permalink( $post->ID ), $data['link'] );
 		if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
-			$this->assertNull( $data['date'] );
-		} else {
-			$this->assertEquals( mysql_to_rfc3339( $post->post_date ), $data['date'] );
+			$this->assertNull( $data['date_gmt'] );
 		}
+		$this->assertEquals( mysql_to_rfc3339( $post->post_date ), $data['date'] );
 
 		if ( '0000-00-00 00:00:00' === $post->post_modified_gmt ) {
-			$this->assertNull( $data['modified'] );
-		} else {
-			$this->assertEquals( mysql_to_rfc3339( $post->post_modified ), $data['modified'] );
+			$this->assertNull( $data['modified_gmt'] );
 		}
+		$this->assertEquals( mysql_to_rfc3339( $post->post_modified ), $data['modified'] );
 
 		// author
 		if ( post_type_supports( $post->post_type, 'author' ) ) {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -550,8 +550,6 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		// Confirm dates are null
 		$this->assertNull( $data['date_gmt'] );
 		$this->assertNull( $data['modified_gmt'] );
-		$this->assertNull( $data['date'] );
-		$this->assertNull( $data['modified'] );
 	}
 
 	public function test_create_post_private() {


### PR DESCRIPTION
- Moves the $date_gmt blank check below the check for $date available, so $date is used if passed
- Fixes an issue where creating a new post with the API returned an object with all datetime fields set to null.
- After this fix, the API properly returns parsed dates for `date` and `date_modified` and `null` for `date_gmt` and `date_modified_gmt`, matching the database state
