### PR TITLE
Avoid unnecessary SQL query by passing `$user_nicename`

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -501,7 +501,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'email'              => $user->user_email,
 			'url'                => $user->user_url,
 			'description'        => $user->description,
-			'link'               => get_author_posts_url( $user->ID ),
+			'link'               => get_author_posts_url( $user->ID, $user->user_nicename ),
 			'nickname'           => $user->nickname,
 			'slug'               => $user->user_nicename,
 			'registered_date'    => date( 'c', strtotime( $user->user_registered ) ),


### PR DESCRIPTION
If no `$user_nicename` is supplied, `get_author_posts_url()` calls `get_userdata()` to get the `$user_nicename`. Because we already have it, we don't need to incur an unnecessary database hit.
