### PR TITLE
Revert "Distinguish between url, body, and query params in Attachments"

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -11,19 +11,18 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @return array          $query_args
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
-		$request_args = $request->get_query_params();
 		$query_args = parent::prepare_items_query( $prepared_args, $request );
 		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ) {
 			$query_args['post_status'] = 'inherit';
 		}
 		$media_types = $this->get_media_types();
-		if ( ! empty( $request_args['media_type'] ) && in_array( $request_args['media_type'], array_keys( $media_types ) ) ) {
-			$query_args['post_mime_type'] = $media_types[ $request_args['media_type'] ];
+		if ( ! empty( $request['media_type'] ) && in_array( $request['media_type'], array_keys( $media_types ) ) ) {
+			$query_args['post_mime_type'] = $media_types[ $request['media_type'] ];
 		}
-		if ( ! empty( $request_args['mime_type'] ) ) {
-			$parts = explode( '/', $request_args['mime_type'] );
-			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request_args['mime_type'], $media_types[ $parts[0] ] ) ) {
-				$query_args['post_mime_type'] = $request_args['mime_type'];
+		if ( ! empty( $request['mime_type'] ) ) {
+			$parts = explode( '/', $request['mime_type'] );
+			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request['mime_type'], $media_types[ $parts[0] ] ) ) {
+				$query_args['post_mime_type'] = $request['mime_type'];
 			}
 		}
 		return $query_args;
@@ -47,13 +46,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you are not allowed to upload media on this site.' ), array( 'status' => 400 ) );
 		}
 
-		$request_args = $request->get_body_params();
-
 		// Attaching media to a post requires ability to edit said post
-		if ( ! empty( $request_args['post'] ) ) {
-			$parent = get_post( (int) $request_args['post'] );
+		if ( ! empty( $request['post'] ) ) {
+			$parent = get_post( (int) $request['post'] );
 			$post_parent_type = get_post_type_object( $parent->post_type );
-			if ( ! current_user_can( $post_parent_type->cap->edit_post, $request_args['post'] ) ) {
+			if ( ! current_user_can( $post_parent_type->cap->edit_post, $request['post'] ) ) {
 				return new WP_Error( 'rest_cannot_edit', __( 'Sorry, you are not allowed to upload media to this resource.' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
@@ -69,9 +66,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function create_item( $request ) {
 
-		$request_args = $request->get_body_params();
-
-		if ( ! empty( $request_args['post'] ) && in_array( get_post_type( $request_args['post'] ), array( 'revision', 'attachment' ) ) ) {
+		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ) ) ) {
 			return new WP_Error( 'rest_invalid_param', __( 'Invalid parent type.' ), array( 'status' => 400 ) );
 		}
 
@@ -135,8 +130,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $file ) );
 
-		if ( isset( $request_args['alt_text'] ) ) {
-			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $request_args['alt_text'] ) );
+		if ( isset( $request['alt_text'] ) ) {
+			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $request['alt_text'] ) );
 		}
 
 		$this->update_additional_fields_for_object( $attachment, $request );
@@ -167,8 +162,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$request_args = $request->get_body_params();
-		if ( ! empty( $request_args['post'] ) && in_array( get_post_type( $request_args['post'] ), array( 'revision', 'attachment' ) ) ) {
+		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ) ) ) {
 			return new WP_Error( 'rest_invalid_param', __( 'Invalid parent type.' ), array( 'status' => 400 ) );
 		}
 		$response = parent::update_item( $request );
@@ -179,13 +173,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$response = rest_ensure_response( $response );
 		$data = $response->get_data();
 
-		if ( isset( $request_args['alt_text'] ) ) {
-			update_post_meta( $data['id'], '_wp_attachment_image_alt', $request_args['alt_text'] );
+		if ( isset( $request['alt_text'] ) ) {
+			update_post_meta( $data['id'], '_wp_attachment_image_alt', $request['alt_text'] );
 		}
 
-		$url_args = $request->get_url_params();
-
-		$attachment = get_post( $url_args['id'] );
+		$attachment = get_post( $request['id'] );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $attachment, $request );
 		$response = rest_ensure_response( $response );
@@ -205,18 +197,16 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	protected function prepare_item_for_database( $request ) {
 		$prepared_attachment = parent::prepare_item_for_database( $request );
 
-		$request_args = $request->get_body_params();
-
-		if ( isset( $request_args['caption'] ) ) {
-			$prepared_attachment->post_excerpt = $request_args['caption'];
+		if ( isset( $request['caption'] ) ) {
+			$prepared_attachment->post_excerpt = $request['caption'];
 		}
 
-		if ( isset( $request_args['description'] ) ) {
-			$prepared_attachment->post_content = $request_args['description'];
+		if ( isset( $request['description'] ) ) {
+			$prepared_attachment->post_content = $request['description'];
 		}
 
-		if ( isset( $request_args['post'] ) ) {
-			$prepared_attachment->post_parent = (int) $request_args['post'];
+		if ( isset( $request['post'] ) ) {
+			$prepared_attachment->post_parent = (int) $request['post'];
 		}
 
 		return $prepared_attachment;
@@ -277,8 +267,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$data['media_details']['sizes'] = new stdClass;
 		}
 
-		$query_args = $request->get_query_params();
-		$context = ! empty( $query_args['context'] ) ? $query_args['context'] : 'edit';
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 
 		$data = $this->filter_response_by_context( $data, $context );
 

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -200,13 +200,11 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$data = $response->get_data();
 		$this->assertEquals( $id1, $data[0]['id'] );
 		// media_type=video
-		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'media_type' => 'video' ) );
+		$request->set_param( 'media_type', 'video' );
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 		// media_type=image
-		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'media_type' => 'image' ) );
+		$request->set_param( 'media_type', 'image' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( $id1, $data[0]['id'] );
@@ -221,13 +219,11 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$data = $response->get_data();
 		$this->assertEquals( $id1, $data[0]['id'] );
 		// mime_type=image/png
-		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'mime_type' => 'image/png' ) );
+		$request->set_param( 'mime_type', 'image/png' );
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 		// mime_type=image/jpeg
-		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'mime_type' => 'image/jpeg' ) );
+		$request->set_param( 'mime_type', 'image/jpeg' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( $id1, $data[0]['id'] );
@@ -247,23 +243,23 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 2, count( $response->get_data() ) );
-		// attachments without a parent
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'parent' => 0 ) );
+		// attachments without a parent
+		$request->set_param( 'parent', 0 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( $attachment_id2, $data[0]['id'] );
 		// attachments with parent=post_id
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'parent' => $post_id ) );
+		$request->set_param( 'parent', $post_id );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( $attachment_id, $data[0]['id'] );
 		// attachments with invalid parent
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'parent' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
+		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 0, count( $data ) );
@@ -276,7 +272,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_excerpt'   => 'A sample caption',
 		) );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'status' => 'publish', 'context' => 'edit' ) );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertCount( 1, $data );
@@ -292,7 +289,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_status'    => 'private',
 		) );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_query_params( array( 'status' => 'private' ) );
+		$request->set_param( 'status', 'private' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 		// Properly authorized users can make the request
@@ -480,7 +477,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$post_id = $this->factory->post->create( array( 'post_author' => $this->editor_id ) );
 		wp_set_current_user( $this->author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
-		$request->set_body_params( array( 'post' => $post_id ) );
+		$request->set_param( 'post', $post_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
@@ -492,7 +489,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
-		$request->set_body_params( array( 'post' => $attachment_id ) );
+		$request->set_param( 'post', $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
@@ -504,7 +501,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 
 		$request->set_body( file_get_contents( $this->test_file ) );
-		$request->set_body_params( array( 'alt_text' => 'test alt text' ) );
+		$request->set_param( 'alt_text', 'test alt text' );
 		$response = $this->server->dispatch( $request );
 		$attachment = $response->get_data();
 		$this->assertEquals( 'test alt text', $attachment['alt_text'] );
@@ -516,7 +513,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request->set_header( 'Content-Type', 'image/jpeg' );
 		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
 		$request->set_body( file_get_contents( $this->test_file ) );
-		$request->set_body_params( array( 'alt_text' => '<script>alert(document.cookie)</script>' ) );
+		$request->set_param( 'alt_text', '<script>alert(document.cookie)</script>' );
 		$response = $this->server->dispatch( $request );
 		$attachment = $response->get_data();
 		$this->assertEquals( '', $attachment['alt_text'] );
@@ -530,12 +527,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_author'    => $this->editor_id,
 		) );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
-		$request->set_body_params( array(
-			'title'        => 'My title is very cool',
-			'caption'      => 'This is a better caption.',
-			'description'  => 'Without a description, my attachment is descriptionless.',
-			'alt_text'     => 'Alt text is stored outside post schema.',
-		) );
+		$request->set_param( 'title', 'My title is very cool' );
+		$request->set_param( 'caption', 'This is a better caption.' );
+		$request->set_param( 'description', 'Without a description, my attachment is descriptionless.' );
+		$request->set_param( 'alt_text', 'Alt text is stored outside post schema.' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$attachment = get_post( $data['id'] );
@@ -563,7 +558,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$new_parent = $this->factory->post->create( array() );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
-		$request->set_body_params( array( 'post' => $new_parent ) );
+		$request->set_param( 'post', $new_parent );
 		$this->server->dispatch( $request );
 
 		$attachment = get_post( $attachment_id );
@@ -578,7 +573,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_author'    => $this->editor_id,
 		) );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
-		$request->set_body_params( array( 'caption' => 'This is a better caption.' ) );
+		$request->set_param( 'caption', 'This is a better caption.' );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
@@ -592,7 +587,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'post_author'    => $this->editor_id,
 		) );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
-		$request->set_body_params( array( 'post' => $attachment_id ) );
+		$request->set_param( 'post', $attachment_id );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}


### PR DESCRIPTION
Reverts WP-API/WP-API#2262

See #2114 
