### PR TITLE
First round at turning protected methods into private methods

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -320,7 +320,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @param array $headers HTTP headers from the request
 	 * @return array|WP_Error Data from {@see wp_handle_sideload()}
 	 */
-	protected function upload_from_data( $data, $headers ) {
+	private function upload_from_data( $data, $headers ) {
 		if ( empty( $data ) ) {
 			return new WP_Error( 'rest_upload_no_data', __( 'No data supplied' ), array( 'status' => 400 ) );
 		}
@@ -424,7 +424,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @param array $headers HTTP headers from the request
 	 * @return array|WP_Error Data from {@see wp_handle_upload()}
 	 */
-	protected function upload_from_file( $files, $headers ) {
+	private function upload_from_file( $files, $headers ) {
 		if ( empty( $files ) ) {
 			return new WP_Error( 'rest_upload_no_data', __( 'No data supplied' ), array( 'status' => 400 ) );
 		}

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -662,7 +662,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @param  string|int $comment_approved
 	 * @return string     $status
 	 */
-	protected function prepare_status_response( $comment_approved ) {
+	private function prepare_status_response( $comment_approved ) {
 
 		switch ( $comment_approved ) {
 			case 'hold':
@@ -1025,7 +1025,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @param object     $comment
 	 * @return boolean   $changed
 	 */
-	protected function handle_status_param( $new_status, $comment ) {
+	private function handle_status_param( $new_status, $comment ) {
 		$old_status = wp_get_comment_status( $comment->comment_ID );
 
 		if ( $new_status === $old_status ) {

--- a/lib/endpoints/class-wp-rest-meta-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-controller.php
@@ -139,7 +139,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 	 *
 	 * @return string
 	 */
-	protected function get_id_column() {
+	private function get_id_column() {
 		return ( 'user' === $this->parent_type ) ? 'umeta_id' : 'meta_id';
 	}
 
@@ -148,7 +148,7 @@ abstract class WP_REST_Meta_Controller extends WP_REST_Controller {
 	 *
 	 * @return string
 	 */
-	protected function get_parent_column() {
+	private function get_parent_column() {
 		return ( 'user' === $this->parent_type ) ? 'user_id' : 'post_id';
 	}
 


### PR DESCRIPTION
Our controller classes are designed to expose a consistent abstraction.
The expected public methods include `get_items()`, `get_item()`,
`create_item()`, `update_item()`, `delete_item()`,
`get_items_permissions_check()`, and so on.

Methods unique to a specific class should be marked `private` instead
of `protected`, so we don't expose them as interfaces for subclasses and
retain the freedom to refactor the internal behavior of a class at a
future date.

See #1063
