### PR TITLE
Rename `post_id` param to `post` for `GET /wp/v2/<taxonomy>`

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -89,6 +89,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'include'    => $request['include'],
 			'order'      => $request['order'],
 			'orderby'    => $request['orderby'],
+			'post'       => $request['post'],
 			'hide_empty' => $request['hide_empty'],
 			'number'     => $request['per_page'],
 			'search'     => $request['search'],
@@ -128,7 +129,15 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 */
 		$prepared_args = apply_filters( "rest_{$this->taxonomy}_query", $prepared_args, $request );
 
-		$query_result = get_terms( $this->taxonomy, $prepared_args );
+		if ( ! empty( $prepared_args['post'] ) ) {
+			$terms_args = array(
+				'order'   => $prepared_args['order'],
+				'orderby' => $prepared_args['orderby'],
+			);
+			$query_result = wp_get_object_terms( $prepared_args['post'], $this->taxonomy, $terms_args );
+		} else {
+			$query_result = get_terms( $this->taxonomy, $prepared_args );
+		}
 		$response = array();
 		foreach ( $query_result as $term ) {
 			$data = $this->prepare_item_for_response( $term, $request );
@@ -665,7 +674,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'sanitize_callback'  => 'absint',
 			);
 		}
-		$query_params['post_id'] = array(
+		$query_params['post'] = array(
 			'description'           => __( 'Limit result set to terms assigned to a specific post.' ),
 			'type'                  => 'number',
 			'default'               => false,

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -56,7 +56,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'page',
 			'parent',
 			'per_page',
-			'post_id',
+			'post',
 			'search',
 			'slug',
 			), $keys );
@@ -265,7 +265,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertEquals( 3, count( $data ) ); // includes 'Uncategorized'
+		$this->assertEquals( 2, count( $data ) );
 		$this->assertEquals( 'DC', $data[0]['name'] );
 	}
 
@@ -275,6 +275,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$controller->register_routes();
 		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'batman' ) );
 		$term2 = $this->factory->term->create( array( 'name' => 'Mask', 'taxonomy' => 'batman' ) );
+		$this->factory->term->create( array( 'name' => 'Car', 'taxonomy' => 'batman' ) );
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -56,7 +56,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 			'orderby',
 			'page',
 			'per_page',
-			'post_id',
+			'post',
 			'search',
 			'slug',
 			), $keys );
@@ -203,6 +203,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$post_id = $this->factory->post->create();
 		$tag1 = $this->factory->tag->create( array( 'name' => 'DC' ) );
 		$tag2 = $this->factory->tag->create( array( 'name' => 'Marvel' ) );
+		$this->factory->tag->create( array( 'name' => 'Dark Horse' ) );
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
@@ -221,6 +222,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$controller->register_routes();
 		$term1 = $this->factory->term->create( array( 'name' => 'Cape', 'taxonomy' => 'batman' ) );
 		$term2 = $this->factory->term->create( array( 'name' => 'Mask', 'taxonomy' => 'batman' ) );
+		$this->factory->term->create( array( 'name' => 'Car', 'taxonomy' => 'batman' ) );
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 


### PR DESCRIPTION
It's more consistent with our other params, where we don't typically
include `_id` in the name.

Also fixes the param generally, which didn't work in the first place.
Just goes to show that test coverage doesn't amount for much unless it's
testing the right things.
