### PR TITLE
Introduce `edit` context for Terms controller

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -74,7 +74,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-		return $this->check_is_taxonomy_allowed( $this->taxonomy );
+		$tax_obj = get_taxonomy( $this->taxonomy );
+		if ( ! $tax_obj || ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
+			return false;
+		}
+		if ( 'edit' === $request['context'] && ! current_user_can( $tax_obj->cap->edit_terms ) ) {
+			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
 	}
 
 	/**
@@ -188,7 +195,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		return $this->check_is_taxonomy_allowed( $this->taxonomy );
+		$tax_obj = get_taxonomy( $this->taxonomy );
+		if ( ! $tax_obj || ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
+			return false;
+		}
+		if ( 'edit' === $request['context'] && ! current_user_can( $tax_obj->cap->edit_terms ) ) {
+			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
 	}
 
 	/**
@@ -544,19 +558,19 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'id'               => array(
 					'description'  => __( 'Unique identifier for the resource.' ),
 					'type'         => 'integer',
-					'context'      => array( 'view', 'embed' ),
+					'context'      => array( 'view', 'embed', 'edit' ),
 					'readonly'     => true,
 				),
 				'count'            => array(
 					'description'  => __( 'Number of published posts for the resource.' ),
 					'type'         => 'integer',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'edit' ),
 					'readonly'     => true,
 				),
 				'description'      => array(
 					'description'  => __( 'HTML description of the resource.' ),
 					'type'         => 'string',
-					'context'      => array( 'view' ),
+					'context'      => array( 'view', 'edit' ),
 					'arg_options'  => array(
 						'sanitize_callback' => 'wp_filter_post_kses',
 					),
@@ -565,13 +579,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'description'  => __( 'URL to the resource.' ),
 					'type'         => 'string',
 					'format'       => 'uri',
-					'context'      => array( 'view', 'embed' ),
+					'context'      => array( 'view', 'embed', 'edit' ),
 					'readonly'     => true,
 				),
 				'name'             => array(
 					'description'  => __( 'HTML title for the resource.' ),
 					'type'         => 'string',
-					'context'      => array( 'view', 'embed' ),
+					'context'      => array( 'view', 'embed', 'edit' ),
 					'arg_options'  => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -580,7 +594,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'slug'             => array(
 					'description'  => __( 'An alphanumeric identifier for the resource unique to its type.' ),
 					'type'         => 'string',
-					'context'      => array( 'view', 'embed' ),
+					'context'      => array( 'view', 'embed', 'edit' ),
 					'arg_options'  => array(
 						'sanitize_callback' => 'sanitize_title',
 					),
@@ -589,7 +603,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'description'  => __( 'Type attribution for the resource.' ),
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
-					'context'      => array( 'view', 'embed' ),
+					'context'      => array( 'view', 'embed', 'edit' ),
 					'readonly'     => true,
 				),
 			),
@@ -599,7 +613,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$schema['properties']['parent'] = array(
 				'description'  => __( 'The id for the parent of the resource.' ),
 				'type'         => 'integer',
-				'context'      => array( 'view' ),
+				'context'      => array( 'view', 'edit' ),
 			);
 		}
 		return $this->add_additional_fields_schema( $schema );

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -30,14 +30,14 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single
 		$category1 = $this->factory->category->create( array( 'name' => 'Season 5' ) );
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/categories/' . $category1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function test_registered_query_params() {
@@ -66,6 +66,14 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_terms_response( $response );
+	}
+
+	public function test_get_items_invalid_permission_for_context() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
 	public function test_get_items_hide_empty_arg() {
@@ -427,6 +435,14 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
+	}
+
+	public function test_get_item_invalid_permission_for_context() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/1' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
 	public function test_get_term_private_taxonomy() {

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -30,14 +30,14 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single
 		$tag1 = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags/' . $tag1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function test_registered_query_params() {
@@ -67,6 +67,14 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$response = $this->server->dispatch( $request );
 		$this->check_get_taxonomy_terms_response( $response );
+	}
+
+	public function test_get_items_invalid_permission_for_context() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
 	public function test_get_items_hide_empty_arg() {
@@ -359,6 +367,15 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_term_invalid', $response, 404 );
+	}
+
+	public function test_get_item_invalid_permission_for_context() {
+		$id = $this->factory->tag->create();
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $id );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
 	public function test_get_term_private_taxonomy() {


### PR DESCRIPTION
While `edit` doesn't include additional fields, it gives us a paradigm
for adding `edit`-specific data in the future, and makes Terms more
    consistent with other controllers.

See #1845
