### PR TITLE
Avoid a duplicate query for the comment count

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -64,7 +64,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$prepared_args = $this->prepare_items_query( $request );
 
-
 		/**
 		 * Filter arguments, before passing to WP_Comment_Query, when querying comments via the REST API.
 		 *

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -82,7 +82,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		foreach ( $query_result as $comment ) {
 			$post = get_post( $comment->comment_post_ID );
 			if ( ! $this->check_read_post_permission( $post ) || ! $this->check_read_permission( $comment ) ) {
-
 				continue;
 			}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -116,7 +116,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$posts[] = $this->prepare_response_for_collection( $data );
 		}
 
-
 		$page = (int) $query_args['paged'];
 		$total_posts = $posts_query->found_posts;
 

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -131,13 +131,17 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		// Store pagation values for headers then unset for count query.
 		$per_page = (int) $prepared_args['number'];
 		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
-		unset( $prepared_args['number'] );
-		unset( $prepared_args['offset'] );
 
 		$prepared_args['fields'] = 'ID';
 
-		$count_query = new WP_User_Query( $prepared_args );
-		$total_users = $count_query->get_total();
+		$total_users = $query->get_total();
+		if ( $total_users < 1 ) {
+			// Out-of-bounds, run the query again without LIMIT for total count
+			unset( $prepared_args['number'] );
+			unset( $prepared_args['offset'] );
+			$count_query = new WP_User_Query( $prepared_args );
+			$total_users = $count_query->get_total();
+		}
 		$response->header( 'X-WP-Total', (int) $total_users );
 		$max_pages = ceil( $total_users / $per_page );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );


### PR DESCRIPTION
Back in 768a2826eb20c86c189b692248419627e89db1c2 (#1197), we introduced the regular pagination headers for comment queries. However, apparently we missed that `WP_Comment_Query` has `SQL_CALC_FOUND_ROWS` built-in (but off by default), so we're doing a complex query twice here.

Attached patch uses `$query->found_comments` and `$query->max_num_pages` instead of redoing the query.
