### PR TITLE
Use dynamic filter names for `rest_post_query` and `rest_terms_query`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -97,7 +97,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param array           $args    Key value array of query var to query value.
 		 * @param WP_REST_Request $request The request used.
 		 */
-		$args = apply_filters( 'rest_post_query', $args, $request );
+		$args = apply_filters( "rest_{$this->post_type}_query", $args, $request );
 		$query_args = $this->prepare_items_query( $args );
 
 		$posts_query = new WP_Query();

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -104,7 +104,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 *                                       passed to get_terms.
 		 * @param WP_REST_Request $request       The current request.
 		 */
-		$prepared_args = apply_filters( 'rest_terms_query', $prepared_args, $request );
+		$prepared_args = apply_filters( "rest_{$this->taxonomy}_query", $prepared_args, $request );
 
 		$query_result = get_terms( $this->taxonomy, $prepared_args );
 		$response = array();


### PR DESCRIPTION
Because these two controllers can be instantiated for different types
and taxonomies, it makes sense for their filters to be named based on
the type / taxonomy

See #1167
