### PR TITLE
Force `GET /wp/v2/media` to be limited to 'status' => [ inherit, private, trash ]

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -11,7 +11,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array() ) {
 		$query_args = parent::prepare_items_query( $prepared_args );
-		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ){
+		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ) {
 			$query_args['post_status'] = 'inherit';
 		}
 		return $query_args;

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -3,6 +3,19 @@
 class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 	/**
+	 * Determine the allowed query_vars for a get_items() response and
+	 * prepare for WP_Query.
+	 *
+	 * @param array $prepared_args
+	 * @return array $query_args
+	 */
+	protected function prepare_items_query( $prepared_args = array() ) {
+		$query_args = parent::prepare_items_query( $prepared_args );
+		$query_args['post_status'] = 'inherit';
+		return $query_args;
+	}
+
+	/**
 	 * Check if a given request has access to create an attachment.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
@@ -415,6 +428,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'default'            => null,
 			'sanitize_callback'  => 'absint',
 			);
+		unset( $params['status'] );
 		return $params;
 	}
 

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -11,7 +11,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array() ) {
 		$query_args = parent::prepare_items_query( $prepared_args );
-		if ( ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ){
+		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ){
 			$query_args['post_status'] = 'inherit';
 		}
 		return $query_args;

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -11,7 +11,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array() ) {
 		$query_args = parent::prepare_items_query( $prepared_args );
-		$query_args['post_status'] = 'inherit';
+		if ( ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ){
+			$query_args['post_status'] = 'inherit';
+		}
 		return $query_args;
 	}
 
@@ -428,8 +430,24 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'default'            => null,
 			'sanitize_callback'  => 'absint',
 			);
-		unset( $params['status'] );
+		$params['status']['default'] = 'inherit';
+		$params['status']['enum'] = array( 'inherit', 'private', 'trash' );
 		return $params;
+	}
+
+	/**
+	 * Validate whether the user can query private statuses
+	 *
+	 * @param  mixed $value
+	 * @param  WP_REST_Request $request
+	 * @param  string $parameter
+	 * @return WP_Error|bool
+	 */
+	public function validate_user_can_query_private_statuses( $value, $request, $parameter ) {
+		if ( 'inherit' === $value ) {
+			return true;
+		}
+		return parent::validate_user_can_query_private_statuses( $value, $request, $parameter );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -542,10 +542,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( empty( $query_args['post_status'] ) && 'attachment' === $this->post_type ) {
-			$query_args['post_status'] = 'inherit';
-		}
-
 		if ( 'post' !== $this->post_type || ! isset( $query_args['ignore_sticky_posts'] ) ) {
 			$query_args['ignore_sticky_posts'] = true;
 		}
@@ -1629,7 +1625,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$params['status'] = array(
-			'default'           => 'attachment' === $this->post_type ? 'inherit' : 'publish',
+			'default'           => 'publish',
 			'description'       => __( 'Limit result set to posts assigned a specific status.' ),
 			'sanitize_callback' => 'sanitize_key',
 			'type'              => 'string',
@@ -1650,7 +1646,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return WP_Error|bool
 	 */
 	public function validate_user_can_query_private_statuses( $value, $request, $parameter ) {
-		if ( 'publish' === $value || ( 'attachment' === $this->post_type && 'inherit' === $value ) ) {
+		if ( 'publish' === $value ) {
 			return true;
 		}
 		$post_type_obj = get_post_type_object( $this->post_type );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -72,6 +72,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'parent',
 			'per_page',
 			'search',
+			'status',
 			), $keys );
 	}
 
@@ -166,7 +167,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( 0, count( $data ) );
 	}
 
-	public function test_get_items_status_param_is_discarded() {
+	public function test_get_items_invalid_status_param_is_discarded() {
 		wp_set_current_user( $this->editor_id );
 		$attachment_id1 = $this->factory->attachment->create_object( $this->test_file, 0, array(
 			'post_mime_type' => 'image/jpeg',
@@ -179,6 +180,26 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$data = $response->get_data();
 		$this->assertCount( 1, $data );
 		$this->assertEquals( 'inherit', $data[0]['status'] );
+	}
+
+	public function test_get_items_private_status() {
+		// Logged out users can't make the request
+		wp_set_current_user( 0 );
+		$attachment_id1 = $this->factory->attachment->create_object( $this->test_file, 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_excerpt'   => 'A sample caption',
+			'post_status'    => 'private',
+		) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'status', 'private' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		// Properly authorized users can make the request
+		wp_set_current_user( $this->editor_id );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $attachment_id1, $data[0]['id'] );
 	}
 
 	public function test_get_item() {

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -54,6 +54,27 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
+	public function test_registered_query_params() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/media' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$keys = array_keys( $data['endpoints'][0]['args'] );
+		sort( $keys );
+		$this->assertEquals( array(
+			'author',
+			'context',
+			'exclude',
+			'filter',
+			'include',
+			'order',
+			'orderby',
+			'page',
+			'parent',
+			'per_page',
+			'search',
+			), $keys );
+	}
+
 	public function test_get_items() {
 		wp_set_current_user( 0 );
 		$id1 = $this->factory->attachment->create_object( $this->test_file, 0, array(
@@ -143,6 +164,21 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 0, count( $data ) );
+	}
+
+	public function test_get_items_status_param_is_discarded() {
+		wp_set_current_user( $this->editor_id );
+		$attachment_id1 = $this->factory->attachment->create_object( $this->test_file, 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_excerpt'   => 'A sample caption',
+		) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( 'inherit', $data[0]['status'] );
 	}
 
 	public function test_get_item() {


### PR DESCRIPTION
Attachments can only ever have the `inherit`, `private`, and `trash` statuses.

Fixes #1986
