### PR TITLE
Use VIP cached function to get_term_link

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -571,7 +571,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$data['description'] = $item->description;
 		}
 		if ( ! empty( $schema['properties']['link'] ) ) {
-			$data['link'] = get_term_link( $item );
+			if ( function_exists( 'wpcom_vip_get_term_link' ) ) {
+				$data['link'] = wpcom_vip_get_term_link( $item );
+			} else {
+				$data['link'] = get_term_link( $item );	
+			}
+			
 		}
 		if ( ! empty( $schema['properties']['name'] ) ) {
 			$data['name'] = $item->name;


### PR DESCRIPTION
During a VIP GO code review, we were asked to update our codebase to ensure we're using cached functions. We've updated our codebase and are working on submitting PR's to codebases we don't directly control. 
