### PR TITLE
Require `force` argument for `DELETE /wp/v2/<taxonomy>/<id>`

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -55,6 +55,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'methods'    => WP_REST_Server::DELETABLE,
 				'callback'   => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				'args'       => array(
+					'force'    => array(
+						'default'     => false,
+						'description' => __( 'Required to be true, as resource does not support trashing.' ),
+					),
+				),
 			),
 
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -289,6 +295,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
+
+		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+
+		// We don't support trashing for this type, error out
+		if ( ! $force ) {
+			return new WP_Error( 'rest_trash_not_supported', __( 'Terms do not support trashing.' ), array( 'status' => 501 ) );
+		}
 
 		// Get the actual term_id
 		$term = get_term( (int) $request['id'], $this->taxonomy );

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -566,11 +566,21 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Deleted Category', $data['data']['name'] );
 		$this->assertTrue( $data['deleted'] );
+	}
+
+	public function test_delete_item_force_false() {
+		wp_set_current_user( $this->administrator );
+		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
+		// force defaults to false
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 501, $response->get_status() );
 	}
 
 	public function test_delete_item_invalid_taxonomy() {

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -426,11 +426,21 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( $this->administrator );
 		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
+		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 'Deleted Tag', $data['data']['name'] );
 		$this->assertTrue( $data['deleted'] );
+	}
+
+	public function test_delete_item_force_false() {
+		wp_set_current_user( $this->administrator );
+		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
+		// force defaults to false
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 501, $response->get_status() );
 	}
 
 	public function test_delete_item_invalid_term() {


### PR DESCRIPTION
While terms don't support trashing, we've established a pattern of
requiring the `force` param for all `DELETE` requests, to give us the
opportunity to introduce trashing in the future.
