### PR TITLE
Ensure `GET /wp/v2/posts` respects `order` and `orderby` params

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -70,6 +70,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$args                   = array();
 		$args['author']         = $request['author'];
+		$args['order']          = $request['order'];
+		$args['orderby']        = $request['orderby'];
 		$args['paged']          = $request['page'];
 		$args['posts_per_page'] = $request['per_page'];
 		$args['post_parent']    = $request['parent'];
@@ -1575,7 +1577,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$params['order'] = array(
 			'description'        => __( 'Order sort attribute ascending or descending.' ),
 			'type'               => 'string',
-			'default'            => 'asc',
+			'default'            => 'desc',
 			'enum'               => array( 'asc', 'desc' ),
 		);
 		$params['orderby'] = array(

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1583,9 +1583,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$params['orderby'] = array(
 			'description'        => __( 'Sort collection by object attribute.' ),
 			'type'               => 'string',
-			'default'            => 'name',
+			'default'            => 'date',
 			'enum'               => array(
 				'id',
+				'date',
 				'title',
 				'slug',
 			),

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -140,6 +140,25 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		}
 	}
 
+	public function test_get_items_order_and_orderby() {
+		$this->factory->post->create( array( 'post_title' => 'Apple Pie', 'post_status' => 'publish' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Sauce', 'post_status' => 'publish' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Cobbler', 'post_status' => 'publish' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Coffee Cake', 'post_status' => 'publish' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'search', 'Apple' );
+		// order defaults to 'desc'
+		$request->set_param( 'orderby', 'title' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Apple Sauce', $data[0]['title']['rendered'] );
+		// order=>desc
+		$request->set_param( 'order', 'asc' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Apple Cobbler', $data[0]['title']['rendered'] );
+	}
+
 	public function test_get_items_ignore_sticky_posts_by_default() {
 		$post_id1 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_date' => '2015-01-01 12:00:00', 'post_date_gmt' => '2015-01-01 12:00:00' ) );
 		$post_id2 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_date' => '2015-01-02 12:00:00', 'post_date_gmt' => '2015-01-02 12:00:00' ) );


### PR DESCRIPTION
Instead of silently discarding them.

Discovered in #1961
Related #924 
