### PR TITLE
Clean up attachment controller

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -83,13 +83,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $file;
 		}
 
-		$name       = basename( $file['file'] );
-		$name_parts = pathinfo( $name );
-		$name       = trim( substr( $name, 0, -(1 + strlen( $name_parts['extension'] ) ) ) );
-
-		$url     = $file['url'];
-		$type    = $file['type'];
-		$file    = $file['file'];
+		$url  = $file['url'];
+		$type = $file['type'];
+		$file = $file['file'];
 
 		// use image exif/iptc data for title and caption defaults if possible
 		// @codingStandardsIgnoreStart
@@ -231,7 +227,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( empty( $data['media_details'] ) ) {
 			$data['media_details'] = new stdClass;
 		} elseif ( ! empty( $data['media_details']['sizes'] ) ) {
-			$img_url_basename = wp_basename( $data['source_url'] );
 
 			foreach ( $data['media_details']['sizes'] as $size => &$size_data ) {
 

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -183,7 +183,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * Prepare a single attachment for create or update
 	 *
 	 * @param WP_REST_Request $request Request object
-	 * @return WP_Error|obj $prepared_attachment Post object
+	 * @return WP_Error|stdClass $prepared_attachment Post object
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_attachment = parent::prepare_item_for_database( $request );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -683,7 +683,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * Prepare a single post for create or update.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_Error|object $prepared_post Post object.
+	 * @return WP_Error|stdClass $prepared_post Post object.
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_post = new stdClass;
@@ -822,7 +822,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * The dynamic portion of the hook name, $this->post_type, refers to post_type of the post being
 		 * prepared for insertion.
 		 *
-		 * @param object          $prepared_post An object representing a single post prepared
+		 * @param stdClass        $prepared_post An object representing a single post prepared
 		 *                                       for inserting or updating the database.
 		 * @param WP_REST_Request $request       Request object.
 		 */


### PR DESCRIPTION
A few updates to the Attachments controller:
- Remove unused variables
- Update docblocks to use `stdClass` instead of `object` where appropriate.

Fixes #2081.
