### PR TITLE
Explicitly distinguish between create and update in prepare_item_for_database()

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -105,7 +105,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
-		$attachment = $this->prepare_item_for_database( $request );
+		$attachment = $this->prepare_item_for_database( $request, true );
 		$attachment->file = $file;
 		$attachment->post_mime_type = $type;
 		$attachment->guid = $url;
@@ -191,11 +191,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Prepare a single attachment for create or update
 	 *
-	 * @param WP_REST_Request $request Request object
-	 * @return WP_Error|stdClass $prepared_attachment Post object
+	 * @param WP_REST_Request $request  Request object
+	 * @param bool            $creating Whether the item is being created.
+	 *
+	 * @return WP_Error|stdClass|array $prepared_attachment Post object
 	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_attachment = parent::prepare_item_for_database( $request );
+	protected function prepare_item_for_database( $request, $creating ) {
+		$prepared_attachment = parent::prepare_item_for_database( $request, $creating );
 
 		if ( isset( $request['caption'] ) ) {
 			$prepared_attachment->post_excerpt = $request['caption'];

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -318,7 +318,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_comment_exists', __( 'Cannot create existing comment.' ), array( 'status' => 400 ) );
 		}
 
-		$prepared_comment = $this->prepare_item_for_database( $request );
+		$prepared_comment = $this->prepare_item_for_database( $request, true );
 
 		// Setting remaining values before wp_insert_comment so we can
 		// use wp_allow_comment().
@@ -429,7 +429,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_comment_invalid_type', __( 'Sorry, you cannot change the comment type.' ), array( 'status' => 404 ) );
 		}
 
-		$prepared_args = $this->prepare_item_for_database( $request );
+		$prepared_args = $this->prepare_item_for_database( $request, false );
 
 		if ( empty( $prepared_args ) && isset( $request['status'] ) ) {
 			// Only the comment status is being changed.
@@ -705,10 +705,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single comment to be inserted into the database.
 	 *
-	 * @param  WP_REST_Request $request Request object.
+	 * @param  WP_REST_Request $request  Request object.
+	 * @param bool             $creating Whether the item is being created.
+	 *
 	 * @return array|WP_Error  $prepared_comment
 	 */
-	protected function prepare_item_for_database( $request ) {
+	protected function prepare_item_for_database( $request, $creating ) {
 		$prepared_comment = array();
 
 		if ( isset( $request['content'] ) ) {
@@ -761,7 +763,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			}
 		}
 
-		return apply_filters( 'rest_preprocess_comment', $prepared_comment, $request );
+		/**
+		 * Filter the comment data before it is inserted into the database.
+		 *
+		 * @param array           $prepared_comment The prepared comment data.
+		 * @param WP_REST_Request $request          Full details about the request.
+		 * @param bool            $creating         Whether the item is being created.
+		 */
+		return apply_filters( 'rest_preprocess_comment', $prepared_comment, $request, $creating );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -127,10 +127,12 @@ abstract class WP_REST_Controller {
 	/**
 	 * Prepare the item for create or update operation.
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_Error|object $prepared_item
+	 * @param WP_REST_Request $request  Request object.
+	 * @param bool            $creating Whether the item is being created.
+	 *
+	 * @return WP_Error|stdClass $prepared_item
 	 */
-	protected function prepare_item_for_database( $request ) {
+	protected function prepare_item_for_database( $request, $creating ) {
 		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be over-ridden in subclass." ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -288,7 +288,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_post_exists', __( 'Cannot create existing post.' ), array( 'status' => 400 ) );
 		}
 
-		$post = $this->prepare_item_for_database( $request );
+		$post = $this->prepare_item_for_database( $request, true );
 		if ( is_wp_error( $post ) ) {
 			return $post;
 		}
@@ -398,7 +398,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Post id is invalid.' ), array( 'status' => 400 ) );
 		}
 
-		$post = $this->prepare_item_for_database( $request );
+		$post = $this->prepare_item_for_database( $request, false );
 		if ( is_wp_error( $post ) ) {
 			return $post;
 		}
@@ -710,10 +710,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single post for create or update.
 	 *
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request  Request object.
+	 * @param bool            $creating Whether the item is being created.
 	 * @return WP_Error|stdClass $prepared_post Post object.
 	 */
-	protected function prepare_item_for_database( $request ) {
+	protected function prepare_item_for_database( $request, $creating ) {
 		$prepared_post = new stdClass;
 
 		// ID.
@@ -853,8 +854,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param stdClass        $prepared_post An object representing a single post prepared
 		 *                                       for inserting or updating the database.
 		 * @param WP_REST_Request $request       Request object.
+		 * @param bool            $creating      Whether the item is being created.
 		 */
-		return apply_filters( "rest_pre_insert_{$this->post_type}", $prepared_post, $request );
+		return apply_filters( "rest_pre_insert_{$this->post_type}", $prepared_post, $request, $creating );
 
 	}
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -344,7 +344,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$prepared_term = $this->prepare_item_for_database( $request );
+		$prepared_term = $this->prepare_item_for_database( $request, true );
 
 		$term = wp_insert_term( $prepared_term->name, $this->taxonomy, $prepared_term );
 		if ( is_wp_error( $term ) ) {
@@ -424,7 +424,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$prepared_term = $this->prepare_item_for_database( $request );
+		$prepared_term = $this->prepare_item_for_database( $request, false );
 
 		$term = get_term( (int) $request['id'], $this->taxonomy );
 
@@ -507,10 +507,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single term for create or update
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return object $prepared_term Term object.
+	 * @param WP_REST_Request $request  Request object.
+	 * @param bool            $creating Whether the item is being created.
+	 *
+	 * @return stdClass $prepared_term Term object.
 	 */
-	public function prepare_item_for_database( $request ) {
+	public function prepare_item_for_database( $request, $creating ) {
 		$prepared_term = new stdClass;
 
 		if ( isset( $request['name'] ) ) {
@@ -545,8 +547,9 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 *
 		 * @param object          $prepared_term Term object.
 		 * @param WP_REST_Request $request       Request object.
+		 * @param bool            $creating      Whether the item is being created.
 		 */
-		return apply_filters( "rest_pre_insert_{$this->taxonomy}", $prepared_term, $request );
+		return apply_filters( "rest_pre_insert_{$this->taxonomy}", $prepared_term, $request, $creating );
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -285,7 +285,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$user = $this->prepare_item_for_database( $request );
+		$user = $this->prepare_item_for_database( $request, true );
 
 		if ( is_multisite() ) {
 			$ret = wpmu_validate_user_signup( $user->user_login, $user->user_email );
@@ -390,7 +390,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$user = $this->prepare_item_for_database( $request );
+		$user = $this->prepare_item_for_database( $request, false );
 
 		// Ensure we're operating on the same user we already checked
 		$user->ID = $id;
@@ -557,10 +557,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single user for create or update
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return object $prepared_user User object.
+	 * @param WP_REST_Request $request  Request object.
+	 * @param bool            $creating Whether the item is being created.
+	 *
+	 * @return stdClass $prepared_user User object.
 	 */
-	protected function prepare_item_for_database( $request ) {
+	protected function prepare_item_for_database( $request, $creating ) {
 		$prepared_user = new stdClass;
 
 		// required arguments.
@@ -609,10 +611,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		/**
 		 * Filter user data before inserting user via the REST API.
 		 *
-		 * @param object          $prepared_user User object.
+		 * @param stdClass        $prepared_user User object.
 		 * @param WP_REST_Request $request       Request object.
+		 * @param bool            $creating      Whether the item is being created.
 		 */
-		return apply_filters( 'rest_pre_insert_user', $prepared_user, $request );
+		return apply_filters( 'rest_pre_insert_user', $prepared_user, $request, $creating );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2370

This updates the various versions of `prepare_item_for_database()`. There is now a `$creating` parameter that can be passed in to indicate a new item. This new parameter is also passed to the filters associated with this method.
