### PR TITLE
Register `exclude` param for `GET /wp/v2/users`

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -810,6 +810,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$query_params['context']['default'] = 'view';
 
+		$query_params['exclude'] = array(
+			'description'        => __( 'Ensure result set excludes specific ids.' ),
+			'type'               => 'array',
+			'default'            => array(),
+			'sanitize_callback'  => 'wp_parse_id_list',
+		);
 		$query_params['include'] = array(
 			'description'        => __( 'Limit result set to specific ids.' ),
 			'type'               => 'array',

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -58,6 +58,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		sort( $keys );
 		$this->assertEquals( array(
 			'context',
+			'exclude',
 			'include',
 			'offset',
 			'order',


### PR DESCRIPTION
The param was already supported in the controller, but still needed to
be registered.

Fixes #2189
