### PR TITLE
Ensure `GET /wp/v2/categories` with out of bounds offset doesn't return results

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -155,6 +155,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			unset( $count_args['offset'] );
 			$total_terms = wp_count_terms( $this->taxonomy, $count_args );
 
+			// Ensure we don't return results when offset is out of bounds
+			// see https://core.trac.wordpress.org/ticket/35935
+			if ( $prepared_args['offset'] >= $total_terms ) {
+				$query_result = array();
+			}
+
 			// wp_count_terms can return a falsy value when the term has no children
 			if ( ! $total_terms ) {
 				$total_terms = 0;

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -440,6 +440,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers = $response->get_headers();
 		$this->assertEquals( 50, $headers['X-WP-Total'] );
 		$this->assertEquals( 5, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 10, $response->get_data() );
 		$next_link = add_query_arg( array(
 			'page'    => 2,
 			), rest_url( '/wp/v2/categories' ) );
@@ -455,6 +456,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers = $response->get_headers();
 		$this->assertEquals( 51, $headers['X-WP-Total'] );
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 10, $response->get_data() );
 		$prev_link = add_query_arg( array(
 			'page'    => 2,
 			), rest_url( '/wp/v2/categories' ) );
@@ -470,6 +472,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers = $response->get_headers();
 		$this->assertEquals( 51, $headers['X-WP-Total'] );
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 1, $response->get_data() );
 		$prev_link = add_query_arg( array(
 			'page'    => 5,
 			), rest_url( '/wp/v2/categories' ) );
@@ -482,6 +485,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers = $response->get_headers();
 		$this->assertEquals( 51, $headers['X-WP-Total'] );
 		$this->assertEquals( 6, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 0, $response->get_data() );
 		$prev_link = add_query_arg( array(
 			'page'    => 6,
 			), rest_url( '/wp/v2/categories' ) );

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -489,6 +489,31 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertFalse( stripos( $headers['Link'], 'rel="next"' ) );
 	}
 
+	public function test_get_items_per_page_exceeds_number_of_items() {
+		// Start of the index + Uncategorized default term
+		for ( $i = 0; $i < 17; $i++ ) {
+			$this->factory->category->create( array(
+				'name'   => "Category {$i}",
+				) );
+		}
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 100 );
+		$response = $this->server->dispatch( $request );
+		$headers = $response->get_headers();
+		$this->assertEquals( 18, $headers['X-WP-Total'] );
+		$this->assertEquals( 1, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 18, $response->get_data() );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request->set_param( 'page', 2 );
+		$request->set_param( 'per_page', 100 );
+		$response = $this->server->dispatch( $request );
+		$headers = $response->get_headers();
+		$this->assertEquals( 18, $headers['X-WP-Total'] );
+		$this->assertEquals( 1, $headers['X-WP-TotalPages'] );
+		$this->assertCount( 0, $response->get_data() );
+	}
+
 	public function test_get_item() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories/1' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Fixes #2309
