### PR TITLE
Return original resource with `DELETE /wp/v2/<taxonomy>/<id>`

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -419,13 +419,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $term, $request );
 
-		$data = $response->get_data();
-		$data = array(
-			'data'    => $data,
-			'deleted' => true,
-		);
-		$response->set_data( $data );
-
 		$retval = wp_delete_term( $term->term_id, $term->taxonomy );
 		if ( ! $retval ) {
 			return new WP_Error( 'rest_cannot_delete', __( 'The resource cannot be deleted.' ), array( 'status' => 500 ) );
@@ -434,11 +427,11 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a single term is deleted via the REST API.
 		 *
-		 * @param WP_Term         $term    The deleted term.
-		 * @param array           $data    The response data.
-		 * @param WP_REST_Request $request The request sent to the API.
+		 * @param WP_Term          $term     The deleted term.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
 		 */
-		do_action( "rest_delete_{$this->taxonomy}", $term, $data, $request );
+		do_action( "rest_delete_{$this->taxonomy}", $term, $response, $request );
 
 		return $response;
 	}

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -585,8 +585,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted Category', $data['data']['name'] );
-		$this->assertTrue( $data['deleted'] );
+		$this->assertEquals( 'Deleted Category', $data['name'] );
 	}
 
 	public function test_delete_item_force_false() {

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -467,8 +467,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Deleted Tag', $data['data']['name'] );
-		$this->assertTrue( $data['deleted'] );
+		$this->assertEquals( 'Deleted Tag', $data['name'] );
 	}
 
 	public function test_delete_item_force_false() {


### PR DESCRIPTION
Now that all resources require the `force` param, we don't need to wrap
delete responses with the `trash` state.

See #1260
