### PR TITLE
Add a more helpful status code when Attachment insert fails

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -68,6 +68,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$attachment->guid = $url;
 		$id = wp_insert_post( $attachment, true );
 		if ( is_wp_error( $id ) ) {
+			if ( in_array( $id->get_error_code(), array( 'db_update_error' ) ) ) {
+				$id->add_data( array( 'status' => 500 ) );
+			} else {
+				$id->add_data( array( 'status' => 400 ) );
+			}
 			return $id;
 		}
 


### PR DESCRIPTION
This follows a similar pattern we use when creating a Post.

See #153
