### PR TITLE
Cut Travis' load in half

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,9 @@ git:
   depth: 1
 
 branches:
-    only:
-        - master
+  only:
+    - master
+    - develop
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,10 @@ after_script:
 git:
   depth: 1
 
+branches:
+    only:
+        - master
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Ensures only one build is created on pull requests, instead of two.

See https://github.com/alleyinteractive/wordpress-fieldmanager/pull/430#issuecomment-169696750