### PR TITLE
Cleanup capabilities in types and taxonomies controllers

### DIFF
--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -148,8 +148,8 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'capabilities'     => array(
-					'description'  => __( 'All capabilities used by the resource' ),
-					'type'         => array(),
+					'description'  => __( 'All capabilities used by the resource.' ),
+					'type'         => 'array',
 					'context'      => array( 'edit' ),
 					'readonly'     => true,
 				),

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -180,8 +180,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			'type'                 => 'object',
 			'properties'           => array(
 				'capabilities'     => array(
-					'description'  => __( 'All capabilities used by the resource' ),
-					'type'         => array(),
+					'description'  => __( 'All capabilities used by the resource.' ),
+					'type'         => 'array',
 					'context'      => array( 'edit' ),
 					'readonly'     => true,
 				),


### PR DESCRIPTION
- Full stop sentences.
- `type=array` instead of `type=array()`

From #2216
