### PR TITLE
Remove unnecessary `is_wp_error()` check

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -205,9 +205,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$get_request->set_param( 'context', $context );
 		$response = $this->get_item( $get_request );
 		$response = rest_ensure_response( $response );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
 		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( '/wp/v2/comments/' . $comment_id ) );
 


### PR DESCRIPTION
`rest_ensure_response()` always returns a response object

Added unnecessarily in efb41e467506fe4e24f4f2e4b66576f7f5faf64e
