### PR TITLE
Use `developer.wordpress.org` links instead of the Codex

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -69,7 +69,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		/**
 		 * Filter arguments, before passing to WP_Comment_Query, when querying comments via the REST API.
 		 *
-		 * @see https://codex.wordpress.org/Class_Reference/WP_Comment_Query
+		 * @see https://developer.wordpress.org/reference/classes/wp_comment_query/
 		 *
 		 * @param array           $prepared_args Array of arguments for WP_Comment_Query.
 		 * @param WP_REST_Request $request       The current request.

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -94,6 +94,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * Enables adding extra arguments or setting defaults for a post
 		 * collection request.
 		 *
+		 * @see https://developer.wordpress.org/reference/classes/wp_user_query/
+		 *
 		 * @param array           $args    Key value array of query var to query value.
 		 * @param WP_REST_Request $request The request used.
 		 */

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -107,7 +107,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		/**
 		 * Filter arguments, before passing to WP_User_Query, when querying users via the REST API.
 		 *
-		 * @see https://codex.wordpress.org/Class_Reference/WP_User_Query
+		 * @see https://developer.wordpress.org/reference/classes/wp_user_query/
 		 *
 		 * @param array           $prepared_args Array of arguments for WP_User_Query.
 		 * @param WP_REST_Request $request       The current request.


### PR DESCRIPTION
It's the latest and greatest.

See #1167
