### PR TITLE
Sanity check test for `GET /wp/v2/users include` with no privilege

### DIFF
--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -260,6 +260,12 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( 2, count( $data ) );
 		$this->assertEquals( $id3, $data[0]['id'] );
+		// No privileges
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 0, count( $data ) );
+
 	}
 
 	public function test_get_items_exclude_query() {


### PR DESCRIPTION
Unauthenticated users shouldn't get results even when they pass
`include`
