### PR TITLE
Add `trash` status to `GET /wp/v2/statuses`

### DIFF
--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -30,27 +30,28 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$data = $response->get_data();
 		$statuses = get_post_stati( array( 'public' => true ), 'objects' );
 		$this->assertEquals( 1, count( $data ) );
-		// Check each key in $data against those in $statuses
-		foreach ( $data as $key => $obj ) {
-			$this->assertEquals( $statuses[ $obj['slug'] ]->name, $key );
-			$this->check_post_status_obj( $statuses[ $obj['slug'] ], $obj );
-		}
+		$this->assertEquals( 'publish', $data['publish']['slug'] );
+		$this->assertFalse( $data['publish']['private'] );
+		$this->assertTrue( $data['publish']['public'] );
 	}
 
 	public function test_get_items_logged_in() {
-		$user_id = $this->factory->user->create();
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $user_id );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses' );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
-		$statuses = get_post_stati( array( 'internal' => false ), 'objects' );
-		$this->assertEquals( 5, count( $data ) );
-		// Check each key in $data against those in $statuses
-		foreach ( $data as $obj ) {
-			$this->check_post_status_obj( $statuses[ $obj['slug'] ], $obj );
-		}
+		$this->assertEquals( 6, count( $data ) );
+		$this->assertEqualSets( array(
+			'publish',
+			'private',
+			'pending',
+			'draft',
+			'trash',
+			'future',
+		), array_keys( $data ) );
 	}
 
 	public function test_get_item() {


### PR DESCRIPTION
Also creates `get_item_permissions_check()` to move check out of
`prepare_item_for_response()`, and uses `current_user_can( 'edit_posts'
)` as a view cap check instead of `is_user_logged_in()`

Fixes #1040
Fixes #2157
Fixes #2143
