### PR TITLE
Introduce WP_REST_Controller::get_post() for allowing plugins to mutate get_post()'s return value

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -48,7 +48,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		// Attaching media to a post requires ability to edit said post
 		if ( ! empty( $request['post'] ) ) {
-			$parent = get_post( (int) $request['post'] );
+			$parent = $this->get_post( (int) $request['post'] );
 			$post_parent_type = get_post_type_object( $parent->post_type );
 			if ( ! current_user_can( $post_parent_type->cap->edit_post, $request['post'] ) ) {
 				return new WP_Error( 'rest_cannot_edit', __( 'Sorry, you are not allowed to upload media to this resource.' ), array( 'status' => rest_authorization_required_code() ) );
@@ -123,7 +123,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			}
 			return $id;
 		}
-		$attachment = get_post( $id );
+		$attachment = $this->get_post( $id );
 
 		/** Include admin functions to get access to wp_generate_attachment_metadata() */
 		require_once ABSPATH . 'wp-admin/includes/admin.php';
@@ -177,7 +177,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			update_post_meta( $data['id'], '_wp_attachment_image_alt', $request['alt_text'] );
 		}
 
-		$attachment = get_post( $request['id'] );
+		$attachment = $this->get_post( $request['id'] );
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $attachment, $request );
 		$response = rest_ensure_response( $response );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -71,7 +71,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {
-				$post = get_post( $post_id );
+				$post = $this->get_post( $post_id );
 				if ( ! empty( $post_id ) && $post && ! $this->check_read_post_permission( $post ) ) {
 					return new WP_Error( 'rest_cannot_read_post', __( 'Sorry, you cannot read the post for this comment.' ), array( 'status' => rest_authorization_required_code() ) );
 				} else if ( 0 === $post_id && ! current_user_can( 'moderate_comments' ) ) {
@@ -230,7 +230,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_cannot_read', __( 'Sorry, you cannot read this comment.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
-		$post = get_post( $comment->comment_post_ID );
+		$post = $this->get_post( $comment->comment_post_ID );
 
 		if ( $post && ! $this->check_read_post_permission( $post ) ) {
 			return new WP_Error( 'rest_cannot_read_post', __( 'Sorry, you cannot read the post for this comment.' ), array( 'status' => rest_authorization_required_code() ) );
@@ -258,7 +258,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! empty( $comment->comment_post_ID ) ) {
-			$post = get_post( $comment->comment_post_ID );
+			$post = $this->get_post( $comment->comment_post_ID );
 			if ( empty( $post ) ) {
 				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
 			}
@@ -293,7 +293,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_comment_invalid_status', __( 'Sorry, you cannot set status for comments.' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
-		if ( ! empty( $request['post'] ) && $post = get_post( (int) $request['post'] ) ) {
+		if ( ! empty( $request['post'] ) && $post = $this->get_post( (int) $request['post'] ) ) {
 
 			if ( ! $this->check_read_post_permission( $post ) ) {
 				return new WP_Error( 'rest_cannot_read_post', __( 'Sorry, you cannot read the post for this comment.' ), array( 'status' => rest_authorization_required_code() ) );
@@ -620,7 +620,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		if ( 0 !== (int) $comment->comment_post_ID ) {
-			$post = get_post( $comment->comment_post_ID );
+			$post = $this->get_post( $comment->comment_post_ID );
 			if ( ! empty( $post->ID ) ) {
 				$obj = get_post_type_object( $post->post_type );
 				$base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
@@ -1137,7 +1137,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		$post = get_post( $comment->comment_post_ID );
+		$post = $this->get_post( $comment->comment_post_ID );
 		if ( $comment->comment_post_ID && $post ) {
 			if ( ! $this->check_read_post_permission( $post ) ) {
 				return false;

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -495,13 +495,18 @@ abstract class WP_REST_Controller {
 	 * @return WP_Post|null A `WP_Post` object when successful.
 	 */
 	public function get_post( $post ) {
-		global $wp_query;
+		$post_obj = get_post( $post );
 
-		$post = get_post( $post );
-		if ( $post && $wp_query ) {
-			/** This action is documented in wp-includes/query.php */
-			do_action_ref_array( 'the_post', array( &$post, &$wp_query ) );
-		}
+		/**
+		 * Filter the post.
+		 *
+		 * Allows plugins to filter the post object as returned by `\WP_REST_Controller::get_post()`.
+		 *
+		 * @param WP_Post|null $post_obj  The post object as returned by `get_post()`.
+		 * @param int|WP_Post  $post      The original value used to obtain the post object.
+		 */
+		$post = apply_filters( 'rest_the_post', $post_obj, $post );
+
 		return $post;
 	}
 }

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -480,4 +480,28 @@ abstract class WP_REST_Controller {
 		return $endpoint_args;
 	}
 
+	/**
+	 * Retrieves post data given a post ID or post object.
+	 *
+	 * This is a subset of the functionality of the `get_post()` function, with
+	 * the additional functionality of having `the_post` action done on the
+	 * resultant post object. This is done so that plugins may manipulate the
+	 * post that is used in the REST API.
+	 *
+	 * @see get_post()
+	 * @global WP_Query $wp_query
+	 *
+	 * @param int|WP_Post $post Post ID or post object. Defaults to global $post.
+	 * @return WP_Post|null A `WP_Post` object when successful.
+	 */
+	public function get_post( $post ) {
+		global $wp_query;
+
+		$post = get_post( $post );
+		if ( $post && $wp_query ) {
+			/** This action is documented in wp-includes/query.php */
+			do_action_ref_array( 'the_post', array( &$post, &$wp_query ) );
+		}
+		return $post;
+	}
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -212,7 +212,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 
-		$post = get_post( (int) $request['id'] );
+		$post = $this->get_post( (int) $request['id'] );
 
 		if ( 'edit' === $request['context'] && $post && ! $this->check_update_permission( $post ) ) {
 			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit this post' ), array( 'status' => rest_authorization_required_code() ) );
@@ -233,7 +233,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 		$id = (int) $request['id'];
-		$post = get_post( $id );
+		$post = $this->get_post( $id );
 
 		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
@@ -333,7 +333,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return $terms_update;
 		}
 
-		$post = get_post( $post_id );
+		$post = $this->get_post( $post_id );
 		$this->update_additional_fields_for_object( $post, $request );
 
 		/**
@@ -362,7 +362,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 
-		$post = get_post( $request['id'] );
+		$post = $this->get_post( $request['id'] );
 		$post_type = get_post_type_object( $this->post_type );
 
 		if ( $post && ! $this->check_update_permission( $post ) ) {
@@ -392,7 +392,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function update_item( $request ) {
 		$id = (int) $request['id'];
-		$post = get_post( $id );
+		$post = $this->get_post( $id );
 
 		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Post id is invalid.' ), array( 'status' => 400 ) );
@@ -440,7 +440,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return $terms_update;
 		}
 
-		$post = get_post( $post_id );
+		$post = $this->get_post( $post_id );
 		$this->update_additional_fields_for_object( $post, $request );
 
 		/* This action is documented in lib/endpoints/class-wp-rest-controller.php */
@@ -459,7 +459,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function delete_item_permissions_check( $request ) {
 
-		$post = get_post( $request['id'] );
+		$post = $this->get_post( $request['id'] );
 
 		if ( $post && ! $this->check_delete_permission( $post ) ) {
 			return new WP_Error( 'rest_cannot_delete', __( 'Sorry, you are not allowed to delete posts.' ), array( 'status' => rest_authorization_required_code() ) );
@@ -478,7 +478,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$id = (int) $request['id'];
 		$force = (bool) $request['force'];
 
-		$post = get_post( $id );
+		$post = $this->get_post( $id );
 
 		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
@@ -822,7 +822,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Parent.
 		if ( ! empty( $schema['properties']['parent'] ) && ! empty( $request['parent'] ) ) {
-			$parent = get_post( (int) $request['parent'] );
+			$parent = $this->get_post( (int) $request['parent'] );
 			if ( empty( $parent ) ) {
 				return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post parent id.' ), array( 'status' => 400 ) );
 			}
@@ -921,7 +921,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @param integer $post_id
 	 */
 	public function handle_template( $template, $post_id ) {
-		if ( in_array( $template, array_keys( wp_get_theme()->get_page_templates( get_post( $post_id ) ) ) ) ) {
+		if ( in_array( $template, array_keys( wp_get_theme()->get_page_templates( $this->get_post( $post_id ) ) ) ) ) {
 			update_post_meta( $post_id, '_wp_page_template', $template );
 		} else {
 			update_post_meta( $post_id, '_wp_page_template', '' );
@@ -999,7 +999,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Can we read the parent if we're inheriting?
 		if ( 'inherit' === $post->post_status && $post->post_parent > 0 ) {
-			$parent = get_post( $post->post_parent );
+			$parent = $this->get_post( $post->post_parent );
 			return $this->check_read_permission( $parent );
 		}
 

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -57,7 +57,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 
-		$parent = get_post( $request['parent'] );
+		$parent = $this->get_post( $request['parent'] );
 		if ( ! $parent ) {
 			return true;
 		}
@@ -77,7 +77,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$parent = get_post( $request['parent'] );
+		$parent = $this->get_post( $request['parent'] );
 		if ( ! $request['parent'] || ! $parent || $this->parent_post_type !== $parent->post_type ) {
 			return new WP_Error( 'rest_post_invalid_parent', __( 'Invalid post parent id.' ), array( 'status' => 404 ) );
 		}
@@ -110,12 +110,12 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 
-		$parent = get_post( $request['parent'] );
+		$parent = $this->get_post( $request['parent'] );
 		if ( ! $request['parent'] || ! $parent || $this->parent_post_type !== $parent->post_type ) {
 			return new WP_Error( 'rest_post_invalid_parent', __( 'Invalid post parent id.' ), array( 'status' => 404 ) );
 		}
 
-		$revision = get_post( $request['id'] );
+		$revision = $this->get_post( $request['id'] );
 		if ( ! $revision || 'revision' !== $revision->post_type ) {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid revision id.' ), array( 'status' => 404 ) );
 		}
@@ -137,7 +137,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			return $response;
 		}
 
-		$post = get_post( $request['id'] );
+		$post = $this->get_post( $request['id'] );
 		if ( ! $post ) {
 			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid revision id.' ), array( 'status' => 404 ) );
 		}

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -134,4 +134,25 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$this->assertEquals( 'a', $args['somedefault']['default'] );
 	}
+
+	public function test_get_post() {
+		$post_id = $this->factory()->post->create( array( 'post_title' => 'Original' ) );
+		$controller = new WP_REST_Test_Controller();
+
+		$action_count = did_action( 'the_post' );
+		$post = $controller->get_post( $post_id );
+		$this->assertEquals( 1 + $action_count, did_action( 'the_post' ) );
+		$this->assertEquals( 'Original', $post->post_title );
+
+		add_action( 'the_post', array( $this, 'action_the_post_for_test_get_post' ), 10, 2 );
+		$post = $controller->get_post( $post_id );
+		$this->assertEquals( 'Overridden', $post->post_title );
+		$this->assertEquals( 2 + $action_count, did_action( 'the_post' ) );
+	}
+
+	public function action_the_post_for_test_get_post( $post, $query ) {
+		$this->assertInstanceOf( 'WP_Post', $post );
+		$this->assertInstanceOf( 'WP_Query', $query );
+		$post->post_title = 'Overridden';
+	}
 }


### PR DESCRIPTION
There is no `get_post` filter as there is when calling `get_comment()` or `get_term()` or `get_{$type}_meta()` and so on. This can make it very difficult particularly in the Customizer to preview changes to posts. Currently the Customizer relies on queries to be made using `suppress_filters => false` and/or for posts to be iterated in The Loop where `setup_postdata` is called and thus `the_post` is done, both of which provide opportunities for a plugin (here Customize Posts) to mutate the post before it is returned. 

In the REST API, we hit a wall recently in Customize Posts with accessing a post that is saved in the DB as a draft with a Customizer state that makes the status `publish`. We are working to allow such posts to be viewed via the REST API publicly for unauthenticated users if a snapshot (aka transaction) UUID is supplied to recall that Customizer state in which the post has the status of `publish`. The problem is that `\WP_REST_Posts_Controller::get_item_permissions_check()` uses `get_post()` to obtain the post object and then passes this into `\WP_REST_Posts_Controller::check_read_permission()` without any opportunity for a plugin to override the `post_status` of this object to have the desired behavior of forcing it to be publicly accessible given the Customizer state.

In lieu of there being a `get_post` filter as proposed in [#12955](https://core.trac.wordpress.org/ticket/12955#comment:33), I'm suggesting that the REST API introduce `\WP_REST_Controller::get_post()` wrapper for `get_post()` which includes a `the_post` action for plugins to extend the object to be returned.

See https://github.com/xwp/wp-customize-snapshots/issues/32
