### PR TITLE
Call `prepare_item_for_response()` directly in `Comment::create_item()`

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -393,12 +393,11 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$this->update_additional_fields_for_object( get_comment( $id ), $request );
+		$comment = get_comment( $id );
+		$this->update_additional_fields_for_object( $comment, $request );
 
-		$get_request = new WP_REST_Request;
-		$get_request->set_param( 'id', $id );
-		$get_request->set_param( 'context', 'edit' );
-		$response = $this->get_item( $get_request );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $comment, $request );
 
 		/* This action is documented in lib/endpoints/class-wp-rest-comments-controller.php */
 		do_action( 'rest_insert_comment', $prepared_args, $request, false );


### PR DESCRIPTION
This lets us pass the original request through to
`prepare_item_for_response()`, giving it genuine context, and avoids an
unnecessary call to `get_item()`
