### PR TITLE
Use `show_in_rest` to determine "public" post types to check

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -181,7 +181,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$id = (int) $request['id'];
 		$user = get_userdata( $id );
-		$types = get_post_types( array( 'public' => true ), 'names' );
+		$types = get_post_types( array( 'show_in_rest' => true ), 'names' );
 
 		if ( empty( $id ) || empty( $user->ID ) ) {
 			return new WP_Error( 'rest_user_invalid_id', __( 'Invalid resource id.' ), array( 'status' => 404 ) );


### PR DESCRIPTION
Whether or not a user should appear in the REST API should be determined by whether they have any posts that appear in the API, not public posts generally.

From 71800a95cc722a85025aeb1fe671665b369c3de6 and #2155
