### PR TITLE
Use our Spy REST Server in tests to call `rest_post_dispatch` filter

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -70,7 +70,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	public function get_items_permissions_check( $request ) {
 
 		if ( ! empty( $request['post'] ) ) {
-			foreach ( $request['post'] as $post_id ) {
+			foreach ( (array) $request['post'] as $post_id ) {
 				$post = get_post( $post_id );
 				if ( ! empty( $post_id ) && $post && ! $this->check_read_post_permission( $post ) ) {
 					return new WP_Error( 'rest_cannot_read_post', __( 'Sorry, you cannot read the post for this comment.' ), array( 'status' => rest_authorization_required_code() ) );

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -138,6 +138,9 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		}
 
 		$post = get_post( $request['id'] );
+		if ( ! $post ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid revision id.' ), array( 'status' => 404 ) );
+		}
 		$post_type = get_post_type_object( 'revision' );
 		return current_user_can( $post_type->cap->delete_post, $post->ID );
 	}

--- a/tests/class-wp-test-rest-controller-testcase.php
+++ b/tests/class-wp-test-rest-controller-testcase.php
@@ -9,7 +9,7 @@ abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new WP_REST_Server;
+		$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
 		do_action( 'rest_api_init' );
 	}
 

--- a/tests/class-wp-test-spy-rest-server.php
+++ b/tests/class-wp-test-spy-rest-server.php
@@ -20,4 +20,16 @@ class WP_Test_Spy_REST_Server extends WP_REST_Server {
 	public function __call( $method, $args ) {
 		return call_user_func_array( array( $this, $method ), $args );
 	}
+
+	/**
+	 * Call dispatch() with the rest_post_dispatch filter
+	 */
+	public function dispatch( $request ) {
+		$result = parent::dispatch( $request );
+		$result = rest_ensure_response( $result );
+		if ( is_wp_error( $result ) ) {
+			$result = $this->error_to_response( $result );
+		}
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $result ), $this, $request );
+	}
 }

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -538,6 +538,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->check_comment_data( $data, 'view' );
 		$this->assertEquals( 'hold', $data['status'] );
 		$this->assertEquals( '2014-11-07T10:14:25', $data['date'] );
+		$this->assertEquals( $this->post_id, $data['post'] );
 	}
 
 	public function test_create_item_invalid_date() {


### PR DESCRIPTION
Also fixes up errors caused in `rest_post_dispatch` call.

Fixes #2260
