### PR TITLE
return error, if user can't list users & content=edit

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -82,6 +82,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_user_cannot_view', __( 'Sorry, you cannot filter by role.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
+		if ( 'edit' === $request['context'] && ! current_user_can( 'list_users' ) ) {
+			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot view this resource with edit context.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Solves https://github.com/WP-API/WP-API/issues/2382 

Instead of the capability `edit_user` I took 'list_users' like it is also done in the `get_item_permissions_check()`. Did make sense to me.
