### PR TITLE
Mark all Statuses, Types and Taxonomies fields as `readonly`

### DIFF
--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -161,36 +161,43 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'private'          => array(
 					'description'  => __( 'Whether posts with this resource should be private.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'protected'        => array(
 					'description'  => __( 'Whether posts with this resource should be protected.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'public'           => array(
 					'description'  => __( 'Whether posts of this resource should be shown in the front end of the site.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'queryable'        => array(
 					'description'  => __( 'Whether posts with this resource should be publicly-queryable.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'show_in_list'     => array(
 					'description'  => __( 'Whether to include posts in the edit listing for their post type.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				'slug'             => array(
 					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view' ),
+					'readonly'     => true,
 					),
 				),
 			);

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -131,26 +131,31 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 					'description'  => __( 'A human-readable description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'hierarchical'     => array(
 					'description'  => __( 'Whether or not the resource should have children.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'labels'           => array(
 					'description'  => __( 'Human-readable labels for the resource for various contexts.' ),
 					'type'         => 'object',
 					'context'      => array( 'edit' ),
+					'readonly'     => true,
 					),
 				'name'             => array(
 					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'slug'             => array(
 					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				),
 			);

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -158,36 +158,43 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 					'description'  => __( 'A human-readable description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'hierarchical'     => array(
 					'description'  => __( 'Whether or not the resource should have children.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'labels'           => array(
 					'description'  => __( 'Human-readable labels for the resource for various contexts.' ),
 					'type'         => 'object',
 					'context'      => array( 'edit' ),
+					'readonly'     => true,
 					),
 				'name'             => array(
 					'description'  => __( 'The title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'slug'             => array(
 					'description'  => __( 'An alphanumeric identifier for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				'show_cloud'       => array(
 					'description'  => __( 'Whether or not the term cloud should be displayed.' ),
 					'type'         => 'boolean',
 					'context'      => array( 'edit' ),
+					'readonly'     => true,
 					),
 				'types'            => array(
 					'description'  => __( 'Types associated with resource.' ),
 					'type'         => 'array',
 					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
 					),
 				),
 			);


### PR DESCRIPTION
See #1918
