### PR TITLE
Ensure search is an empty string

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -138,6 +138,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( empty( $request['offset'] ) ) {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
+		if ( empty( $request['search'] ) ) {
+			$prepared_args['search'] = '';
+		}
 
 		/**
 		 * Filter arguments, before passing to WP_Comment_Query, when querying comments via the REST API.

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -371,6 +371,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_approved' => 1,
 			'comment_post_ID'  => $this->post_id,
 			'comment_content'  => 'foo',
+			'comment_author'   => 'Homer J Simpson',
 		);
 		$id1 = $this->factory->comment->create( $args );
 		$args['comment_content'] = 'bar';
@@ -379,7 +380,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->factory->comment->create( $args );
 		// 3 comments, plus 1 created in construct
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		$request->set_param( 'search', '' );
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 4, $response->get_data() );
 		// One matching comments

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -365,6 +365,31 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertCount( 3, $response->get_data() );
 	}
 
+	public function test_get_items_search_query() {
+		wp_set_current_user( $this->admin_id );
+		$args = array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => $this->post_id,
+			'comment_content'  => 'foo',
+		);
+		$id1 = $this->factory->comment->create( $args );
+		$args['comment_content'] = 'bar';
+		$this->factory->comment->create( $args );
+		$args['comment_content'] = 'burrito';
+		$this->factory->comment->create( $args );
+		// 3 comments, plus 1 created in construct
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'search', '' );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 4, $response->get_data() );
+		// One matching comments
+		$request->set_param( 'search', 'foo' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id1, $data[0]['id'] );
+	}
+
 	public function test_get_comments_pagination_headers() {
 		wp_set_current_user( $this->admin_id );
 		// Start of the index


### PR DESCRIPTION
See #2255; if it's an empty value (like null, our default) but not an empty string, this will generate a useless search query.

Fixes #2255 for the API, core should be patched too.
