### PR TITLE
Respect `show_avatars` option when adding avatars to Users

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -503,7 +503,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$schema = $this->get_item_schema();
 
 		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
-				$data['avatar_urls'] = rest_get_avatar_urls($user->user_email);
+				$data['avatar_urls'] = rest_get_avatar_urls( $user->user_email );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'embed';
@@ -639,8 +639,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-
-
 		global $wp_roles;
 
 		$schema = array(
@@ -763,7 +761,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( get_option('show_avatars') ) {
+		if ( get_option( 'show_avatars' ) ) {
 			$avatar_properties = array();
 
 			$avatar_sizes = rest_get_avatar_sizes();

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -503,7 +503,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$schema = $this->get_item_schema();
 
 		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
-				$data['avatar_urls'] = rest_get_avatar_urls( $user->user_email );
+			$data['avatar_urls'] = rest_get_avatar_urls( $user->user_email );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'embed';

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -897,6 +897,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 17, count( $properties ) );
+		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'email', $properties );
@@ -917,13 +918,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_schema_show_avatar() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
-		$properties = $data['schema']['properties'];
-
-		$this->assertArrayHasKey( 'avatar_urls', $properties );
-
 		update_option( 'show_avatars', false );
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -897,7 +897,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 17, count( $properties ) );
-		$this->assertArrayHasKey( 'avatar_urls', $properties );
 		$this->assertArrayHasKey( 'capabilities', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'email', $properties );
@@ -914,6 +913,24 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'username', $properties );
 		$this->assertArrayHasKey( 'roles', $properties );
 		$this->assertArrayHasKey( 'role', $properties );
+
+	}
+
+	public function test_get_item_schema_show_avatar() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayHasKey( 'avatar_urls', $properties );
+
+		update_option( 'show_avatars', false );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayNotHasKey( 'avatar_urls', $properties );
 	}
 
 	public function test_get_additional_field_registration() {


### PR DESCRIPTION
If `show_avatars=>false`, then `avatar_url` shouldn't be included on the User Resource.

See #1872 
