### PR TITLE
Add date query for comments

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -135,6 +135,17 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'author__not_in'  => $request['author_exclude'],
 		);
 
+		$prepared_args['date_query'] = array();
+		// Set before into date query. Date query must be specified as an array of an array.
+		if ( isset( $request['before'] ) ) {
+			$prepared_args['date_query'][0]['before'] = $request['before'];
+		}
+
+		// Set after into date query. Date query must be specified as an array of an array.
+		if ( isset( $request['after'] ) ) {
+			$prepared_args['date_query'][0]['after'] = $request['after'];
+		}
+
 		if ( empty( $request['offset'] ) ) {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
@@ -924,6 +935,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$query_params['context']['default'] = 'view';
 
+		$query_params['after'] = array(
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 		$query_params['author'] = array(
 			'description'       => __( 'Limit result set to comments assigned to specific user ids. Requires authorization.' ),
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -943,6 +960,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'sanitize_callback' => 'sanitize_email',
 			'validate_callback' => 'rest_validate_request_arg',
 			'type'              => 'string',
+		);
+		$query_params['before'] = array(
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['exclude'] = array(
 			'description'        => __( 'Ensure result set excludes specific ids.' ),


### PR DESCRIPTION
This should add before and after parameters to the top level of query arguments for the comments endpoint.  Similar to #2266 and the same functionality pretty much that goes for #2144 using posts.  Use ISO8601 compliant date time strings!

Example:

**GET wp/v2/comments/?after=2015-01-01T00:00:00Z&before=2017-01-01T00:00:00Z**
For comments between January 1st, 2015 and January 1st, 2017.

Let me know what improvements can be made!
