### PR TITLE
Removed unnecessary global variables from users controller

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -263,8 +263,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function create_item( $request ) {
-		global $wp_roles;
-
 		if ( ! empty( $request['id'] ) ) {
 			return new WP_Error( 'rest_user_exists', __( 'Cannot create existing resource.' ), array( 'status' => 400 ) );
 		}
@@ -650,8 +648,6 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		global $wp_roles;
-
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'user',


### PR DESCRIPTION
No need for that global variables on `create_item()` or `get_item_schema()` methods.
