### PR TITLE
Instantiating a `WP_User_Query` won't ever produce `WP_Error`

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -121,9 +121,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$prepared_args = apply_filters( 'rest_user_query', $prepared_args, $request );
 
 		$query = new WP_User_Query( $prepared_args );
-		if ( is_wp_error( $query ) ) {
-			return $query;
-		}
 
 		$users = array();
 		foreach ( $query->results as $user ) {


### PR DESCRIPTION
Introduced in 4fd39052e47360527509b3810948d6d1ed4130c3. Must've been a
fluke.
