### PR TITLE
Only check permission of types and taxonomies with `show_in_rest`

### DIFF
--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -43,7 +43,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	public function get_items_permissions_check( $request ) {
 		if ( 'edit' === $request['context'] ) {
 			foreach ( get_post_types( array(), 'object' ) as $post_type ) {
-				if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				if ( ! empty( $post_type->show_in_rest ) && current_user_can( $post_type->cap->edit_posts ) ) {
 					return true;
 				}
 			}

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -49,7 +49,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 				$taxonomies = get_taxonomies( '', 'objects' );
 			}
 			foreach ( $taxonomies as $taxonomy ) {
-				if ( current_user_can( $taxonomy->cap->manage_terms ) ) {
+				if ( ! empty( $taxonomy->show_in_rest ) && current_user_can( $taxonomy->cap->manage_terms ) ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
It's more precise.

From #2218
