### PR TITLE
Avoid unnecessary SQL SELECT against user meta

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -93,7 +93,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$prepared_args = array();
+		$prepared_args = array(
+			'fields'              => 'all_with_meta',
+		);
 		$prepared_args['exclude'] = $request['exclude'];
 		$prepared_args['include'] = $request['include'];
 		$prepared_args['order'] = $request['order'];


### PR DESCRIPTION
Because we're fetching all fields, `WP_User_Query` primes our user objects with their role / capabilities. This data is stored in user meta. But, core [isn't yet smart enough](https://core.trac.wordpress.org/ticket/36508) to precache user meta when `fields=>all`. We can be smarter than core by using `fields=>all_with_meta`
