### PR TITLE
Add support for filter param to comments query

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -137,6 +137,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
+		$allowed_filters = array( 'post_name', 'post_type', 'post_author', 'post_parent', 'post_status', 'type__in', 'type__not_in', 'date_query' );
+
+		if ( is_array( $request['filter'] ) ) {
+			$filter_args = array_intersect_key( $request['filter'], array_flip( $allowed_filters ) );
+			$prepared_args = array_merge( $prepared_args, $filter_args );
+		}
+
 		/**
 		 * Filter arguments, before passing to WP_Comment_Query, when querying comments via the REST API.
 		 *

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -1018,6 +1018,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		$query_params['filter'] = array(
+			'description'       => __( 'Use WP_Comment_Query arguments to modify the response; private query vars require appropriate authorization.' ),
+		);
 		return $query_params;
 	}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -86,6 +86,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'author_email',
 			'context',
 			'exclude',
+			'filter',
 			'include',
 			'karma',
 			'offset',
@@ -98,7 +99,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'search',
 			'status',
 			'type',
-			'filter',
 			), $keys );
 	}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -132,11 +132,27 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 	public function test_get_items_for_post() {
 		$second_post_id = $this->factory->post->create();
+		$post = get_post( $second_post_id );
 		$this->factory->comment->create_post_comments( $second_post_id, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_query_params( array(
 			'post' => $second_post_id,
+		) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$comments = $response->get_data();
+		$this->assertCount( 2, $comments );
+
+		// With filter params.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_query_params( array(
+			'filter' => array(
+				'post_name' => $post->post_name,
+				'post_type' => 'post',
+			),
 		) );
 
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -98,6 +98,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'search',
 			'status',
 			'type',
+			'filter',
 			), $keys );
 	}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -151,7 +151,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_query_params( array(
 			'filter' => array(
 				'post_name' => $post->post_name,
-				'post_type' => 'post',
 			),
 		) );
 


### PR DESCRIPTION
Only added support for some of the `comments_query` parameters but this will allow listing comments by post slug etc...

See #2066
