### PR TITLE
Fix links in plugin docs #2331

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Access your WordPress site's data through an easy-to-use HTTP REST API.
 
 ## WARNING
 
-The **"develop"** branch is undergoing substantial changes and is **NOT COMPLETE OR STABLE**. [Read the in-progress documentation](http://v2.wp-api.org/) to introduce yourself to endpoints, internal patterns, and implementation details. 
+The **"develop"** branch is undergoing substantial changes and is **NOT COMPLETE OR STABLE**. [Read the in-progress documentation](http://v2.wp-api.org/) to introduce yourself to endpoints, internal patterns, and implementation details.
 
 The **"master"** branch represents a **BETA** of our next version release.
 
-The latest **stable** version is available from the [WordPress Plugin Directory](https://wordpress.org/plugins/json-rest-api/).
+The latest **stable** version is available from the [WordPress Plugin Directory](https://wordpress.org/plugins/rest-api/).
 
 ## About
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP REST API
  * Description: JSON-based REST API for WordPress, originally developed as part of GSoC 2013.
  * Author: WP REST API Team
- * Author URI: http://wp-api.org
+ * Author URI: http://v2.wp-api.org
  * Version: 2.0-beta12
  * Plugin URI: https://github.com/WP-API/WP-API
  * License: GPL2+


### PR DESCRIPTION
This is a partial fix for #2331.  This fixes the Author URI to match v2.wp-api.org instead of v1 docs.  This also fixes a link in the Readme.md that points to v1 plugin instead of v2 (eeeek).  As for the second portion of #2331 there is a plugin in the WordPress.org repository with the slug wp-api, which is generating a View Details link if you are installing the develop branch of WP-API into your site.  Not sure how we want to solve that problem but I think that is less imperative than these other fixes.
