### PR TITLE
Revert `$singular_label` and `$plural_label`; use generic "Resource"

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -18,12 +18,6 @@ abstract class WP_REST_Controller {
 	protected $rest_base;
 
 	/**
-	 * The resource's singular label
-	 *
-	 * @var string
-	 */
-
-	/**
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -5,8 +5,6 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'statuses';
-		$this->singular_label = __( 'Status' );
-		$this->plural_label = __( 'Statuses' );
 	}
 
 	/**
@@ -67,7 +65,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	public function get_item( $request ) {
 		$obj = get_post_status_object( $request['status'] );
 		if ( empty( $obj ) ) {
-			return new WP_Error( 'rest_status_invalid', sprintf( __( 'Invalid %s.' ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_status_invalid', __( 'Invalid resource.' ), array( 'status' => 404 ) );
 		}
 		$data = $this->prepare_item_for_response( $obj, $request );
 		return rest_ensure_response( $data );
@@ -82,7 +80,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $status, $request ) {
 		if ( ( false === $status->public && ! is_user_logged_in() ) || ( true === $status->internal && is_user_logged_in() ) ) {
-			return new WP_Error( 'rest_cannot_read_status', sprintf( __( 'Cannot view %s.' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_read_status', __( 'Cannot view resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		$data = array(
@@ -133,27 +131,27 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'name'             => array(
-					'description'  => sprintf( __( 'The title for the %s.' ), $this->singular_label ),
+					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view' ),
 					),
 				'private'          => array(
-					'description'  => sprintf( __( 'Whether posts with this %s should be private.' ), $this->singular_label ),
+					'description'  => __( 'Whether posts with this resource should be private.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
 					),
 				'protected'        => array(
-					'description'  => sprintf( __( 'Whether posts with this %s should be protected.' ), $this->singular_label ),
+					'description'  => __( 'Whether posts with this resource should be protected.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
 					),
 				'public'           => array(
-					'description'  => sprintf( __( 'Whether posts of this %s should be shown in the front end of the site.' ), $this->singular_label ),
+					'description'  => __( 'Whether posts of this resource should be shown in the front end of the site.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
 					),
 				'queryable'        => array(
-					'description'  => sprintf( __( 'Whether posts with this %s should be publicly-queryable.' ), $this->singular_label ),
+					'description'  => __( 'Whether posts with this resource should be publicly-queryable.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
 					),
@@ -163,7 +161,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 					'context'      => array( 'view' ),
 					),
 				'slug'             => array(
-					'description'  => sprintf( __( 'An alphanumeric identifier for the %s.' ), $this->singular_label ),
+					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view' ),
 					),

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -5,8 +5,6 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'types';
-		$this->singular_label = __( 'Type' );
-		$this->plural_label = __( 'Types' );
 	}
 
 	/**
@@ -62,13 +60,13 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	public function get_item( $request ) {
 		$obj = get_post_type_object( $request['type'] );
 		if ( empty( $obj ) ) {
-			return new WP_Error( 'rest_type_invalid', sprintf( __( 'Invalid %s.' ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_type_invalid', __( 'Invalid resource.' ), array( 'status' => 404 ) );
 		}
 		if ( empty( $obj->show_in_rest ) ) {
-			return new WP_Error( 'rest_cannot_read_type', sprintf( __( 'Cannot view %s.' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_read_type', __( 'Cannot view resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		if ( 'edit' === $request['context'] && ! current_user_can( $obj->cap->edit_posts ) ) {
-			return new WP_Error( 'rest_forbidden_context', sprintf( __( 'Sorry, you are not allowed to manage this %s.' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to manage this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		$data = $this->prepare_item_for_response( $obj, $request );
 		return rest_ensure_response( $data );
@@ -130,27 +128,27 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'description'      => array(
-					'description'  => sprintf( __( 'A human-readable description of the %s.' ), $this->singular_label ),
+					'description'  => __( 'A human-readable description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'hierarchical'     => array(
-					'description'  => sprintf( __( 'Whether or not the %s should have children.' ), $this->singular_label ),
+					'description'  => __( 'Whether or not the resource should have children.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'labels'           => array(
-					'description'  => sprintf( __( 'Human-readable labels for the %s for various contexts.' ), $this->singular_label ),
+					'description'  => __( 'Human-readable labels for the resource for various contexts.' ),
 					'type'         => 'object',
 					'context'      => array( 'edit' ),
 					),
 				'name'             => array(
-					'description'  => sprintf( __( 'The title for the %s.' ), $this->singular_label ),
+					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'slug'             => array(
-					'description'  => sprintf( __( 'An alphanumeric identifier for the %s.' ), $this->singular_label ),
+					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -5,8 +5,6 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'taxonomies';
-		$this->singular_label = __( 'Taxonomy' );
-		$this->plural_label = __( 'Taxonomies' );
 	}
 
 	/**
@@ -75,7 +73,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				return false;
 			}
 			if ( 'edit' === $request['context'] && ! current_user_can( $tax_obj->cap->manage_terms ) ) {
-				return new WP_Error( 'rest_forbidden_context', sprintf( __( 'Sorry, you are not allowed to manage this %s.' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+				return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to manage this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
 
@@ -91,7 +89,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	public function get_item( $request ) {
 		$tax_obj = get_taxonomy( $request['taxonomy'] );
 		if ( empty( $tax_obj ) ) {
-			return new WP_Error( 'rest_taxonomy_invalid', sprintf( __( 'Invalid %s.' ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_taxonomy_invalid', __( 'Invalid resource.' ), array( 'status' => 404 ) );
 		}
 		$data = $this->prepare_item_for_response( $tax_obj, $request );
 		return rest_ensure_response( $data );
@@ -157,27 +155,27 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'description'      => array(
-					'description'  => sprintf( __( 'A human-readable description of the %s.' ), $this->singular_label ),
+					'description'  => __( 'A human-readable description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'hierarchical'     => array(
-					'description'  => sprintf( __( 'Whether or not the %s should have children.' ), $this->singular_label ),
+					'description'  => __( 'Whether or not the resource should have children.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'labels'           => array(
-					'description'  => sprintf( __( 'Human-readable labels for the %s for various contexts.' ), $this->singular_label ),
+					'description'  => __( 'Human-readable labels for the resource for various contexts.' ),
 					'type'         => 'object',
 					'context'      => array( 'edit' ),
 					),
 				'name'             => array(
-					'description'  => sprintf( __( 'The title for the %s.' ), $this->singular_label ),
+					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),
 				'slug'             => array(
-					'description'  => sprintf( __( 'An alphanumeric identifier for the %s.' ), $this->singular_label ),
+					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
 					),
@@ -187,7 +185,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 					'context'      => array( 'edit' ),
 					),
 				'types'            => array(
-					'description'  => sprintf( __( 'Types associated with %s.' ), $this->singular_label ),
+					'description'  => __( 'Types associated with resource.' ),
 					'type'         => 'array',
 					'context'      => array( 'view', 'edit' ),
 					),
@@ -205,7 +203,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$new_params = array();
 		$new_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 		$new_params['type'] = array(
-			'description'  => sprintf( __( 'Limit results to %s associated with a specific post type.' ), $this->plural_label ),
+			'description'  => __( 'Limit results to resources associated with a specific post type.' ),
 			'type'         => 'string',
 		);
 		return $new_params;

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -15,8 +15,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$this->namespace = 'wp/v2';
 		$tax_obj = get_taxonomy( $taxonomy );
 		$this->rest_base = ! empty( $tax_obj->rest_base ) ? $tax_obj->rest_base : $tax_obj->name;
-		$this->singular_label = ! empty( $tax_obj->labels->singular_name ) ? $tax_obj->labels->singular_name : $tax_obj->name;
-		$this->plural_label = ! empty( $tax_obj->label ) ? $tax_obj->label : $tax_obj->name;
 	}
 
 	/**
@@ -205,7 +203,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$term = get_term( (int) $request['id'], $this->taxonomy );
 		if ( ! $term || $term->taxonomy !== $this->taxonomy ) {
-			return new WP_Error( 'rest_term_invalid', sprintf( __( "%s doesn't exist." ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_term_invalid', __( "Resource doesn't exist." ), array( 'status' => 404 ) );
 		}
 		if ( is_wp_error( $term ) ) {
 			return $term;
@@ -230,7 +228,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 		if ( ! current_user_can( $taxonomy_obj->cap->manage_terms ) ) {
-			return new WP_Error( 'rest_cannot_create', sprintf( __( 'Sorry, you cannot create new %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you cannot create new resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -256,13 +254,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		if ( isset( $request['parent'] ) ) {
 			if ( ! is_taxonomy_hierarchical( $this->taxonomy ) ) {
-				return new WP_Error( 'rest_taxonomy_not_hierarchical', sprintf( __( 'Can not set %s parent, taxonomy is not hierarchical.' ), $this->singular_label ), array( 'status' => 400 ) );
+				return new WP_Error( 'rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.' ), array( 'status' => 400 ) );
 			}
 
 			$parent = get_term( (int) $request['parent'], $this->taxonomy );
 
 			if ( ! $parent ) {
-				return new WP_Error( 'rest_term_invalid', sprintf( __( "Parent %s doesn't exist." ), $this->singular_label ), array( 'status' => 404 ) );
+				return new WP_Error( 'rest_term_invalid', __( "Parent resource doesn't exist." ), array( 'status' => 404 ) );
 			}
 
 			$args['parent'] = $parent->term_id;
@@ -316,12 +314,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$term = get_term( (int) $request['id'], $this->taxonomy );
 		if ( ! $term ) {
-			return new WP_Error( 'rest_term_invalid', sprintf( __( "%s doesn't exist." ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_term_invalid', __( "Resource doesn't exist." ), array( 'status' => 404 ) );
 		}
 
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 		if ( ! current_user_can( $taxonomy_obj->cap->edit_terms ) ) {
-			return new WP_Error( 'rest_cannot_update', sprintf( __( 'Sorry, you cannot update %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_update', __( 'Sorry, you cannot update resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -348,13 +346,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		if ( isset( $request['parent'] ) ) {
 			if ( ! is_taxonomy_hierarchical( $this->taxonomy ) ) {
-				return new WP_Error( 'rest_taxonomy_not_hierarchical', sprintf( __( 'Can not set %s parent, taxonomy is not hierarchical.' ), $this->singular_label ), array( 'status' => 400 ) );
+				return new WP_Error( 'rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.' ), array( 'status' => 400 ) );
 			}
 
 			$parent = get_term( (int) $request['parent'], $this->taxonomy );
 
 			if ( ! $parent ) {
-				return new WP_Error( 'rest_term_invalid', sprintf( __( "Parent %s doesn't exist." ), $this->singular_label ), array( 'status' => 400 ) );
+				return new WP_Error( 'rest_term_invalid', __( "Parent resource doesn't exist." ), array( 'status' => 400 ) );
 			}
 
 			$prepared_args['parent'] = $parent->term_id;
@@ -393,11 +391,11 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		}
 		$term = get_term( (int) $request['id'], $this->taxonomy );
 		if ( ! $term ) {
-			return new WP_Error( 'rest_term_invalid', sprintf( __( "%s doesn't exist." ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_term_invalid', __( "Resource doesn't exist." ), array( 'status' => 404 ) );
 		}
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 		if ( ! current_user_can( $taxonomy_obj->cap->delete_terms ) ) {
-			return new WP_Error( 'rest_cannot_delete', sprintf( __( 'Sorry, you cannot delete %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_delete', __( 'Sorry, you cannot delete resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -414,7 +412,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		// We don't support trashing for this type, error out
 		if ( ! $force ) {
-			return new WP_Error( 'rest_trash_not_supported', sprintf( __( '%s do not support trashing.' ), $this->plural_label ), array( 'status' => 501 ) );
+			return new WP_Error( 'rest_trash_not_supported', __( 'Resource does not support trashing.' ), array( 'status' => 501 ) );
 		}
 
 		$term = get_term( (int) $request['id'], $this->taxonomy );
@@ -430,7 +428,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$retval = wp_delete_term( $term->term_id, $term->taxonomy );
 		if ( ! $retval ) {
-			return new WP_Error( 'rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.' ), $this->singular_label ), array( 'status' => 500 ) );
+			return new WP_Error( 'rest_cannot_delete', __( 'The resource cannot be deleted.' ), array( 'status' => 500 ) );
 		}
 
 		/**
@@ -533,19 +531,19 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'id'               => array(
-					'description'  => sprintf( __( 'Unique identifier for the %s.' ), $this->singular_label ),
+					'description'  => __( 'Unique identifier for the resource.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
 				),
 				'count'            => array(
-					'description'  => sprintf( __( 'Number of published posts for the %s.' ), $this->singular_label ),
+					'description'  => __( 'Number of published posts for the resource.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view' ),
 					'readonly'     => true,
 				),
 				'description'      => array(
-					'description'  => sprintf( __( 'A human-readable description of the %s.' ), $this->singular_label ),
+					'description'  => __( 'A human-readable description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view' ),
 					'arg_options'  => array(
@@ -553,14 +551,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					),
 				),
 				'link'             => array(
-					'description'  => sprintf( __( 'URL to the %s.' ), $this->singular_label ),
+					'description'  => __( 'URL to the resource.' ),
 					'type'         => 'string',
 					'format'       => 'uri',
 					'context'      => array( 'view', 'embed' ),
 					'readonly'     => true,
 				),
 				'name'             => array(
-					'description'  => sprintf( __( 'The title for the %s.' ), $this->singular_label ),
+					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed' ),
 					'arg_options'  => array(
@@ -569,7 +567,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'required'     => true,
 				),
 				'slug'             => array(
-					'description'  => sprintf( __( 'An alphanumeric identifier for the %s unique to its type.' ), $this->singular_label ),
+					'description'  => __( 'An alphanumeric identifier for the resource unique to its type.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed' ),
 					'arg_options'  => array(
@@ -577,7 +575,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					),
 				),
 				'taxonomy'         => array(
-					'description'  => sprintf( __( 'Type attribution for the %s.' ), $this->singular_label ),
+					'description'  => __( 'Type attribution for the resource.' ),
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
 					'context'      => array( 'view', 'embed' ),
@@ -588,7 +586,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$taxonomy = get_taxonomy( $this->taxonomy );
 		if ( $taxonomy->hierarchical ) {
 			$schema['properties']['parent'] = array(
-					'description'  => sprintf( __( 'The id for the parent of the %s.' ), $this->singular_label ),
+					'description'  => __( 'The id for the parent of the resource.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view' ),
 					);
@@ -621,7 +619,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		);
 		if ( ! $taxonomy->hierarchical ) {
 			$query_params['offset'] = array(
-				'description'        => sprintf( __( 'Offset the result set by a specific number of %s.' ), $this->plural_label ),
+				'description'        => __( 'Offset the result set by a specific number of items.' ),
 				'type'               => 'integer',
 				'sanitize_callback'  => 'absint',
 			);
@@ -637,7 +635,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			),
 		);
 		$query_params['orderby']    = array(
-			'description'           => sprintf( __( 'Sort collection by %s attribute.' ), $this->singular_label ),
+			'description'           => __( 'Sort collection by resource attribute.' ),
 			'type'                  => 'string',
 			'sanitize_callback'     => 'sanitize_key',
 			'default'               => 'name',
@@ -652,24 +650,24 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			),
 		);
 		$query_params['hide_empty'] = array(
-			'description'           => sprintf( __( 'Whether to hide %s not assigned to any posts.' ), $this->plural_label ),
+			'description'           => __( 'Whether to hide resources not assigned to any posts.' ),
 			'type'                  => 'boolean',
 			'default'               => false,
 		);
 		if ( $taxonomy->hierarchical ) {
 			$query_params['parent'] = array(
-				'description'        => sprintf( __( 'Limit result set to %s assigned to a specific parent.' ), $this->plural_label ),
+				'description'        => __( 'Limit result set to resources assigned to a specific parent.' ),
 				'type'               => 'integer',
 				'sanitize_callback'  => 'absint',
 			);
 		}
 		$query_params['post'] = array(
-			'description'           => sprintf( __( 'Limit result set to %s assigned to a specific post.' ), $this->plural_label ),
+			'description'           => __( 'Limit result set to resources assigned to a specific post.' ),
 			'type'                  => 'number',
 			'default'               => false,
 		);
 		$query_params['slug']    = array(
-			'description'        => sprintf( __( 'Limit result set to %s with a specific slug.' ), $this->plural_label ),
+			'description'        => __( 'Limit result set to resources with a specific slug.' ),
 			'type'               => 'string',
 		);
 		return $query_params;

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -8,8 +8,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'users';
-		$this->singular_label = __( 'User' );
-		$this->plural_label = __( 'Users' );
 	}
 
 	/**
@@ -190,7 +188,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$user = get_userdata( $id );
 
 		if ( empty( $id ) || empty( $user->ID ) ) {
-			return new WP_Error( 'rest_user_invalid_id', sprintf( __( 'Invalid %s id.' ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid resource id.' ), array( 'status' => 404 ) );
 		}
 
 		if ( get_current_user_id() === $id ) {
@@ -200,11 +198,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) && in_array( $request['context'], array( 'edit', 'view', 'embed' ) ) ? $request['context'] : 'embed';
 
 		if ( 'edit' === $context && ! current_user_can( 'edit_user', $id ) ) {
-			return new WP_Error( 'rest_user_cannot_view', sprintf( __( 'Sorry, you cannot view this %s with edit context' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
 		} else if ( 'view' === $context && ! current_user_can( 'list_users' ) ) {
-			return new WP_Error( 'rest_user_cannot_view', sprintf( __( 'Sorry, you cannot view this %s with view context' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource with view context.' ), array( 'status' => rest_authorization_required_code() ) );
 		} else if ( 'embed' === $context && ! count_user_posts( $id ) && ! current_user_can( 'edit_user', $id ) && ! current_user_can( 'list_users' ) ) {
-			return new WP_Error( 'rest_user_cannot_view', sprintf( __( 'Sorry, you cannot view this %s' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -221,7 +219,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$user = get_userdata( $id );
 
 		if ( empty( $id ) || empty( $user->ID ) ) {
-			return new WP_Error( 'rest_user_invalid_id', sprintf( __( 'Invalid %s id.' ), $this->singular_label ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid resource id.' ), array( 'status' => 404 ) );
 		}
 
 		$user = $this->prepare_item_for_response( $user, $request );
@@ -260,7 +258,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	public function create_item_permissions_check( $request ) {
 
 		if ( ! current_user_can( 'create_users' ) ) {
-			return new WP_Error( 'rest_cannot_create_user', sprintf( __( 'Sorry, you are not allowed to create %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_create_user', __( 'Sorry, you are not allowed to create resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -276,7 +274,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		global $wp_roles;
 
 		if ( ! empty( $request['id'] ) ) {
-			return new WP_Error( 'rest_user_exists', sprintf( __( 'Cannot create existing %s.' ), $this->singular_label ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_user_exists', __( 'Cannot create existing resource.' ), array( 'status' => 400 ) );
 		}
 
 		$user = $this->prepare_item_for_database( $request );
@@ -291,7 +289,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( is_multisite() ) {
 			$user_id = wpmu_create_user( $user->user_login, $user->user_pass, $user->user_email );
 			if ( ! $user_id ) {
-				return new WP_Error( 'rest_user_create', sprintf( __( 'Error creating new %s.' ), $this->singular_label ), array( 'status' => 500 ) );
+				return new WP_Error( 'rest_user_create', __( 'Error creating new resource.' ), array( 'status' => 500 ) );
 			}
 			$user->ID = $user_id;
 			$user_id = wp_update_user( $user );
@@ -337,11 +335,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$id = (int) $request['id'];
 
 		if ( ! current_user_can( 'edit_user', $id ) ) {
-			return new WP_Error( 'rest_cannot_edit', sprintf( __( 'Sorry, you are not allowed to edit %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_edit', __( 'Sorry, you are not allowed to edit resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		if ( ! empty( $request['role'] ) && ! current_user_can( 'edit_users' ) ) {
-			return new WP_Error( 'rest_cannot_edit_roles', sprintf( __( 'Sorry, you are not allowed to edit roles of %s.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_cannot_edit_roles', __( 'Sorry, you are not allowed to edit roles of this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -358,7 +356,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$user = get_userdata( $id );
 		if ( ! $user ) {
-			return new WP_Error( 'rest_user_invalid_id', sprintf( __( '%s id is invalid.' ), $this->singular_label ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid resource id.' ), array( 'status' => 400 ) );
 		}
 
 		if ( email_exists( $request['email'] ) && $request['email'] !== $user->user_email ) {
@@ -413,7 +411,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$id = (int) $request['id'];
 
 		if ( ! current_user_can( 'delete_user', $id ) ) {
-			return new WP_Error( 'rest_user_cannot_delete', sprintf( __( 'Sorry, you are not allowed to delete this %s.' ), $this->singular_label ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'rest_user_cannot_delete', __( 'Sorry, you are not allowed to delete this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -437,12 +435,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$user = get_userdata( $id );
 		if ( ! $user ) {
-			return new WP_Error( 'rest_user_invalid_id', sprintf( __( 'Invalid %s id.' ), $this->singular_label ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid resource id.' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! empty( $reassign ) ) {
 			if ( $reassign === $id || ! get_userdata( $reassign ) ) {
-				return new WP_Error( 'rest_user_invalid_reassign', sprintf( __( 'Invalid %s id.' ), $this->singular_label ), array( 'status' => 400 ) );
+				return new WP_Error( 'rest_user_invalid_reassign', __( 'Invalid resource id for reassignment.' ), array( 'status' => 400 ) );
 			}
 		}
 
@@ -462,7 +460,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$result = wp_delete_user( $id, $reassign );
 
 		if ( ! $result ) {
-			return new WP_Error( 'rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.' ), $this->singular_label ), array( 'status' => 500 ) );
+			return new WP_Error( 'rest_cannot_delete', __( 'The resource cannot be deleted.' ), array( 'status' => 500 ) );
 		}
 
 		/**
@@ -621,13 +619,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 			$editable_roles = get_editable_roles();
 			if ( empty( $editable_roles[ $role ] ) ) {
-				return new WP_Error( 'rest_user_invalid_role', sprintf( __( 'You cannot give %s that role.' ), $this->plural_label ), array( 'status' => 403 ) );
+				return new WP_Error( 'rest_user_invalid_role', __( 'You cannot give resource that role.' ), array( 'status' => 403 ) );
 			}
 
 			return true;
 		}
 
-		return new WP_Error( 'rest_user_invalid_role', sprintf( __( 'You cannot give %s that role.' ), $this->plural_label ), array( 'status' => rest_authorization_required_code() ) );
+		return new WP_Error( 'rest_user_invalid_role', __( 'You cannot give resource that role.' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
@@ -656,13 +654,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'id'          => array(
-					'description' => sprintf( __( 'Unique identifier for the %s.' ), $this->singular_label ),
+					'description' => __( 'Unique identifier for the resource.' ),
 					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'username'    => array(
-					'description' => sprintf( __( 'Login name for the %s.' ), $this->singular_label ),
+					'description' => __( 'Login name for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'edit' ),
 					'required'    => true,
@@ -671,7 +669,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'name'        => array(
-					'description' => sprintf( __( 'Display name for the %s.' ), $this->singular_label ),
+					'description' => __( 'Display name for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'arg_options' => array(
@@ -679,7 +677,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'first_name'  => array(
-					'description' => sprintf( __( 'First name for the %s.' ), $this->singular_label ),
+					'description' => __( 'First name for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'arg_options' => array(
@@ -687,7 +685,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'last_name'   => array(
-					'description' => sprintf( __( 'Last name for the %s.' ), $this->singular_label ),
+					'description' => __( 'Last name for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'arg_options' => array(
@@ -695,21 +693,21 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'email'       => array(
-					'description' => sprintf( __( 'The email address for the %s.' ), $this->singular_label ),
+					'description' => __( 'The email address for the resource.' ),
 					'type'        => 'string',
 					'format'      => 'email',
 					'context'     => array( 'view', 'edit' ),
 					'required'    => true,
 				),
 				'url'         => array(
-					'description' => sprintf( __( 'URL of the %s.' ), $this->singular_label ),
+					'description' => __( 'URL of the resource.' ),
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'description' => array(
-					'description' => sprintf( __( 'Description of the %s.' ), $this->singular_label ),
+					'description' => __( 'Description of the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'arg_options' => array(
@@ -717,21 +715,21 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'link'        => array(
-					'description' => sprintf( __( 'Author URL to the %s.' ), $this->singular_label ),
+					'description' => __( 'Author URL to the resource.' ),
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'avatar_urls'  => array(
-					'description' => sprintf( __( 'Avatar URLs for the %s.' ), $this->singular_label ),
+					'description' => __( 'Avatar URLs for the resource.' ),
 					'type'        => 'object',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $avatar_properties,
 				),
 				'nickname'    => array(
-					'description' => sprintf( __( 'The nickname for the %s.' ), $this->singular_label ),
+					'description' => __( 'The nickname for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'arg_options' => array(
@@ -739,7 +737,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'slug'        => array(
-					'description' => sprintf( __( 'An alphanumeric identifier for the %s.' ), $this->singular_label ),
+					'description' => __( 'An alphanumeric identifier for the resource.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'arg_options' => array(
@@ -747,29 +745,29 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					),
 				),
 				'registered_date' => array(
-					'description' => sprintf( __( 'Registration date for the %s.' ), $this->singular_label ),
+					'description' => __( 'Registration date for the resource.' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'roles'           => array(
-					'description' => sprintf( __( 'Roles assigned to the %s.' ), $this->singular_label ),
+					'description' => __( 'Roles assigned to the resource.' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'role'            => array(
-					'description' => sprintf( __( 'Role assigned to the %s.' ), $this->singular_label ),
+					'description' => __( 'Role assigned to the resource.' ),
 					'type'        => 'string',
 					'enum'        => array_keys( $wp_roles->role_objects ),
 				),
 				'capabilities'    => array(
-					'description' => sprintf( __( 'All capabilities assigned to the %s.' ), $this->singular_label ),
+					'description' => __( 'All capabilities assigned to the resource.' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'extra_capabilities' => array(
-					'description' => sprintf( __( 'Any extra capabilities assigned to the %s.' ), $this->singular_label ),
+					'description' => __( 'Any extra capabilities assigned to the resource.' ),
 					'type'        => 'object',
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
@@ -820,7 +818,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'type'               => 'string',
 		);
 		$query_params['slug']    = array(
-			'description'        => sprintf( __( 'Limit result set to %s with a specific slug.' ), $this->plural_label ),
+			'description'        => __( 'Limit result set to resources with a specific slug.' ),
 			'type'               => 'string',
 		);
 		return $query_params;


### PR DESCRIPTION
As it turns out, we can't use label variables in strings. Instead, we'll
just use a more generic "Resource" throughout.

See #2118, #2056
