### PR TITLE
Revision schema titles should be singular, not plural

### DIFF
--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -252,7 +252,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => "{$this->parent_base}-revision",
+			'title'      => "{$this->parent_post_type}-revision",
 			'type'       => 'object',
 			/*
 			 * Base properties for every Revision

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -190,7 +190,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			'context'     => array( 'view', 'edit' ),
 		);
 
-		register_rest_field( 'posts-revision', 'my_custom_int', array(
+		register_rest_field( 'post-revision', 'my_custom_int', array(
 			'schema'          => $schema,
 			'get_callback'    => array( $this, 'additional_field_get_callback' ),
 			'update_callback' => array( $this, 'additional_field_update_callback' ),


### PR DESCRIPTION
`post-revision` instead of `posts-revision`

Schema titles are singular, not plural
