### PR TITLE
Use class variables for easier subclassing in Post(s) controllers

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -120,7 +120,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$response = $this->prepare_item_for_response( $attachment, $request );
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( '/wp/v2/' . $this->get_post_type_base( $attachment->post_type ) . '/' . $id ) );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $id ) ) );
 
 		/**
 		 * Fires after a single attachment is created or updated via the REST API.

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -605,8 +605,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( 0 !== (int) $comment->comment_post_ID ) {
 			$post = get_post( $comment->comment_post_ID );
 			if ( ! empty( $post->ID ) ) {
-				$posts_controller = new WP_REST_Posts_Controller( $post->post_type );
-				$base = $posts_controller->get_post_type_base( $post->post_type );
+				$obj = get_post_type_object( $post->post_type );
+				$base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
 
 				$links['up'] = array(
 					'href'       => rest_url( '/wp/v2/' . $base . '/' . $comment->comment_post_ID ),

--- a/lib/endpoints/class-wp-rest-meta-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-meta-posts-controller.php
@@ -32,7 +32,8 @@ class WP_REST_Meta_Posts_Controller extends WP_REST_Meta_Controller {
 	public function __construct( $parent_post_type ) {
 		$this->parent_post_type = $parent_post_type;
 		$this->parent_controller = new WP_REST_Posts_Controller( $this->parent_post_type );
-		$this->parent_base = $this->parent_controller->get_post_type_base( $this->parent_post_type );
+		$obj = get_post_type_object( $this->parent_post_type );
+		$this->parent_base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -101,12 +101,10 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $data );
 
-		$posts_controller = new WP_REST_Posts_Controller( 'post' );
-
 		if ( 'publish' === $status->name ) {
-			$response->add_link( 'archives', rest_url( '/wp/v2/' . $posts_controller->get_post_type_base( 'post' ) ) );
+			$response->add_link( 'archives', rest_url( '/wp/v2/posts' ) );
 		} else {
-			$response->add_link( 'archives', add_query_arg( 'status', $status->name, rest_url( '/wp/v2/' . $posts_controller->get_post_type_base( 'post' ) ) ) );
+			$response->add_link( 'archives', add_query_arg( 'status', $status->name, rest_url( '/wp/v2/posts' ) ) );
 		}
 
 		/**

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -9,7 +9,10 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	public function __construct( $parent_post_type ) {
 		$this->parent_post_type = $parent_post_type;
 		$this->parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
-		$this->parent_base = $this->parent_controller->get_post_type_base( $this->parent_post_type );
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'revisions';
+		$post_type_object = get_post_type_object( $parent_post_type );
+		$this->parent_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
 	}
 
 	/**
@@ -17,7 +20,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions', array(
+		register_rest_route( $this->namespace, '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/' . $this->rest_base, array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_items' ),
@@ -28,7 +31,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
-		register_rest_route( 'wp/v2', '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/revisions/(?P<id>[\d]+)', array(
+		register_rest_route( $this->namespace, '/' . $this->parent_base . '/(?P<parent_id>[\d]+)/' . $this->rest_base . '/(?P<id>[\d]+)', array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
 				'callback'        => array( $this, 'get_item' ),
@@ -209,7 +212,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		$response = rest_ensure_response( $data );
 
 		if ( ! empty( $data['parent'] ) ) {
-			$response->add_link( 'parent', rest_url( sprintf( 'wp/%s/%d', $this->parent_base, $data['parent'] ) ) );
+			$response->add_link( 'parent', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->parent_base, $data['parent'] ) ) );
 		}
 
 		/**

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -248,7 +248,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$parent_controller = new WP_REST_Posts_Controller( $parent->post_type );
 		$parent_object = get_post_type_object( $parent->post_type );
 		$parent_base = ! empty( $parent_object->rest_base ) ? $parent_object->rest_base : $parent_object->name;
-		$this->assertEquals( rest_url( '/wp/v2' . $parent_base . '/' . $revision->post_parent ), $links['parent'][0]['href'] );
+		$this->assertEquals( rest_url( '/wp/v2/' . $parent_base . '/' . $revision->post_parent ), $links['parent'][0]['href'] );
 	}
 
 }

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -246,8 +246,9 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 		$parent = get_post( $revision->post_parent );
 		$parent_controller = new WP_REST_Posts_Controller( $parent->post_type );
-		$parent_base = $parent_controller->get_post_type_base( $parent->post_type );
-		$this->assertEquals( rest_url( 'wp/' . $parent_base . '/' . $revision->post_parent ), $links['parent'][0]['href'] );
+		$parent_object = get_post_type_object( $parent->post_type );
+		$parent_base = ! empty( $parent_object->rest_base ) ? $parent_object->rest_base : $parent_object->name;
+		$this->assertEquals( rest_url( '/wp/v2' . $parent_base . '/' . $revision->post_parent ), $links['parent'][0]['href'] );
 	}
 
 }


### PR DESCRIPTION
- Removes `get_post_type_base()` method, which isn't necessary.
- Fixes `parent` link for revisions, which was previously missing `v2` from `wp/v2`

See #2118 
