### PR TITLE
Fix broken `is_bool()` check on boolean request args

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -97,7 +97,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			'order'      => $request['order'],
 			'orderby'    => $request['orderby'],
 			'post'       => $request['post'],
-			'hide_empty' => $request['hide_empty'],
+			'hide_empty' => (bool) $request['hide_empty'],
 			'number'     => $request['per_page'],
 			'search'     => $request['search'],
 			'slug'       => $request['slug'],

--- a/plugin.php
+++ b/plugin.php
@@ -299,8 +299,8 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'integer' ) );
 		}
 
-		if ( 'boolean' === $args['type'] && ! is_bool( $value ) ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'boolean' ) );
+		if ( 'boolean' === $args['type'] && true != $value && false != $value ) {
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $value, 'boolean' ) );
 		}
 
 		if ( 'string' === $args['type'] && ! is_string( $value ) ) {

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -114,7 +114,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$data = $response->get_data();
 
 		$args = array(
-			'hide_empty' => 'false',
+			'hide_empty' => false,
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );
@@ -144,7 +144,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$data = $response->get_data();
 
 		$args = array(
-			'hide_empty' => 'false',
+			'hide_empty' => false,
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -82,7 +82,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$category2 = $this->factory->category->create( array( 'name' => 'The Be Sharps' ) );
 		wp_set_object_terms( $post_id, array( $category1, $category2 ), 'category' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
-		$request->set_param( 'hide_empty', true );
+		// Test with string of boolean equivalent from url query parameter.
+		$request->set_param( 'hide_empty', 'true' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 2, count( $data ) );
@@ -113,7 +114,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$data = $response->get_data();
 
 		$args = array(
-			'hide_empty' => false,
+			'hide_empty' => 'false',
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );
@@ -143,7 +144,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$data = $response->get_data();
 
 		$args = array(
-			'hide_empty' => false,
+			'hide_empty' => 'false',
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -52,9 +52,10 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			rest_validate_request_arg( false, $this->request, 'someboolean' )
 		);
 
-		$this->assertTrue(,
+		$this->assertTrue(
 			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
 		);
+
 		$this->assertErrorResponse(
 			'rest_invalid_param',
 			rest_validate_request_arg( '123', $this->request, 'someboolean' )

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -52,8 +52,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			rest_validate_request_arg( false, $this->request, 'someboolean' )
 		);
 
-		$this->assertErrorResponse(
-			'rest_invalid_param',
+		$this->assertTrue(,
 			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
 		);
 		$this->assertErrorResponse(


### PR DESCRIPTION
In `rest_validate_request_arg()` we cannot use the `! is_bool()` conditional to validate if a request argument is either `true` or `false`.  The query string in the url (example: https://demo.wp-api.org/wp-json/wp/v2/categories?hide_empty=true) will be parsed as a string.  Which means you will always get the error: 
`{
code: "rest_invalid_param",
message: "Invalid parameter(s): hide_empty",
data: {
status: 400,
params: {
hide_empty: "hide_empty is not of type boolean"
}
}
}`

This PR changes the conditional in `rest_validate_request_args()` to use a conditional that is much less strict and accepts query string parameters correctly.  
