### PR TITLE
Adds validation to filter params

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -250,7 +250,6 @@ abstract class WP_REST_Controller {
 				'default'            => 10,
 				'minimum'            => 1,
 				'maximum'            => 100,
-				'sanitize_callback'  => 'absint',
 				'validate_callback'  => 'rest_validate_request_arg',
 			),
 			'search'                 => array(

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1702,6 +1702,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$params['filter'] = array(
 			'description'       => __( 'Use WP Query arguments to modify the response; private query vars require appropriate authorization.' ),
 		);
+		$params['filter[posts_per_page]'] = $params['per_page'];
 		return $params;
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -282,6 +282,13 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 	 * @return WP_Error|boolean
 	 */
 	function rest_validate_request_arg( $value, $request, $param ) {
+		// for validating filter args
+		if ( preg_match( "/filter\[([a-zA-Z0-9_]+)\]/", $param, $m )) {
+			$filters = $request->get_param( 'filter' );
+			if ( ! empty( $filters[ $m[1] ] ) ) {
+				$value = $filters[ $m[1] ];
+			}
+		}
 
 		$attributes = $request->get_attributes();
 		if ( ! isset( $attributes['args'][ $param ] ) || ! is_array( $attributes['args'][ $param ] ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -283,10 +283,12 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 	 */
 	function rest_validate_request_arg( $value, $request, $param ) {
 		// for validating filter args
-		if ( preg_match( "/filter\[([a-zA-Z0-9_]+)\]/", $param, $m )) {
-			$filters = $request->get_param( 'filter' );
-			if ( ! empty( $filters[ $m[1] ] ) ) {
-				$value = $filters[ $m[1] ];
+		if ( isset( $request['filter'] ) ) {
+			if ( preg_match( "/filter\[([a-zA-Z0-9_]+)\]/", $param, $matches ) ) {
+				$filters = $request->get_param( 'filter' );
+				if ( ! empty( $filters[ $matches[1] ] ) ) {
+					$value = $filters[ $matches[1] ];
+				}
 			}
 		}
 

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -112,6 +112,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'context',
 			'exclude',
 			'filter',
+			'filter[posts_per_page]',
 			'include',
 			'media_type',
 			'mime_type',

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -57,6 +57,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'context',
 			'exclude',
 			'filter',
+			'filter[posts_per_page]',
 			'include',
 			'menu_order',
 			'offset',

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -64,6 +64,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'context',
 			'exclude',
 			'filter',
+			'filter[posts_per_page]',
 			'include',
 			'offset',
 			'order',
@@ -1662,6 +1663,50 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		global $wp_rest_additional_fields;
 		$wp_rest_additional_fields = array();
+	}
+
+	public function test_enforce_minimum_and_max_to_posts_per_page() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array(
+			'per_page' => 101,
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array(
+			'per_page' => -1,
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array(
+			'filter' => array(
+				'posts_per_page' => 101
+			)
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array(
+			'filter' => array(
+				'posts_per_page' => -1
+			)
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array(
+			'per_page' => 10,
+			'filter' => array(
+				'posts_per_page' => -1
+			)
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	public function additional_field_get_callback( $object ) {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1671,14 +1671,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'per_page' => 101,
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array(
 			'per_page' => -1,
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array(
@@ -1687,7 +1687,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array(
@@ -1696,7 +1696,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array(
@@ -1706,7 +1706,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	public function additional_field_get_callback( $object ) {


### PR DESCRIPTION
Fixes following.
- `per_page=-1` => Status header should be 400, but 200. It has been ok with `per_page=101`.
- `filter[posts_per_page]=-1` => Validation is not working then API returns all posts.
