### PR TITLE
Remove unused `$contexts` variable definition

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -254,7 +254,6 @@ abstract class WP_REST_Controller {
 			'type'               => 'string',
 		);
 		$schema = $this->get_item_schema();
-		$contexts = array();
 		if ( empty( $schema['properties'] ) ) {
 			return array_merge( $param_details, $args );
 		}


### PR DESCRIPTION
The variable is defined again two lines down, before it is used.
