### PR TITLE
Add `parent_exclude` param to `GET /wp/v2/posts`

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -423,12 +423,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		$params['parent']        = array(
-			'description'        => __( 'Limit results to attachments from a specified parent.' ),
-			'type'               => 'integer',
-			'default'            => null,
-			'sanitize_callback'  => 'absint',
-			);
 		$params['status']['default'] = 'inherit';
 		$params['status']['enum'] = array( 'inherit', 'private', 'trash' );
 		return $params;

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -86,19 +86,20 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$args                   = array();
-		$args['author']         = $request['author'];
-		$args['offset']         = $request['offset'];
-		$args['order']          = $request['order'];
-		$args['orderby']        = $request['orderby'];
-		$args['paged']          = $request['page'];
-		$args['post__in']       = $request['include'];
-		$args['post__not_in']   = $request['exclude'];
-		$args['posts_per_page'] = $request['per_page'];
-		$args['name']           = $request['slug'];
-		$args['post_parent']    = $request['parent'];
-		$args['post_status']    = $request['status'];
-		$args['s']              = $request['search'];
+		$args                         = array();
+		$args['author']               = $request['author'];
+		$args['offset']               = $request['offset'];
+		$args['order']                = $request['order'];
+		$args['orderby']              = $request['orderby'];
+		$args['paged']                = $request['page'];
+		$args['post__in']             = $request['include'];
+		$args['post__not_in']         = $request['exclude'];
+		$args['posts_per_page']       = $request['per_page'];
+		$args['name']                 = $request['slug'];
+		$args['post_parent']          = $request['parent'];
+		$args['post_parent__not_in']  = $request['parent_exclude'];
+		$args['post_status']          = $request['status'];
+		$args['s']                    = $request['search'];
 
 		if ( is_array( $request['filter'] ) ) {
 			$args = array_merge( $args, $request['filter'] );
@@ -593,7 +594,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$valid_vars = array_merge( $valid_vars, $private );
 		}
 		// Define our own in addition to WP's normal vars.
-		$rest_valid = array( 'offset', 'post__in', 'post__not_in', 'posts_per_page', 'ignore_sticky_posts', 'post_parent' );
+		$rest_valid = array( 'offset', 'post__in', 'post__not_in', 'posts_per_page', 'ignore_sticky_posts', 'post_parent', 'post_parent__not_in' );
 		$valid_vars = array_merge( $valid_vars, $rest_valid );
 
 		/**
@@ -1666,12 +1667,18 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		);
 
 		$post_type_obj = get_post_type_object( $this->post_type );
-		if ( $post_type_obj->hierarchical ) {
+		if ( $post_type_obj->hierarchical || 'attachment' === $this->post_type ) {
 			$params['parent'] = array(
 				'description'       => _( 'Limit result set to that of a specific parent id.' ),
 				'type'              => 'integer',
 				'sanitize_callback' => 'absint',
 				'default'           => null,
+			);
+			$params['parent_exclude'] = array(
+				'description'       => _( 'Limit result set to all items except those of a particular parent id.' ),
+				'type'              => 'array',
+				'sanitize_callback' => 'wp_parse_id_list',
+				'default'           => array(),
 			);
 		}
 

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -71,6 +71,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'orderby',
 			'page',
 			'parent',
+			'parent_exclude',
 			'per_page',
 			'search',
 			'slug',

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -60,6 +60,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'orderby',
 			'page',
 			'parent',
+			'parent_exclude',
 			'per_page',
 			'search',
 			'slug',
@@ -85,6 +86,22 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( $id2, $data[0]['id'] );
+	}
+
+	public function test_get_items_parent_exclude_query() {
+		$id1 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page' ) );
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page', 'post_parent' => $id1 ) );
+		// No parent
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 2, count( $data ) );
+		// Filter to parent
+		$request->set_param( 'parent_exclude', $id1 );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 1, count( $data ) );
+		$this->assertEquals( $id1, $data[0]['id'] );
 	}
 
 	public function test_get_items_private_filter_query_var() {


### PR DESCRIPTION
Functionally equivalent to WP_Query's `post_parent__not_in`

Fixes #1927
See #924
