### PR TITLE
Provide `embed` and `view` as public contexts for users

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -40,7 +40,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'callback'        => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'            => array(
-					'context'          => $this->get_context_param( array( 'default' => 'embed' ) ),
+					'context'          => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -106,9 +106,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		if ( ! current_user_can( 'list_users' ) ) {
 			$prepared_args['has_published_posts'] = true;
-
-			// Only display a public subset of information
-			$request['context'] = 'embed';
 		}
 
 		if ( '' !== $prepared_args['search'] ) {
@@ -196,13 +193,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return true;
 		}
 
-		$context = ! empty( $request['context'] ) && in_array( $request['context'], array( 'edit', 'view', 'embed' ) ) ? $request['context'] : 'embed';
-
-		if ( 'edit' === $context && ! current_user_can( 'edit_user', $id ) ) {
-			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
-		} else if ( 'view' === $context && ! current_user_can( 'list_users' ) ) {
+		if ( 'edit' === $request['context'] && ! current_user_can( 'list_users' ) ) {
 			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource with view context.' ), array( 'status' => rest_authorization_required_code() ) );
-		} else if ( 'embed' === $context && ! count_user_posts( $id, $types ) && ! current_user_can( 'edit_user', $id ) && ! current_user_can( 'list_users' ) ) {
+		} else if ( ! count_user_posts( $id, $types ) && ! current_user_can( 'edit_user', $id ) && ! current_user_can( 'list_users' ) ) {
 			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot view this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -667,7 +660,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'first_name'  => array(
 					'description' => __( 'First name for the resource.' ),
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -675,7 +668,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'last_name'   => array(
 					'description' => __( 'Last name for the resource.' ),
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -684,7 +677,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => __( 'The email address for the resource.' ),
 					'type'        => 'string',
 					'format'      => 'email',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'required'    => true,
 				),
 				'url'         => array(
@@ -711,7 +704,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'nickname'    => array(
 					'description' => __( 'The nickname for the resource.' ),
 					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -727,13 +720,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'registered_date' => array(
 					'description' => __( 'Registration date for the resource.' ),
 					'type'        => 'date-time',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
 				'roles'           => array(
 					'description' => __( 'Roles assigned to the resource.' ),
 					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
 				'role'            => array(
@@ -744,7 +737,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				'capabilities'    => array(
 					'description' => __( 'All capabilities assigned to the resource.' ),
 					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
+					'context'     => array( 'edit' ),
 				),
 				'extra_capabilities' => array(
 					'description' => __( 'Any extra capabilities assigned to the resource.' ),

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -752,7 +752,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => __( 'Roles assigned to the resource.' ),
 					'type'        => 'array',
 					'context'     => array( 'edit' ),
-					'enum'        => array_keys( $wp_roles->role_objects ),
 				),
 				'capabilities'    => array(
 					'description' => __( 'All capabilities assigned to the resource.' ),

--- a/plugin.php
+++ b/plugin.php
@@ -292,9 +292,6 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			if ( 'string' === $args['type'] && ! in_array( $value, $args['enum'] ) ) {
 				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not one of %s' ), $param, implode( ', ', $args['enum'] ) ) );
 			}
-			if ( 'array' === $args['type'] && array_diff( $value, $args['enum'] ) ) {
-				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s includes a value not in %s' ), $param, implode( ', ', $args['enum'] ) ) );
-			}
 		}
 
 		if ( 'integer' === $args['type'] && ! is_numeric( $value ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -289,8 +289,11 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 		$args = $attributes['args'][ $param ];
 
 		if ( ! empty( $args['enum'] ) ) {
-			if ( ! in_array( $value, $args['enum'] ) ) {
+			if ( 'string' === $args['type'] && ! in_array( $value, $args['enum'] ) ) {
 				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not one of %s' ), $param, implode( ', ', $args['enum'] ) ) );
+			}
+			if ( 'array' === $args['type'] && array_diff( $value, $args['enum'] ) ) {
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s includes a value not in %s' ), $param, implode( ', ', $args['enum'] ) ) );
 			}
 		}
 

--- a/plugin.php
+++ b/plugin.php
@@ -289,7 +289,7 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 		$args = $attributes['args'][ $param ];
 
 		if ( ! empty( $args['enum'] ) ) {
-			if ( 'string' === $args['type'] && ! in_array( $value, $args['enum'] ) ) {
+			if ( ! in_array( $value, $args['enum'] ) ) {
 				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not one of %s' ), $param, implode( ', ', $args['enum'] ) ) );
 			}
 		}

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -567,7 +567,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
 	}
 
 	public function test_update_item() {
@@ -772,7 +772,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'roles', array( 'BeSharp' ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
 
 		$user = get_userdata( $this->editor );
 		$this->assertArrayHasKey( 'editor', $user->caps );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -46,7 +46,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . $this->user );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertEquals( 'embed', $data['endpoints'][0]['args']['context']['default'] );
+		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertEquals( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
@@ -1027,37 +1027,25 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'avatar_urls', $data );
 		$this->assertEquals( $user->user_nicename, $data['slug'] );
 
-		if ( 'view' === $context || 'edit' === $context ) {
+		if ( 'edit' === $context ) {
 			$this->assertEquals( $user->first_name, $data['first_name'] );
 			$this->assertEquals( $user->last_name, $data['last_name'] );
 			$this->assertEquals( $user->nickname, $data['nickname'] );
+			$this->assertEquals( $user->user_email, $data['email'] );
+			$this->assertEquals( $user->allcaps, $data['capabilities'] );
+			$this->assertEquals( $user->caps, $data['extra_capabilities'] );
+			$this->assertEquals( date( 'c', strtotime( $user->user_registered ) ), $data['registered_date'] );
+			$this->assertEquals( $user->user_login, $data['username'] );
+			$this->assertEquals( $user->roles, $data['roles'] );
 		}
 
-		if ( 'view' !== $context && 'edit' !== $context ) {
+		if ( 'edit' !== $context ) {
 			$this->assertArrayNotHasKey( 'roles', $data );
 			$this->assertArrayNotHasKey( 'capabilities', $data );
 			$this->assertArrayNotHasKey( 'registered', $data );
 			$this->assertArrayNotHasKey( 'first_name', $data );
 			$this->assertArrayNotHasKey( 'last_name', $data );
 			$this->assertArrayNotHasKey( 'nickname', $data );
-		}
-
-		if ( 'view' === $context ) {
-			$this->assertEquals( $user->roles, $data['roles'] );
-			$this->assertEquals( $user->allcaps, $data['capabilities'] );
-			$this->assertEquals( date( 'c', strtotime( $user->user_registered ) ), $data['registered_date'] );
-			$this->assertEquals( $user->user_email, $data['email'] );
-			$this->assertArrayNotHasKey( 'extra_capabilities', $data );
-		}
-
-		if ( 'edit' === $context ) {
-			$this->assertEquals( $user->user_email, $data['email'] );
-			$this->assertEquals( $user->caps, $data['extra_capabilities'] );
-			$this->assertEquals( $user->user_login, $data['username'] );
-			$this->assertEquals( $user->roles, $data['roles'] );
-		}
-
-		if ( 'edit' !== $context ) {
 			$this->assertArrayNotHasKey( 'extra_capabilities', $data );
 			$this->assertArrayNotHasKey( 'username', $data );
 		}

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -566,7 +566,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_body_params( $params );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	public function test_update_item() {
@@ -771,7 +771,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'roles', array( 'BeSharp' ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_user_invalid_role', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$user = get_userdata( $this->editor );
 		$this->assertArrayHasKey( 'editor', $user->caps );


### PR DESCRIPTION
Details historically in `view` have been moved to `edit`

Fixes #1869
Related #1845
