### PR TITLE
Introduce `media_type` and `mime_type` params for `GET /wp/v2/media`

### DIFF
--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -80,13 +80,16 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'slug',
 			'status',
 			), $keys );
-		$this->assertEqualSets( array(
+		$media_types = array(
 			'application',
 			'video',
 			'image',
 			'audio',
-			'text',
-		), $data['endpoints'][0]['args']['media_type']['enum'] );
+		);
+		if ( ! is_multisite() ) {
+			$media_types[] = 'text';
+		}
+		$this->assertEqualSets( $media_types, $data['endpoints'][0]['args']['media_type']['enum'] );
 	}
 
 	public function test_get_items() {


### PR DESCRIPTION
`media_type` permits querying by the group of mime types (e.g. 'image'
vs. 'video'). `mime_type` permits querying by a particular mime type.

Introduces a new `mime_type` attribute on the Attachment resource.

Fixes #2188
