### PR TITLE
Define type as a string, not an array

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -818,13 +818,13 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 				),
 				'capabilities'    => array(
 					'description' => __( 'All capabilities assigned to the resource.' ),
-					'type'        => array( 'object' ),
+					'type'        => 'object',
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
 				'extra_capabilities' => array(
 					'description' => __( 'Any extra capabilities assigned to the resource.' ),
-					'type'        => array( 'object' ),
+					'type'        => 'object',
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
From #2429
