### PR TITLE
Update post status description for multiple posts.

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1742,7 +1742,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		);
 		$params['status'] = array(
 			'default'           => 'publish',
-			'description'       => __( 'Limit result set to posts assigned a specific status.' ),
+			'description'       => __( 'Limit result set to posts assigned a specific status; can be comma-delimited list of status types.' ),
 			'sanitize_callback' => 'sanitize_key',
 			'type'              => 'string',
 			'validate_callback' => array( $this, 'validate_user_can_query_private_statuses' ),


### PR DESCRIPTION
Multiple post status types can be used in a comma-delimited list
within the string given for a post status query. This updates
the description to reflect that ability.
