### PR TITLE
Use Compact links for embedded responses if they are available.

### DIFF
--- a/core-integration.php
+++ b/core-integration.php
@@ -35,3 +35,50 @@ if ( ! function_exists( 'wp_parse_slug_list' ) ) {
 		return array_unique( $list );
 	}
 }
+
+if ( ! function_exists( 'rest_get_server' ) ) {
+	/**
+	 * Retrieves the current REST server instance.
+	 *
+	 * Instantiates a new instance if none exists already.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @global WP_REST_Server $wp_rest_server REST server instance.
+	 *
+	 * @return WP_REST_Server REST server instance.
+	 */
+	function rest_get_server() {
+		/* @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+
+		if ( empty( $wp_rest_server ) ) {
+			/**
+			 * Filter the REST Server Class.
+			 *
+			 * This filter allows you to adjust the server class used by the API, using a
+			 * different class to handle requests.
+			 *
+			 * @since 4.4.0
+			 *
+			 * @param string $class_name The name of the server class. Default 'WP_REST_Server'.
+			 */
+			$wp_rest_server_class = apply_filters( 'wp_rest_server_class', 'WP_REST_Server' );
+			$wp_rest_server = new $wp_rest_server_class;
+
+			/**
+			 * Fires when preparing to serve an API request.
+			 *
+			 * Endpoint objects should be created and register their hooks on this action rather
+			 * than another action to ensure they're only loaded when needed.
+			 *
+			 * @since 4.4.0
+			 *
+			 * @param WP_REST_Server $wp_rest_server Server object.
+			 */
+			do_action( 'rest_api_init', $wp_rest_server );
+		}
+
+		return $wp_rest_server;
+	}
+}

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -157,7 +157,14 @@ abstract class WP_REST_Controller {
 		}
 
 		$data = (array) $response->get_data();
-		$links = WP_REST_Server::get_response_links( $response );
+		$server = rest_get_server();
+
+		if ( method_exists( $server, 'get_compact_response_links' ) ) {
+			$links = call_user_func( array( $server, 'get_compact_response_links' ), $response );
+		} else {
+			$links = call_user_func( array( $server, 'get_response_links' ), $response );
+		}
+
 		if ( ! empty( $links ) ) {
 			$data['_links'] = $links;
 		}

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -1101,7 +1101,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'self',
 			'collection',
 		), array_keys( $links ) );
-		
+
 		$this->assertArrayNotHasKey( 'password', $data );
 	}
 


### PR DESCRIPTION
This fixes curies compatibility with 4.5, and doesn't fatal under 4.4
