### PR TITLE
Accept empty string as orderby

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1668,7 +1668,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			'type'               => 'string',
 			'default'            => 'date',
 			'enum'               => array(
-				'',
+				'relevance',
 				'date',
 				'id',
 				'include',

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1668,6 +1668,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			'type'               => 'string',
 			'default'            => 'date',
 			'enum'               => array(
+				'',
 				'date',
 				'id',
 				'include',

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -272,6 +272,20 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( 'Apple Cobbler', $data[0]['title']['rendered'] );
 	}
 
+	public function test_get_items_orderby_relevance() {
+		$this->factory->post->create( array( 'post_title' => 'Apple Pie', 'post_status' => 'publish', 'post_content' => 'Sauce, Cobbler and Coffee Cake.' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Sauce', 'post_status' => 'publish', 'post_content' => 'Pie, Cobbler and Coffee Cake.' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Cobbler', 'post_status' => 'publish', 'post_content' => 'Sauce, Pie and Coffee Cake.' ) );
+		$this->factory->post->create( array( 'post_title' => 'Apple Coffee Cake', 'post_status' => 'publish', 'post_content' => 'Sauce, Cobbler and Pie.' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		// orderby=>relevance
+		$request->set_param( 'search', 'Sauce' );
+		$request->set_param( 'orderby', 'relevance' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( 'Apple Sauce', $data[0]['title']['rendered'] );
+	}
+
 	public function test_get_items_ignore_sticky_posts_by_default() {
 		$this->markTestSkipped( 'Broken, see https://github.com/WP-API/WP-API/issues/2210' );
 		$post_id1 = $this->factory->post->create( array( 'post_status' => 'publish', 'post_date' => '2015-01-01 12:00:00', 'post_date_gmt' => '2015-01-01 12:00:00' ) );

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -1101,7 +1101,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'self',
 			'collection',
 		), array_keys( $links ) );
-		
+
 		$this->assertArrayNotHasKey( 'password', $data );
 	}
 


### PR DESCRIPTION
First, I want to thank you all for a great work with the WP REST API. We use it a lot. But this other day we found a problem in using the API to fetch live search result. So I wanted to propose a very simple solution that we ended up using in our latest project.
## The problem

When using the WP-API to achive live search with AJAX you will not be able to get the result ordered by relevance.
## The solution

As stated in WP core query.php (https://core.trac.wordpress.org/browser/tags/4.4.2/src/wp-includes/query.php#L3028) search results is ordered by relevance only when another "orderby" is not specified in the query. The problem is that there is no way not to specify "orderby" in WP REST API v2.

WordPress seams to handle this by setting the query variable of "orderby" to an empty string. By letting the user to pass an empty string through the WP-APIs function rest_validate_request_arg. This is easiest achived by returning $params['orderby']['em'] = array('', ... ) in the function get_collection_params.
