### PR TITLE
Conditionally define functions likely to be committed to core

### DIFF
--- a/extras.php
+++ b/extras.php
@@ -11,69 +11,75 @@
 add_action( 'wp_enqueue_scripts', 'rest_register_scripts', -100 );
 add_action( 'admin_enqueue_scripts', 'rest_register_scripts', -100 );
 
-/**
- * Registers REST API JavaScript helpers.
- *
- * @since 4.4.0
- *
- * @see wp_register_scripts()
- */
-function rest_register_scripts() {
-
-	// Use minified scripts if SCRIPT_DEBUG is not on.
-	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
-	wp_register_script( 'wp-api', plugins_url( 'wp-api' . $suffix . '.js', __FILE__ ), array( 'jquery', 'backbone', 'underscore' ), '1.1', true );
-
-	$settings = array(
-		'root'          => esc_url_raw( get_rest_url() ),
-		'nonce'         => wp_create_nonce( 'wp_rest' ),
-		'versionString' => 'wp/v2/',
-	);
-	wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
-}
-
-/**
- * Retrieves the avatar urls in various sizes based on a given email address.
- *
- * @since 4.4.0
- *
- * @see get_avatar_url()
- *
- * @param string $email Email address.
- * @return array $urls Gravatar url for each size.
- */
-function rest_get_avatar_urls( $email ) {
-	$avatar_sizes = rest_get_avatar_sizes();
-
-	$urls = array();
-	foreach ( $avatar_sizes as $size ) {
-		$urls[ $size ] = get_avatar_url( $email, array( 'size' => $size ) );
-	}
-
-	return $urls;
-}
-
-/**
- * Retrieves the pixel sizes for avatars.
- *
- * @since 4.4.0
- *
- * @return array List of pixel sizes for avatars. Default `[ 24, 48, 96 ]`.
- */
-function rest_get_avatar_sizes() {
+if ( ! function_exists( 'rest_register_scripts' ) ) {
 	/**
-	 * Filter the REST avatar sizes.
-	 *
-	 * Use this filter to adjust the array of sizes returned by the
-	 * `rest_get_avatar_sizes` function.
+	 * Registers REST API JavaScript helpers.
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param array $sizes An array of int values that are the pixel sizes for avatars.
-	 *                     Default `[ 24, 48, 96 ]`.
+	 * @see wp_register_scripts()
 	 */
-	return apply_filters( 'rest_avatar_sizes', array( 24, 48, 96 ) );
+	function rest_register_scripts() {
+
+		// Use minified scripts if SCRIPT_DEBUG is not on.
+		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		wp_register_script( 'wp-api', plugins_url( 'wp-api' . $suffix . '.js', __FILE__ ), array( 'jquery', 'backbone', 'underscore' ), '1.1', true );
+
+		$settings = array(
+			'root'          => esc_url_raw( get_rest_url() ),
+			'nonce'         => wp_create_nonce( 'wp_rest' ),
+			'versionString' => 'wp/v2/',
+		);
+		wp_localize_script( 'wp-api', 'wpApiSettings', $settings );
+	}
+}
+
+if ( ! function_exists( 'rest_get_avatar_urls' ) ) {
+	/**
+	 * Retrieves the avatar urls in various sizes based on a given email address.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @see get_avatar_url()
+	 *
+	 * @param string $email Email address.
+	 * @return array $urls Gravatar url for each size.
+	 */
+	function rest_get_avatar_urls( $email ) {
+		$avatar_sizes = rest_get_avatar_sizes();
+
+		$urls = array();
+		foreach ( $avatar_sizes as $size ) {
+			$urls[ $size ] = get_avatar_url( $email, array( 'size' => $size ) );
+		}
+
+		return $urls;
+	}
+}
+
+if ( ! function_exists( 'rest_get_avatar_sizes' ) ) {
+	/**
+	 * Retrieves the pixel sizes for avatars.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return array List of pixel sizes for avatars. Default `[ 24, 48, 96 ]`.
+	 */
+	function rest_get_avatar_sizes() {
+		/**
+		 * Filter the REST avatar sizes.
+		 *
+		 * Use this filter to adjust the array of sizes returned by the
+		 * `rest_get_avatar_sizes` function.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param array $sizes An array of int values that are the pixel sizes for avatars.
+		 *                     Default `[ 24, 48, 96 ]`.
+		 */
+		return apply_filters( 'rest_avatar_sizes', array( 24, 48, 96 ) );
+	}
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -139,80 +139,82 @@ function _add_extra_api_taxonomy_arguments() {
 	}
 }
 
-/**
- * Registers default REST API routes.
- *
- * @since 4.4.0
- */
-function create_initial_rest_routes() {
+if ( ! function_exists( 'create_initial_rest_routes' ) ) {
+	/**
+	 * Registers default REST API routes.
+	 *
+	 * @since 4.4.0
+	 */
+	function create_initial_rest_routes() {
 
-	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
-		$class = ! empty( $post_type->rest_controller_class ) ? $post_type->rest_controller_class : 'WP_REST_Posts_Controller';
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			$class = ! empty( $post_type->rest_controller_class ) ? $post_type->rest_controller_class : 'WP_REST_Posts_Controller';
 
-		if ( ! class_exists( $class ) ) {
-			continue;
-		}
-		$controller = new $class( $post_type->name );
-		if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
-			continue;
-		}
-
-		$controller->register_routes();
-
-		if ( post_type_supports( $post_type->name, 'custom-fields' ) ) {
-			$meta_controller = new WP_REST_Meta_Posts_Controller( $post_type->name );
-			$meta_controller->register_routes();
-		}
-		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
-			$revisions_controller = new WP_REST_Revisions_Controller( $post_type->name );
-			$revisions_controller->register_routes();
-		}
-
-		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
-
-			if ( empty( $taxonomy->show_in_rest ) ) {
+			if ( ! class_exists( $class ) ) {
+				continue;
+			}
+			$controller = new $class( $post_type->name );
+			if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
 				continue;
 			}
 
-			$posts_terms_controller = new WP_REST_Posts_Terms_Controller( $post_type->name, $taxonomy->name );
-			$posts_terms_controller->register_routes();
-		}
-	}
+			$controller->register_routes();
 
-	// Post types.
-	$controller = new WP_REST_Post_Types_Controller;
-	$controller->register_routes();
+			if ( post_type_supports( $post_type->name, 'custom-fields' ) ) {
+				$meta_controller = new WP_REST_Meta_Posts_Controller( $post_type->name );
+				$meta_controller->register_routes();
+			}
+			if ( post_type_supports( $post_type->name, 'revisions' ) ) {
+				$revisions_controller = new WP_REST_Revisions_Controller( $post_type->name );
+				$revisions_controller->register_routes();
+			}
 
-	// Post statuses.
-	$controller = new WP_REST_Post_Statuses_Controller;
-	$controller->register_routes();
+			foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
 
-	// Taxonomies.
-	$controller = new WP_REST_Taxonomies_Controller;
-	$controller->register_routes();
+				if ( empty( $taxonomy->show_in_rest ) ) {
+					continue;
+				}
 
-	// Terms.
-	foreach ( get_taxonomies( array( 'show_in_rest' => true ), 'object' ) as $taxonomy ) {
-		$class = ! empty( $taxonomy->rest_controller_class ) ? $taxonomy->rest_controller_class : 'WP_REST_Terms_Controller';
-
-		if ( ! class_exists( $class ) ) {
-			continue;
-		}
-		$controller = new $class( $taxonomy->name );
-		if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
-			continue;
+				$posts_terms_controller = new WP_REST_Posts_Terms_Controller( $post_type->name, $taxonomy->name );
+				$posts_terms_controller->register_routes();
+			}
 		}
 
+		// Post types.
+		$controller = new WP_REST_Post_Types_Controller;
+		$controller->register_routes();
+
+		// Post statuses.
+		$controller = new WP_REST_Post_Statuses_Controller;
+		$controller->register_routes();
+
+		// Taxonomies.
+		$controller = new WP_REST_Taxonomies_Controller;
+		$controller->register_routes();
+
+		// Terms.
+		foreach ( get_taxonomies( array( 'show_in_rest' => true ), 'object' ) as $taxonomy ) {
+			$class = ! empty( $taxonomy->rest_controller_class ) ? $taxonomy->rest_controller_class : 'WP_REST_Terms_Controller';
+
+			if ( ! class_exists( $class ) ) {
+				continue;
+			}
+			$controller = new $class( $taxonomy->name );
+			if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
+				continue;
+			}
+
+			$controller->register_routes();
+		}
+
+		// Users.
+		$controller = new WP_REST_Users_Controller;
+		$controller->register_routes();
+
+		// Comments.
+		$controller = new WP_REST_Comments_Controller;
 		$controller->register_routes();
 	}
-
-	// Users.
-	$controller = new WP_REST_Users_Controller;
-	$controller->register_routes();
-
-	// Comments.
-	$controller = new WP_REST_Comments_Controller;
-	$controller->register_routes();
 }
 
 if ( ! function_exists( 'rest_authorization_required_code' ) ) {


### PR DESCRIPTION
Functions likely to be committed to core include:
- `create_initial_rest_routes()`
- `rest_authorization_required_code()`
- `register_rest_field()`
- `rest_register_scripts()`
- `rest_get_avatar_urls()`
- `rest_get_avatar_sizes()`

Functions not likely to be committed to core include:
- `register_api_field()` - deprecated
- `rest_get_avatar_url()` - deprecated
- `rest_mysql_to_rfc3339()` - deprecated
- `_add_extra_api_taxonomy_arguments()` - not applicable to core
- `_add_extra_api_post_type_arguments()` - not applicable to core

See #2021
