### PR TITLE
Add validation callbacks to `GET /wp/v2/users` params

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -802,6 +802,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'description'        => __( 'Offset the result set by a specific number of items.' ),
 			'type'               => 'integer',
 			'sanitize_callback'  => 'absint',
+			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		$query_params['order'] = array(
 			'default'            => 'asc',
@@ -809,6 +810,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'enum'               => array( 'asc', 'desc' ),
 			'sanitize_callback'  => 'sanitize_key',
 			'type'               => 'string',
+			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		$query_params['orderby'] = array(
 			'default'            => 'name',
@@ -821,10 +823,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			),
 			'sanitize_callback'  => 'sanitize_key',
 			'type'               => 'string',
+			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		$query_params['slug']    = array(
 			'description'        => __( 'Limit result set to resources with a specific slug.' ),
 			'type'               => 'string',
+			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		return $query_params;
 	}


### PR DESCRIPTION
See #1212
