### PR TITLE
Add support for `GET /wp/v2/pages parent=1,2,3`

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -96,7 +96,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$args['post__not_in']         = $request['exclude'];
 		$args['posts_per_page']       = $request['per_page'];
 		$args['name']                 = $request['slug'];
-		$args['post_parent']          = $request['parent'];
+		$args['post_parent__in']      = $request['parent'];
 		$args['post_parent__not_in']  = $request['parent_exclude'];
 		$args['post_status']          = $request['status'];
 		$args['s']                    = $request['search'];
@@ -594,7 +594,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$valid_vars = array_merge( $valid_vars, $private );
 		}
 		// Define our own in addition to WP's normal vars.
-		$rest_valid = array( 'offset', 'post__in', 'post__not_in', 'posts_per_page', 'ignore_sticky_posts', 'post_parent', 'post_parent__not_in' );
+		$rest_valid = array( 'offset', 'post__in', 'post__not_in', 'posts_per_page', 'ignore_sticky_posts', 'post_parent', 'post_parent__in', 'post_parent__not_in' );
 		$valid_vars = array_merge( $valid_vars, $rest_valid );
 
 		/**
@@ -1665,10 +1665,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$post_type_obj = get_post_type_object( $this->post_type );
 		if ( $post_type_obj->hierarchical || 'attachment' === $this->post_type ) {
 			$params['parent'] = array(
-				'description'       => _( 'Limit result set to that of a specific parent id.' ),
-				'type'              => 'integer',
-				'sanitize_callback' => 'absint',
-				'default'           => null,
+				'description'       => _( 'Limit result set to those of particular parent ids.' ),
+				'type'              => 'array',
+				'sanitize_callback' => 'wp_parse_id_list',
+				'default'           => array(),
 			);
 			$params['parent_exclude'] = array(
 				'description'       => _( 'Limit result set to all items except those of a particular parent id.' ),

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -88,6 +88,24 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $id2, $data[0]['id'] );
 	}
 
+	public function test_get_items_parents_query() {
+		$id1 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page' ) );
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page', 'post_parent' => $id1 ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page' ) );
+		$id4 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page', 'post_parent' => $id3 ) );
+		// No parent
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 4, count( $data ) );
+		// Filter to parents
+		$request->set_param( 'parent', array( $id1, $id3 ) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEqualSets( array( $id2, $id4 ), wp_list_pluck( $data, 'id' ) );
+	}
+
 	public function test_get_items_parent_exclude_query() {
 		$id1 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page' ) );
 		$id2 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_type' => 'page', 'post_parent' => $id1 ) );


### PR DESCRIPTION
By changing our existing `parent` param to interchangably support one or
more values, we can make it a more useful param.

See #924 
