### PR TITLE
Remove `GET /wp/v2/comments` support for `post_*` params

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -120,11 +120,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'type'         => isset( $request['type'] ) ? $request['type'] : '',
 				'author_email' => isset( $request['author_email'] ) ? $request['author_email'] : '',
 				'karma'        => isset( $request['karma'] ) ? $request['karma'] : '',
-				'post_author'  => isset( $request['post_author'] ) ? $request['post_author'] : '',
-				'post_name'    => isset( $request['post_slug'] ) ? $request['post_slug'] : '',
-				'post_parent'  => isset( $request['post_parent'] ) ? $request['post_parent'] : '',
-				'post_status'  => isset( $request['post_status'] ) ? $request['post_status'] : '',
-				'post_type'    => isset( $request['post_type'] ) ? $request['post_type'] : '',
 			);
 
 			$prepared_args = array_merge( $prepared_args, $protected_args );
@@ -974,36 +969,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'description'       => __( 'Limit result set to comments assigned to a specific post id.' ),
 			'sanitize_callback' => 'absint',
 			'type'              => 'integer',
-		);
-		$query_params['post_author'] = array(
-			'default'           => null,
-			'description'       => __( 'Limit result set to comments associated with posts of a specific post author id.' ),
-			'sanitize_callback' => 'absint',
-			'type'              => 'integer',
-		);
-		$query_params['post_slug'] = array(
-			'default'           => null,
-			'description'       => __( 'Limit result set to comments associated with posts of a specific post slug.' ),
-			'sanitize_callback' => 'sanitize_title',
-			'type'              => 'string',
-		);
-		$query_params['post_parent'] = array(
-			'default'           => null,
-			'description'       => __( 'Limit result set to comments associated with posts of a specific post parent id.' ),
-			'sanitize_callback' => 'absint',
-			'type'              => 'integer',
-		);
-		$query_params['post_status'] = array(
-			'default'           => null,
-			'description'       => __( 'Limit result set to comments associated with posts of a specific post status.' ),
-			'sanitize_callback' => 'sanitize_key',
-			'type'              => 'string',
-		);
-		$query_params['post_type'] = array(
-			'default'           => null,
-			'description'       => __( 'Limit result set to comments associated with posts of a specific post type.' ),
-			'sanitize_callback' => 'sanitize_key',
-			'type'              => 'string',
 		);
 		$query_params['status'] = array(
 			'default'           => 'approve',

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -95,11 +95,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'parent',
 			'per_page',
 			'post',
-			'post_author',
-			'post_parent',
-			'post_slug',
-			'post_status',
-			'post_type',
 			'search',
 			'status',
 			'type',
@@ -252,62 +247,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$comments = $response->get_data();
 		$this->assertCount( 4, $comments );
-	}
-
-	public function test_get_items_for_post_type() {
-		wp_set_current_user( $this->admin_id );
-		$second_post_id = $this->factory->post->create();
-		$first_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$this->factory->comment->create_post_comments( $second_post_id, 2 );
-		$this->factory->comment->create_post_comments( $first_page_id, 1 );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		$request->set_query_params( array(
-			'post_type' => 'page',
-		) );
-
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$comments = $response->get_data();
-		$this->assertCount( 1, $comments );
-	}
-
-	public function test_get_items_for_post_author() {
-		wp_set_current_user( $this->admin_id );
-		$second_post_id = $this->factory->post->create();
-		$third_post_id = $this->factory->post->create( array( 'post_author' => $this->author_id ) );
-		$this->factory->comment->create_post_comments( $second_post_id, 2 );
-		$this->factory->comment->create_post_comments( $third_post_id, 3 );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		$request->set_query_params( array(
-			'post_author' => $this->author_id,
-		) );
-
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$comments = $response->get_data();
-		$this->assertCount( 3, $comments );
-	}
-
-	public function test_get_items_for_post_slug() {
-		wp_set_current_user( $this->admin_id );
-		$second_post_id = $this->factory->post->create();
-		$third_post_id = $this->factory->post->create( array( 'post_name' => 'such-a-unique-post-slug' ) );
-		$this->factory->comment->create_post_comments( $second_post_id, 2 );
-		$this->factory->comment->create_post_comments( $third_post_id, 3 );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		$request->set_query_params( array(
-			'post_slug' => 'such-a-unique-post-slug',
-		) );
-
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$comments = $response->get_data();
-		$this->assertCount( 3, $comments );
 	}
 
 	public function test_get_comments_pagination_headers() {


### PR DESCRIPTION
The proper pattern is to use `GET /wp/v2/posts` to fetch the post IDs to
limit the request to.

We may add support for these again in #2066, but that's a later discussion.

Fixes #1979
