### PR TITLE
Remove unnecessary since it exists in permission callback

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -169,10 +169,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$id = (int) $request['id'];
 		$user = get_userdata( $id );
 
-		if ( empty( $id ) || empty( $user->ID ) ) {
-			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid user id.' ), array( 'status' => 404 ) );
-		}
-
 		$user = $this->prepare_item_for_response( $user, $request );
 		$response = rest_ensure_response( $user );
 


### PR DESCRIPTION
`get_item` in users controller has a check for invalid user that is unnecessary since the same check exists in the [permission callback](https://github.com/WP-API/WP-API/blob/develop/lib/endpoints/class-wp-rest-users-controller.php#L398) so the check in `get_item` will never return a `WP_Error`