### PR TITLE
`search` param should default to an empty string

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -235,6 +235,7 @@ abstract class WP_REST_Controller {
 			'search'                 => array(
 				'description'        => __( 'Limit results to those matching a string.' ),
 				'type'               => 'string',
+				'default'            => '',
 				'sanitize_callback'  => 'sanitize_text_field',
 			),
 		);


### PR DESCRIPTION
`WP_Comment_Query` expects an empty string to be no search operation,
otherwise it generates erroneous SQL:

```
[18-Jan-2016 13:18:31 UTC] WP_Comment_Query::__set_state(array(
   'request' => 'SELECT SQL_CALC_FOUND_ROWS wp_comments.comment_ID FROM
   wp_comments JOIN wp_posts ON wp_posts.ID =
   wp_comments.comment_post_ID WHERE ( comment_approved = \'1\' ) AND
   comment_type IN (\'\') AND (comment_author LIKE \'%%\' OR
   comment_author_email LIKE \'%%\' OR comment_author_url LIKE \'%%\' OR
   comment_author_IP LIKE \'%%\' OR comment_content LIKE \'%%\') AND
   wp_posts.post_type IN (\'page\')  ORDER BY
   wp_comments.comment_date_gmt ASC, wp_comments.comment_ID ASC LIMIT
   10',
```
