### PR TITLE
Deprecate `validate_request()` within `get_items()`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-terms-controller.php
@@ -65,18 +65,11 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$post = get_post( absint( $request['post_id'] ) );
-
-		$is_request_valid = $this->validate_request( $request );
-		if ( is_wp_error( $is_request_valid ) ) {
-			return $is_request_valid;
-		}
-
 		$args = array(
 			'order'        => $request['order'],
 			'orderby'      => $request['orderby'],
 		);
-		$terms = wp_get_object_terms( $post->ID, $this->taxonomy, $args );
+		$terms = wp_get_object_terms( $request['post_id'], $this->taxonomy, $args );
 
 		$response = array();
 		foreach ( $terms as $term ) {
@@ -248,7 +241,9 @@ class WP_REST_Posts_Terms_Controller extends WP_REST_Controller {
 
 		$post_check = $this->posts_controller->get_item_permissions_check( $post_request );
 
-		if ( ! $post_check || is_wp_error( $post_check ) ) {
+		if ( ! $post_check ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view this post.' ), array( 'status' => rest_authorization_required_code() ) );
+		} else if ( is_wp_error( $post_check ) ) {
 			return $post_check;
 		}
 

--- a/tests/test-rest-posts-terms-controller.php
+++ b/tests/test-rest-posts-terms-controller.php
@@ -53,6 +53,14 @@ class WP_Test_REST_Posts_Terms_Controller extends WP_Test_REST_Controller_Testca
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
 	}
 
+	public function test_get_items_no_permissions() {
+		wp_set_current_user( 0 );
+		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/tags', $post_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
 	public function test_get_items_invalid_taxonomy() {
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d/%s', $this->public_taxonomy_pages, $this->post_id ) );


### PR DESCRIPTION
The logic is duplicative of `get_items_permissions_check()`

See #1860
Related #1063
