### PR TITLE
Properly quote concatenated filter name string

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1166,7 +1166,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param WP_Post            $post       Post object.
 		 * @param WP_REST_Request    $request    Request object.
 		 */
-		return apply_filters( 'rest_prepare_' . $this->post_type, $response, $post, $request );
+		return apply_filters( "rest_prepare_{$this->post_type}", $response, $post, $request );
 	}
 
 	/**


### PR DESCRIPTION
This ensures the parser can pick up the full representation.

See #1167
