### PR TITLE
Add rendered and raw to attachment's caption

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -224,7 +224,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$data = $response->get_data();
 
 		$data['alt_text']      = get_post_meta( $post->ID, '_wp_attachment_image_alt', true );
-		$data['caption']       = $post->post_excerpt;
+		$data['caption'] = array(
+			'raw'      => $post->post_excerpt,
+			'rendered' => wptexturize( $post->post_excerpt ),
+		);
 		$data['description']   = $post->post_content;
 		$data['media_type']    = wp_attachment_is_image( $post->ID ) ? 'image' : 'file';
 		$data['mime_type']     = $post->post_mime_type;

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -413,7 +413,6 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertEquals( 'image', $data['media_type'] );
 		$this->assertEquals( 'A field of amazing canola', $data['title']['rendered'] );
-		$this->assertEquals( 'The description for the image', $data['caption'] );
 		$this->assertEquals( 'The description for the image', $data['caption']['raw'] );
 		$this->assertEquals( wptexturize( 'The description for the image' ), $data['caption']['rendered'] );
 	}

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -414,6 +414,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( 'image', $data['media_type'] );
 		$this->assertEquals( 'A field of amazing canola', $data['title']['rendered'] );
 		$this->assertEquals( 'The description for the image', $data['caption'] );
+		$this->assertEquals( 'The description for the image', $data['caption']['raw'] );
+		$this->assertEquals( wptexturize( 'The description for the image' ), $data['caption']['rendered'] );
 	}
 
 	public function test_create_item_default_filename_title() {
@@ -571,7 +573,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$attachment = get_post( $data['id'] );
 		$this->assertEquals( 'My title is very cool', $data['title']['raw'] );
 		$this->assertEquals( 'My title is very cool', $attachment->post_title );
-		$this->assertEquals( 'This is a better caption.', $data['caption'] );
+		$this->assertEquals( 'This is a better caption.', $data['caption']['raw'] );
+		$this->assertEquals( wptexturize( 'This is a better caption.' ), $data['caption']['rendered'] );
 		$this->assertEquals( 'This is a better caption.', $attachment->post_excerpt );
 		$this->assertEquals( 'Without a description, my attachment is descriptionless.', $data['description'] );
 		$this->assertEquals( 'Without a description, my attachment is descriptionless.', $attachment->post_content );
@@ -767,7 +770,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		parent::check_post_data( $attachment, $data, $context );
 
 		$this->assertEquals( get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ), $data['alt_text'] );
-		$this->assertEquals( $attachment->post_excerpt, $data['caption'] );
+		$this->assertEquals( $attachment->post_excerpt, $data['caption']['raw'] );
+		$this->assertEquals( wptexturize( $attachment->post_excerpt ), $data['caption']['rendered'] );
 		$this->assertEquals( $attachment->post_content, $data['description'] );
 		$this->assertTrue( isset( $data['media_details'] ) );
 


### PR DESCRIPTION
HTML is allowed in attachment's caption.
Do they need `raw` and `rendered` like `the_content`?

https://github.com/WordPress/WordPress/blob/master/wp-includes/media.php#L1725
