### PR TITLE
Add `embed` and `edit` contexts to Revisions for parity

### DIFF
--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -262,51 +262,51 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 				'author'          => array(
 					'description' => __( 'The id for the author of the object.' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'date'            => array(
 					'description' => __( 'The date the object was published.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'date_gmt'        => array(
 					'description' => __( 'The date the object was published, as GMT.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'guid'            => array(
 					'description' => __( 'GUID for the object, as it exists in the database.' ),
 					'type'        => 'string',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'id'              => array(
 					'description' => __( 'Unique identifier for the object.' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'modified'        => array(
 					'description' => __( 'The date the object was last modified.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'modified_gmt'    => array(
 					'description' => __( 'The date the object was last modified, as GMT.' ),
 					'type'        => 'string',
 					'format'      => 'date-time',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'parent'          => array(
 					'description' => __( 'The id for the parent of the object.' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 					),
 				'slug'            => array(
 					'description' => __( 'An alphanumeric identifier for the object unique to its type.' ),
 					'type'        => 'string',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);
@@ -324,7 +324,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 					$schema['properties']['title'] = array(
 						'description' => __( 'Title for the object, as it exists in the database.' ),
 						'type'        => 'string',
-						'context'     => array( 'view' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 					);
 					break;
 
@@ -332,7 +332,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 					$schema['properties']['content'] = array(
 						'description' => __( 'Content for the object, as it exists in the database.' ),
 						'type'        => 'string',
-						'context'     => array( 'view' ),
+						'context'     => array( 'view', 'edit' ),
 					);
 					break;
 
@@ -340,7 +340,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 					$schema['properties']['excerpt'] = array(
 						'description' => __( 'Excerpt for the object, as it exists in the database.' ),
 						'type'        => 'string',
-						'context'     => array( 'view' ),
+						'context'     => array( 'view', 'edit', 'embed' ),
 					);
 					break;
 

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -43,13 +43,13 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single
 		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_1->ID );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
-		$this->assertEquals( array( 'view' ), $data['endpoints'][0]['args']['context']['enum'] );
+		$this->assertEqualSets( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}
 
 	public function test_get_items() {
@@ -99,6 +99,40 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->check_get_revision_response( $response, $this->revision_1 );
+		$fields = array(
+			'author',
+			'date',
+			'date_gmt',
+			'modified',
+			'modified_gmt',
+			'guid',
+			'id',
+			'parent',
+			'slug',
+			'title',
+			'excerpt',
+			'content',
+		);
+		$data = $response->get_data();
+		$this->assertEqualSets( $fields, array_keys( $data ) );
+	}
+
+	public function test_get_item_embed_context() {
+		wp_set_current_user( $this->editor_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->post_id . '/revisions/' . $this->revision_id1 );
+		$request->set_param( 'context', 'embed' );
+		$response = $this->server->dispatch( $request );
+		$fields = array(
+			'author',
+			'date',
+			'id',
+			'parent',
+			'slug',
+			'title',
+			'excerpt',
+		);
+		$data = $response->get_data();
+		$this->assertEqualSets( $fields, array_keys( $data ) );
 	}
 
 	public function test_get_item_no_permission() {


### PR DESCRIPTION
`edit` is the same as `view`. `embed` is a subset of `view`, following
what we've established for Posts

Fixes #1845
