### PR TITLE
Mark Users' `capabilities` property as readonly

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -770,6 +770,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'description' => __( 'All capabilities assigned to the resource.' ),
 					'type'        => 'object',
 					'context'     => array( 'edit' ),
+					'readonly'    => true,
 				),
 				'extra_capabilities' => array(
 					'description' => __( 'Any extra capabilities assigned to the resource.' ),


### PR DESCRIPTION
It's not actually editable through the API
