### PR TITLE
Add timezone to date and date_gmt

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -664,7 +664,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	protected function prepare_date_response( $date_gmt, $date = null ) {
 		// Use the date if passed.
 		if ( isset( $date ) ) {
-			return mysql_to_rfc3339( $date );
+			if ( get_option( 'gmt_offset' ) < 0 ) {
+				$timezone = '-' . date( 'H:i', abs( get_option( 'gmt_offset' ) ) * 3600 );
+			} else {
+				$timezone = '+' . date( 'H:i', abs( get_option( 'gmt_offset' ) ) * 3600 );
+			}
+			return mysql_to_rfc3339( $date ) . $timezone;
 		}
 
 		// Return null if $date_gmt is empty/zeros.
@@ -673,7 +678,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Return the formatted datetime.
-		return mysql_to_rfc3339( $date_gmt );
+		return mysql_to_rfc3339( $date_gmt ) . '+00:00';
 	}
 
 	protected function prepare_password_response( $password ) {

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -12,12 +12,12 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
 			$this->assertNull( $data['date_gmt'] );
 		}
-		$this->assertEquals( mysql_to_rfc3339( $post->post_date ), $data['date'] );
+		$this->assertEquals( mysql_to_rfc3339( $post->post_date ) . '+00:00', $data['date'] );
 
 		if ( '0000-00-00 00:00:00' === $post->post_modified_gmt ) {
 			$this->assertNull( $data['modified_gmt'] );
 		}
-		$this->assertEquals( mysql_to_rfc3339( $post->post_modified ), $data['modified'] );
+		$this->assertEquals( mysql_to_rfc3339( $post->post_modified ) . '+00:00', $data['modified'] );
 
 		// author
 		if ( post_type_supports( $post->post_type, 'author' ) ) {
@@ -135,13 +135,13 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 			if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
 				$this->assertNull( $data['date_gmt'] );
 			} else {
-				$this->assertEquals( mysql_to_rfc3339( $post->post_date_gmt ), $data['date_gmt'] );
+				$this->assertEquals( mysql_to_rfc3339( $post->post_date_gmt ) . '+00:00', $data['date_gmt'] );
 			}
 
 			if ( '0000-00-00 00:00:00' === $post->post_modified_gmt ) {
 				$this->assertNull( $data['modified_gmt'] );
 			} else {
-				$this->assertEquals( mysql_to_rfc3339( $post->post_modified_gmt ), $data['modified_gmt'] );
+				$this->assertEquals( mysql_to_rfc3339( $post->post_modified_gmt ) . '+00:00', $data['modified_gmt'] );
 			}
 		}
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -974,7 +974,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$data = $response->get_data();
 		$new_post = get_post( $data['id'] );
 		$time = gmmktime( 2, 0, 0, 1, 1, 2010 );
-		$this->assertEquals( '2010-01-01T02:00:00', $data['date'] );
+		$this->assertEquals( '2010-01-01T02:00:00+00:00', $data['date'] );
 		$this->assertEquals( $time, strtotime( $new_post->post_date ) );
 	}
 
@@ -992,8 +992,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$new_post = get_post( $data['id'] );
 		$time = gmmktime( 12, 0, 0, 1, 1, 2010 );
 
-		$this->assertEquals( '2010-01-01T12:00:00', $data['date'] );
-		$this->assertEquals( '2010-01-01T12:00:00', $data['modified'] );
+		$this->assertEquals( '2010-01-01T12:00:00+00:00', $data['date'] );
+		$this->assertEquals( '2010-01-01T12:00:00+00:00', $data['modified'] );
 
 		$this->assertEquals( $time, strtotime( $new_post->post_date ) );
 		$this->assertEquals( $time, strtotime( $new_post->post_modified ) );


### PR DESCRIPTION
If there isn't timezone, `new date( date_gmt )` always returns `date_gmt` as local time.

Before:

``` javascript
new date( '2016-02-24T11:45:36' ); // always returns same value at anywhere.
```

After:

``` javascript
new date( '2016-02-24T11:45:36+00:00' ); // returns local time.
```
