### PR TITLE
Fix content disposition parsing

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -461,7 +461,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		foreach ( $disposition_header as $value ) {
 			$value = trim( $value );
 
-			if ( strpos( $value, 'filename' ) === false ) {
+			if ( strpos( $value, ';' ) === false ) {
 				continue;
 			}
 

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -433,20 +433,20 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * As per RFC6266:
 	 *
 	 *     content-disposition = "Content-Disposition" ":"
-     *                            disposition-type *( ";" disposition-parm )
+	 *                            disposition-type *( ";" disposition-parm )
 	 *
-     *     disposition-type    = "inline" | "attachment" | disp-ext-type
-     *                         ; case-insensitive
-     *     disp-ext-type       = token
+	 *     disposition-type    = "inline" | "attachment" | disp-ext-type
+	 *                         ; case-insensitive
+	 *     disp-ext-type       = token
 	 *
-     *     disposition-parm    = filename-parm | disp-ext-parm
+	 *     disposition-parm    = filename-parm | disp-ext-parm
 	 *
-     *     filename-parm       = "filename" "=" value
-     *                         | "filename*" "=" ext-value
+	 *     filename-parm       = "filename" "=" value
+	 *                         | "filename*" "=" ext-value
 	 *
-     *     disp-ext-parm       = token "=" value
-     *                         | ext-token "=" ext-value
-     *     ext-token           = <the characters in token, followed by "*">
+	 *     disp-ext-parm       = token "=" value
+	 *                         | ext-token "=" ext-value
+	 *     ext-token           = <the characters in token, followed by "*">
 	 *
 	 * @see http://tools.ietf.org/html/rfc2388
 	 * @see http://tools.ietf.org/html/rfc6266

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -368,7 +368,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
@@ -422,7 +422,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_header( 'Content-MD5', 'abc123' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$response = $this->server->dispatch( $request );
@@ -466,7 +466,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		wp_set_current_user( $this->editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$request->set_param( 'post', $attachment_id );
 		$response = $this->server->dispatch( $request );
@@ -477,7 +477,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$request->set_param( 'alt_text', 'test alt text' );
@@ -490,7 +490,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_header( 'Content-Type', 'image/jpeg' );
-		$request->set_header( 'Content-Disposition', 'filename=canola.jpg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
 		$request->set_param( 'alt_text', '<script>alert(document.cookie)</script>' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Fixes #1744. This should allow regular form submissions from HTML forms, as well as properly formatted HTTP requests from clients.

Note: this breaks backwards compatibility, as previously, the header parsing was completely wrong.
