### PR TITLE
Return original resource with `DELETE /wp/v2/users/<id>`

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -445,14 +445,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		$request->set_param( 'context', 'edit' );
-		$orig_user = $this->prepare_item_for_response( $user, $request );
-
-		$data = $orig_user->get_data();
-		$data = array(
-			'data'    => $data,
-			'deleted' => true,
-		);
-		$orig_user->set_data( $data );
+		$response = $this->prepare_item_for_response( $user, $request );
 
 		/** Include admin user functions to get access to wp_delete_user() */
 		require_once ABSPATH . 'wp-admin/includes/user.php';
@@ -466,12 +459,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a user is deleted via the REST API.
 		 *
-		 * @param WP_User         $user    The user data.
-		 * @param WP_REST_Request $request The request sent to the API.
+		 * @param WP_User          $user     The user data.
+		 * @param WP_REST_Response $response The response returned from the API.
+		 * @param WP_REST_Request  $request  The request sent to the API.
 		 */
-		do_action( 'rest_delete_user', $user, $data, $request );
+		do_action( 'rest_delete_user', $user, $response, $request );
 
-		return $orig_user;
+		return $response;
 	}
 
 	/**

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -804,8 +804,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted User', $data['data']['name'] );
-		$this->assertTrue( $data['deleted'] );
+		$this->assertEquals( 'Deleted User', $data['name'] );
 	}
 
 	public function test_delete_item_no_trash() {


### PR DESCRIPTION
Now that all resources require the `force` param, we don't need to wrap
delete responses with the `trash` state.

See #1260
