### PR TITLE
Fix PHPDoc for `prepare_item_for_response()` return val

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -194,7 +194,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @param WP_Post $post Post object
 	 * @param WP_REST_Request $request Request object
-	 * @return array $response
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $post, $request ) {
 		$response = parent::prepare_item_for_response( $post, $request );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -532,7 +532,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 *
 	 * @param  object          $comment Comment object.
 	 * @param  WP_REST_Request $request Request object.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $comment, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -125,7 +125,7 @@ abstract class WP_REST_Controller {
 	 *
 	 * @param mixed $item WordPress representation of the item.
 	 * @param WP_REST_Request $request Request object.
-	 * @return mixed
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -72,7 +72,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	 *
 	 * @param stdClass $post_type Post type data
 	 * @param WP_REST_Request $request
-	 * @return array Post type data
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $post_type, $request ) {
 		$data = array(

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -172,7 +172,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_Post $post Post revision object.
 	 * @param WP_REST_Request $request Request object.
-	 * @return array
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $post, $request ) {
 
@@ -207,9 +207,6 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
 
 		if ( ! empty( $data['parent'] ) ) {
 			$response->add_link( 'parent', rest_url( sprintf( 'wp/%s/%d', $this->parent_base, $data['parent'] ) ) );

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -95,7 +95,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 *
 	 * @param stdClass $taxonomy Taxonomy data
 	 * @param WP_REST_Request $request
-	 * @return array Taxonomy data
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $taxonomy, $request ) {
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -462,6 +462,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 *
 	 * @param obj $item Term object
 	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -474,7 +474,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 *
 	 * @param object $user User object.
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response data.
+	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $user, $request ) {
 		$data = array(


### PR DESCRIPTION
This method consistently returns `WP_REST_Response()`, except in a
couple inconsistent cases needing to be fixed.
