### PR TITLE
When a comment is already trashed, return `410:rest_already_trashed`

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -461,6 +461,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			if ( ! $supports_trash ) {
 				return new WP_Error( 'rest_trash_not_supported', __( 'The comment does not support trashing.' ), array( 'status' => 501 ) );
 			}
+			
+			if ( 'trash' === $comment->comment_approved ) {
+				return new WP_Error( 'rest_already_trashed', __( 'The comment has already been trashed.' ), array( 'status' => 410 ) );
+			}
 
 			$result = wp_trash_comment( $comment->comment_ID );
 			$status = 'trashed';

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -461,7 +461,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			if ( ! $supports_trash ) {
 				return new WP_Error( 'rest_trash_not_supported', __( 'The comment does not support trashing.' ), array( 'status' => 501 ) );
 			}
-			
+
 			if ( 'trash' === $comment->comment_approved ) {
 				return new WP_Error( 'rest_already_trashed', __( 'The comment has already been trashed.' ), array( 'status' => 410 ) );
 			}

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -981,6 +981,23 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( $this->post_id, $data['data']['post'] );
 		$this->assertTrue( $data['deleted'] );
 	}
+	
+	public function test_delete_item_already_trashed() {
+		wp_set_current_user( $this->admin_id );
+
+		$comment_id = $this->factory->comment->create( array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => $this->post_id,
+			'user_id'          => $this->subscriber_id,
+		));
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertTrue( $data['trashed'] );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_already_trashed', $response, 410 );
+	}
 
 	public function test_delete_comment_invalid_id() {
 		wp_set_current_user( $this->admin_id );

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -981,7 +981,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( $this->post_id, $data['data']['post'] );
 		$this->assertTrue( $data['deleted'] );
 	}
-	
+
 	public function test_delete_item_already_trashed() {
 		wp_set_current_user( $this->admin_id );
 


### PR DESCRIPTION
This is a more correct error than `500:rest_cannot_delete`
