### PR TITLE
#2516 change permissions check to match core

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -40,9 +40,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $ret;
 		}
 
-		// "upload_files" cap is returned for an attachment by $post_type_obj->cap->create_posts
 		$post_type_obj = get_post_type_object( $this->post_type );
-		if ( ! current_user_can( $post_type_obj->cap->create_posts ) || ! current_user_can( $post_type_obj->cap->edit_posts ) ) {
+		if ( ! current_user_can( 'upload_files' ) ) {
 			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you are not allowed to upload media on this site.' ), array( 'status' => 400 ) );
 		}
 

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -21,12 +21,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'role' => 'contributor',
 		) );
 		//matches core capabilities for subscriber role and adds upload_files
-		_x('File upload role', 'User role');
-		add_role('uploader', 'File upload role');
-		$role = get_role('uploader');
-		$role->add_cap('upload_files');
-		$role->add_cap('read');
-		$role->add_cap('level_0');
+		_x( 'File upload role', 'User role' );
+		add_role( 'uploader', 'File upload role' );
+		$role = get_role( 'uploader' );
+		$role->add_cap( 'upload_files' );
+		$role->add_cap( 'read' );
+		$role->add_cap( 'level_0' );
 		//print_r(array('role'=>$role));
 		$this->uploader_id = $this->factory->user->create( array(
 			'role' => 'uploader',


### PR DESCRIPTION
update permissions check to match core. Removes checks for create/edit_post permissions in favor of upload_files. Should resolve #2516 
