### PR TITLE
Add `include` parameter to `GET /wp/v2/posts`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -70,6 +70,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$args                   = array();
 		$args['author']         = $request['author'];
+		$args['orderby']        = $request['orderby'];
+		$args['post__in']       = $request['include'];
 		$args['paged']          = $request['page'];
 		$args['posts_per_page'] = $request['per_page'];
 		$args['post_parent']    = $request['parent'];
@@ -539,6 +541,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$query_args['ignore_sticky_posts'] = true;
 		}
 
+		if ( 'include' === $query_args['orderby'] ) {
+			$query_args['orderby'] = 'post__in';
+		}
+
 		return $query_args;
 	}
 
@@ -578,7 +584,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$valid_vars = array_merge( $valid_vars, $private );
 		}
 		// Define our own in addition to WP's normal vars.
-		$rest_valid = array( 'posts_per_page', 'ignore_sticky_posts', 'post_parent' );
+		$rest_valid = array( 'post__in', 'posts_per_page', 'ignore_sticky_posts', 'post_parent' );
 		$valid_vars = array_merge( $valid_vars, $rest_valid );
 
 		/**
@@ -1572,6 +1578,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'sanitize_callback'   => 'absint',
 			);
 		}
+		$params['include'] = array(
+			'description'        => __( 'Limit result set to specific ids.' ),
+			'type'               => 'array',
+			'default'            => array(),
+			'sanitize_callback'  => 'wp_parse_id_list',
+		);
 		$params['order'] = array(
 			'description'        => __( 'Order sort attribute ascending or descending.' ),
 			'type'               => 'string',
@@ -1584,6 +1596,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			'default'            => 'name',
 			'enum'               => array(
 				'id',
+				'include',
 				'title',
 				'slug',
 			),

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -87,6 +87,25 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $this->editor_id, $data[0]['author'] );
 	}
 
+	public function test_get_items_include_query() {
+		$id1 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		// Orderby=>desc
+		$request->set_param( 'include', array( $id1, $id3 ) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( $id3, $data[0]['id'] );
+		// Orderby=>include
+		$request->set_param( 'orderby', 'include' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( $id1, $data[0]['id'] );
+	}
+
 	public function test_get_items_search_query() {
 		for ( $i = 0;  $i < 5;  $i++ ) {
 			$this->factory->post->create( array( 'post_status' => 'publish' ) );


### PR DESCRIPTION
Permits limiting results to a specific defined set

See #1668