### PR TITLE
Revert "Avoid unnecessary SQL SELECT against user meta"

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -93,9 +93,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$prepared_args = array(
-			'fields'              => 'all_with_meta',
-		);
+		$prepared_args = array();
 		$prepared_args['exclude'] = $request['exclude'];
 		$prepared_args['include'] = $request['include'];
 		$prepared_args['order'] = $request['order'];


### PR DESCRIPTION
Reverts WP-API/WP-API#2436

@boonebgorges made a wise comment about the negative performance impact of loading user meta when a given site has abused the amount of data they put in user meta. For now, I think it's better for developers to opt-in to this change as needed.
