### PR TITLE
Remove Unused Parameter in lib/endpoints/class-wp-rest-controller.php

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -289,7 +289,7 @@ abstract class WP_REST_Controller {
 			return array_merge( $param_details, $args );
 		}
 		$contexts = array();
-		foreach ( $schema['properties'] as $key => $attributes ) {
+		foreach ( $schema['properties'] as $attributes ) {
 			if ( ! empty( $attributes['context'] ) ) {
 				$contexts = array_merge( $contexts, $attributes['context'] );
 			}


### PR DESCRIPTION
I run [phpmd](https://phpmd.org/), and find following notification.

```
/var/www/wordpress/wp-content/plugins/rest-api/lib/endpoints/class-wp-rest-controller.php:292Avoid unused local variables such as ''.
```

So, I removed  parameter
