### PR TITLE
Add `slug` param for `GET /wp/v2/<taxonomy>`

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -92,6 +92,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'hide_empty' => $request['hide_empty'],
 			'number'     => $request['per_page'],
 			'search'     => $request['search'],
+			'slug'       => $request['slug'],
 		);
 
 		if ( ! empty( $request['offset'] ) ) {
@@ -668,6 +669,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'description'           => __( 'Limit result set to terms assigned to a specific post.' ),
 			'type'                  => 'number',
 			'default'               => false,
+		);
+		$query_params['slug']    = array(
+			'description'        => __( 'Limit result set to terms with a specific slug.' ),
+			'type'               => 'string',
 		);
 		return $query_params;
 	}

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -58,6 +58,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'per_page',
 			'post_id',
 			'search',
+			'slug',
 			), $keys );
 	}
 
@@ -307,6 +308,18 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 0, count( $data ) );
+	}
+
+	public function test_get_items_slug_arg() {
+		$tag1 = $this->factory->category->create( array( 'name' => 'Apple' ) );
+		$tag2 = $this->factory->category->create( array( 'name' => 'Banana' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'slug', 'apple' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 1, count( $data ) );
+		$this->assertEquals( 'Apple', $data[0]['name'] );
 	}
 
 	public function test_get_terms_parent_arg() {

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -58,6 +58,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 			'per_page',
 			'post_id',
 			'search',
+			'slug',
 			), $keys );
 	}
 
@@ -253,6 +254,18 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 0, count( $data ) );
+	}
+
+	public function test_get_items_slug_arg() {
+		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
+		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
+		$request->set_param( 'slug', 'apple' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 1, count( $data ) );
+		$this->assertEquals( 'Apple', $data[0]['name'] );
 	}
 
 	public function test_get_terms_private_taxonomy() {


### PR DESCRIPTION
Related https://github.com/WP-API/WP-API/issues/2065#issuecomment-173988524
See #924
