### PR TITLE
Remove unused `$img_url_basename` variable

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -231,7 +231,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( empty( $data['media_details'] ) ) {
 			$data['media_details'] = new stdClass;
 		} elseif ( ! empty( $data['media_details']['sizes'] ) ) {
-			$img_url_basename = wp_basename( $data['source_url'] );
 
 			foreach ( $data['media_details']['sizes'] as $size => &$size_data ) {
 


### PR DESCRIPTION
It was originally used to generate image size URLs, but is no longer.

See #2081
