### PR TITLE
Respect-`show_avatars`-comments-#2248

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -886,7 +886,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( true === get_option( 'show_avatars' ) ) {
+		if ( '1' === get_option( 'show_avatars' ) ) {
 			$avatar_properties = array();
 
 			$avatar_sizes = rest_get_avatar_sizes();

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -557,7 +557,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$schema = $this->get_item_schema();
 
-		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+		if ( ! empty( $schema['properties']['author_avatar_urls'] ) ) {
 			$data['author_avatar_urls'] = rest_get_avatar_urls( $comment->comment_author_email );
 		}
 
@@ -886,7 +886,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( get_option( 'show_avatars' ) ) {
+		if ( 1 === get_option( 'show_avatars' ) ) {
 			$avatar_properties = array();
 
 			$avatar_sizes = rest_get_avatar_sizes();

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -886,7 +886,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( 1 === get_option( 'show_avatars' ) ) {
+		if ( true === get_option( 'show_avatars' ) ) {
 			$avatar_properties = array();
 
 			$avatar_sizes = rest_get_avatar_sizes();

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -542,7 +542,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'author_email'       => $comment->comment_author_email,
 			'author_url'         => $comment->comment_author_url,
 			'author_ip'          => $comment->comment_author_IP,
-			'author_avatar_urls' => rest_get_avatar_urls( $comment->comment_author_email ),
 			'author_user_agent'  => $comment->comment_agent,
 			'date'               => mysql_to_rfc3339( $comment->comment_date ),
 			'date_gmt'           => mysql_to_rfc3339( $comment->comment_date_gmt ),
@@ -555,6 +554,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'status'             => $this->prepare_status_response( $comment->comment_approved ),
 			'type'               => get_comment_type( $comment->comment_ID ),
 		);
+
+		$schema = $this->get_item_schema();
+
+		if ( ! empty( $schema['properties']['avatar_urls'] ) ) {
+			$data['author_avatar_urls'] = rest_get_avatar_urls( $comment->comment_author_email );
+		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
@@ -751,18 +756,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$avatar_properties = array();
-
-		$avatar_sizes = rest_get_avatar_sizes();
-		foreach ( $avatar_sizes as $size ) {
-			$avatar_properties[ $size ] = array(
-				'description' => sprintf( __( 'Avatar URL with image size of %d pixels.' ), $size ),
-				'type'        => 'string',
-				'format'      => 'uri',
-				'context'     => array( 'embed', 'view', 'edit' ),
-			);
-		}
-
 		$schema = array(
 			'$schema'              => 'http://json-schema.org/draft-04/schema#',
 			'title'                => 'comment',
@@ -778,13 +771,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'description'  => __( 'The id of the user object, if author was a user.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit', 'embed' ),
-				),
-				'author_avatar_urls' => array(
-					'description'   => __( 'Avatar URLs for the object author.' ),
-					'type'          => 'object',
-					'context'       => array( 'view', 'edit', 'embed' ),
-					'readonly'    => true,
-					'properties'  => $avatar_properties,
 				),
 				'author_email'     => array(
 					'description'  => __( 'Email address for the object author.' ),
@@ -899,6 +885,29 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				),
 			),
 		);
+
+		if ( get_option( 'show_avatars' ) ) {
+			$avatar_properties = array();
+
+			$avatar_sizes = rest_get_avatar_sizes();
+			foreach ( $avatar_sizes as $size ) {
+				$avatar_properties[ $size ] = array(
+					'description' => sprintf( __( 'Avatar URL with image size of %d pixels.' ), $size ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'embed', 'view', 'edit' ),
+				);
+			}
+
+			$schema['properties']['author_avatar_urls'] = array(
+				'description'   => __( 'Avatar URLs for the object author.' ),
+				'type'          => 'object',
+				'context'       => array( 'view', 'edit', 'embed' ),
+				'readonly'      => true,
+				'properties'    => $avatar_properties,
+			);
+		}
+
 		return $this->add_additional_fields_schema( $schema );
 	}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -889,7 +889,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( '1' === get_option( 'show_avatars' ) ) {
+		if ( get_option( 'show_avatars' ) ) {
 			$avatar_properties = array();
 
 			$avatar_sizes = rest_get_avatar_sizes();

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1150,7 +1150,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
-
+		update_option( 'show_avatars', true );
 		$this->assertArrayNotHasKey( 'author_avatar_urls', $properties );
 	}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1150,7 +1150,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
-		update_option( 'show_avatars', true );
+
 		$this->assertArrayNotHasKey( 'author_avatar_urls', $properties );
 	}
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1144,6 +1144,16 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertArrayHasKey( 'type', $properties );
 	}
 
+	public function test_get_item_schema_show_avatar() {
+		update_option( 'show_avatars', false );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayNotHasKey( 'author_avatar_urls', $properties );
+	}
+
 	public function test_get_additional_field_registration() {
 
 		$schema = array(


### PR DESCRIPTION
Possible fix for #2248.  Respects the show_avatars option when
retrieving avatars data for comments. Modeled after #2151.
