### PR TITLE
Remove duplicated query params from Terms controller

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -602,27 +602,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'count',
 			),
 		);
-		$query_params['per_page']   = array(
-			'description'           => __( 'Number of terms to query at a time with pagination.' ),
-			'type'                  => 'integer',
-			'sanitize_callback'     => 'absint',
-			'default'               => 10,
-		);
-		$query_params['page']     = array(
-			'description'           => __( 'Number of the desired page within the paginated query results.' ),
-			'type'                  => 'integer',
-			'sanitize_callback'     => 'absint',
-			'default'               => 1,
-		);
 		$query_params['hide_empty'] = array(
 			'description'           => __( 'Whether to hide terms not assigned to any posts.' ),
 			'type'                  => 'boolean',
 			'default'               => false,
-		);
-		$query_params['search']     = array(
-			'description'           => __( 'Search keyword.' ),
-			'type'                  => 'string',
-			'sanitize_callback'     => 'sanitize_text_field',
 		);
 		$taxonomy = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy->hierarchical ) {

--- a/tests/test-rest-terms-controller.php
+++ b/tests/test-rest-terms-controller.php
@@ -42,6 +42,23 @@ class WP_Test_REST_Terms_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
+	public function test_registered_query_params() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$keys = array_keys( $data['endpoints'][0]['args'] );
+		sort( $keys );
+		$this->assertEquals( array(
+			'context',
+			'hide_empty',
+			'order',
+			'orderby',
+			'page',
+			'per_page',
+			'search',
+			), $keys );
+	}
+
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
`page`, `per_page` and `search` are inherited from the base controller