### PR TITLE
Introduce `rest_validate_request_arg()`/`rest_sanitize_request_arg()`

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -426,8 +426,8 @@ abstract class WP_REST_Controller {
 			}
 
 			$endpoint_args[ $field_id ] = array(
-				'validate_callback' => array( $this, 'validate_schema_property' ),
-				'sanitize_callback' => array( $this, 'sanitize_schema_property' ),
+				'validate_callback' => 'rest_validate_request_arg',
+				'sanitize_callback' => 'rest_sanitize_request_arg',
 			);
 
 			if ( WP_REST_Server::CREATABLE === $method && isset( $params['default'] ) ) {
@@ -436,6 +436,12 @@ abstract class WP_REST_Controller {
 
 			if ( WP_REST_Server::CREATABLE === $method && ! empty( $params['required'] ) ) {
 				$endpoint_args[ $field_id ]['required'] = true;
+			}
+
+			foreach ( array( 'type', 'format', 'enum' ) as $schema_prop ) {
+				if ( isset( $params[ $schema_prop ] ) ) {
+					$endpoint_args[ $field_id ][ $schema_prop ] = $params[ $schema_prop ];
+				}
 			}
 
 			// Merge in any options provided by the schema property.
@@ -453,106 +459,4 @@ abstract class WP_REST_Controller {
 		return $endpoint_args;
 	}
 
-	/**
-	 * Validate a parameter value that's based on a property from the item schema.
-	 *
-	 * @param  mixed $value
-	 * @param  WP_REST_Request $request
-	 * @param  string $parameter
-	 * @return WP_Error|boolean
-	 */
-	public function validate_schema_property( $value, $request, $parameter ) {
-
-		/**
-		 * We don't currently validate against empty values, as lots of checks
-		 * can unintentionally fail, as the callback will often handle an empty
-		 * value it's self.
-		 */
-		if ( ! $value ) {
-			return true;
-		}
-
-		$schema = $this->get_item_schema();
-
-		if ( ! isset( $schema['properties'][ $parameter ] ) ) {
-			return true;
-		}
-
-		$property = $schema['properties'][ $parameter ];
-
-		if ( ! empty( $property['enum'] ) ) {
-			if ( ! in_array( $value, $property['enum'] ) ) {
-				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not one of %s' ), $parameter, implode( ', ', $property['enum'] ) ) );
-			}
-		}
-
-		if ( 'integer' === $property['type'] && ! is_numeric( $value ) ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $parameter, 'integer' ) );
-		}
-
-		if ( 'string' === $property['type'] && ! is_string( $value ) ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $parameter, 'string' ) );
-		}
-
-		if ( isset( $property['format'] ) ) {
-			switch ( $property['format'] ) {
-				case 'date-time' :
-					if ( ! rest_parse_date( $value ) ) {
-						return new WP_Error( 'rest_invalid_date', __( 'The date you provided is invalid.' ) );
-					}
-					break;
-
-				case 'email' :
-					if ( ! is_email( $value ) ) {
-						return new WP_Error( 'rest_invalid_email', __( 'The email address you provided is invalid.' ) );
-					}
-					break;
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Sanitize a parameter value that's based on a property from the item schema.
-	 *
-	 * @param  mixed $value
-	 * @param  WP_REST_Request $request
-	 * @param  string $parameter
-	 * @return mixed
-	 */
-	public function sanitize_schema_property( $value, $request, $parameter ) {
-
-		$schema = $this->get_item_schema();
-
-		if ( ! isset( $schema['properties'][ $parameter ] ) ) {
-			return true;
-		}
-
-		$property = $schema['properties'][ $parameter ];
-
-		if ( 'integer' === $property['type'] ) {
-			return (int) $value;
-		}
-
-		if ( isset( $property['format'] ) ) {
-			switch ( $property['format'] ) {
-				case 'date-time' :
-					return sanitize_text_field( $value );
-
-				case 'email' :
-					// as sanitize_email is very lossy, we just want to
-					// make sure the string is safe.
-					if ( sanitize_email( $value ) ) {
-						return sanitize_email( $value );
-					}
-					return sanitize_text_field( $value );
-
-				case 'uri' :
-					return esc_url_raw( $value );
-			}
-		}
-
-		return $value;
-	}
 }

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -2,74 +2,89 @@
 
 class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
+	public function setUp() {
+		parent::setUp();
+		$this->request = new WP_REST_Request( 'GET', '/wp/v2/testroute', array(
+			'args'     => array(
+				'someinteger'     => array(
+					'type'        => 'integer',
+				),
+				'somestring'      => array(
+					'type'        => 'string',
+				),
+				'someenum'        => array(
+					'type'        => 'string',
+					'enum'        => array( 'a' ),
+				),
+				'somedate'        => array(
+					'type'        => 'string',
+					'format'      => 'date-time',
+				),
+				'someemail'       => array(
+					'type'        => 'string',
+					'format'      => 'email',
+				),
+			),
+		));
+	}
 
 	public function test_validate_schema_type_integer() {
 
-		$controller = new WP_REST_Test_Controller();
-
 		$this->assertTrue(
-			$controller->validate_schema_property( '123', new WP_REST_Request, 'someinteger' )
+			rest_validate_request_arg( '123', $this->request, 'someinteger' )
 		);
 
 		$this->assertErrorResponse(
 			'rest_invalid_param',
-			$controller->validate_schema_property( 'abc', new WP_REST_Request, 'someinteger' )
+			rest_validate_request_arg( 'abc', $this->request, 'someinteger' )
 		);
 	}
 
 	public function test_validate_schema_type_string() {
 
-		$controller = new WP_REST_Test_Controller();
-
 		$this->assertTrue(
-			$controller->validate_schema_property( '123', new WP_REST_Request, 'somestring' )
+			rest_validate_request_arg( '123', $this->request, 'somestring' )
 		);
 
 		$this->assertErrorResponse(
 			'rest_invalid_param',
-			$controller->validate_schema_property( array( 'foo' => 'bar' ), new WP_REST_Request, 'somestring' )
+			rest_validate_request_arg( array( 'foo' => 'bar' ), $this->request, 'somestring' )
 		);
 	}
 
 	public function test_validate_schema_enum() {
 
-		$controller = new WP_REST_Test_Controller();
-
 		$this->assertTrue(
-			$controller->validate_schema_property( 'a', new WP_REST_Request, 'someenum' )
+			rest_validate_request_arg( 'a', $this->request, 'someenum' )
 		);
 
 		$this->assertErrorResponse(
 			'rest_invalid_param',
-			$controller->validate_schema_property( 'd', new WP_REST_Request, 'someenum' )
+			rest_validate_request_arg( 'd', $this->request, 'someenum' )
 		);
 	}
 
 	public function test_validate_schema_format_email() {
 
-		$controller = new WP_REST_Test_Controller();
-
 		$this->assertTrue(
-			$controller->validate_schema_property( 'joe@foo.bar', new WP_REST_Request, 'someemail' )
+			rest_validate_request_arg( 'joe@foo.bar', $this->request, 'someemail' )
 		);
 
 		$this->assertErrorResponse(
 			'rest_invalid_email',
-			$controller->validate_schema_property( 'd', new WP_REST_Request, 'someemail' )
+			rest_validate_request_arg( 'd', $this->request, 'someemail' )
 		);
 	}
 
 	public function test_validate_schema_format_date_time() {
 
-		$controller = new WP_REST_Test_Controller();
-
 		$this->assertTrue(
-			$controller->validate_schema_property( '2010-01-01T12:00:00', new WP_REST_Request, 'somedate' )
+			rest_validate_request_arg( '2010-01-01T12:00:00', $this->request, 'somedate' )
 		);
 
 		$this->assertErrorResponse(
 			'rest_invalid_date',
-			$controller->validate_schema_property( '2010-18-18T12:00:00', new WP_REST_Request, 'somedate' )
+			rest_validate_request_arg( '2010-18-18T12:00:00', $this->request, 'somedate' )
 		);
 	}
 


### PR DESCRIPTION
Dedicated functions means we can use them for validating / sanitizing
query args too. Removes `WP_REST_Controller::validate_schema_property()`
and `WP_REST_Controller::sanitize_schema_property()`

See #1212
