### PR TITLE
For posts, change `rest_already_deleted` to `rest_already_trashed`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -488,7 +488,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 			// Otherwise, only trash if we haven't already.
 			if ( 'trash' === $post->post_status ) {
-				return new WP_Error( 'rest_already_deleted', __( 'The post has already been deleted.' ), array( 'status' => 410 ) );
+				return new WP_Error( 'rest_already_trashed', __( 'The post has already been deleted.' ), array( 'status' => 410 ) );
 			}
 
 			// (Note that internally this falls through to `wp_delete_post` if

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1433,6 +1433,18 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertTrue( $data['deleted'] );
 	}
 
+	public function test_delete_item_already_trashed() {
+		$post_id = $this->factory->post->create( array( 'post_title' => 'Deleted post' ) );
+		wp_set_current_user( $this->editor_id );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertTrue( $data['trashed'] );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_already_trashed', $response, 410 );
+	}
+
 	public function test_delete_post_invalid_id() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
It's more precise language. The post hasn't yet been deleted; it's been
trashed.

Related #2069
