### PR TITLE
Add testing for cached get_the_terms() call

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -224,7 +224,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				case 'term_group':
 				case 'description':
 				case 'count':
-					$this->sort_column = $terms_args['orderby'];
+					$this->sort_column = $prepared_args['orderby'];
 					break;
 			}
 			usort( $query_result, array( $this, 'compare_terms' ) );

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -224,6 +224,18 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEquals( 'DC', $data[0]['name'] );
 	}
 
+	public function test_get_items_post_empty() {
+		$post_id = $this->factory->post->create();
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
+		$request->set_param( 'post', $post_id );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 0, $data );
+	}
+
 	public function test_get_items_custom_tax_post_args() {
 		register_taxonomy( 'batman', 'post', array( 'show_in_rest' => true ) );
 		$controller = new WP_REST_Terms_Controller( 'batman' );


### PR DESCRIPTION
Following on from #2257, we need unit tests, since there's a bug. :|

Fixes #2228.
