### PR TITLE
Fix broken `is_bool()` check on boolean request args

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -299,8 +299,8 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'integer' ) );
 		}
 
-		if ( 'boolean' === $args['type'] && ! is_bool( $value ) ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'boolean' ) );
+		if ( 'boolean' === $args['type'] && ! rest_is_boolean( $value ) ) {
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $value, 'boolean' ) );
 		}
 
 		if ( 'string' === $args['type'] && ! is_string( $value ) ) {
@@ -428,5 +428,36 @@ if ( ! function_exists( 'rest_is_ip_address' ) ) {
 		}
 
 		return $ipv4;
+	}
+}
+
+/**
+ * Determines if a given value is boolean-like.
+ *
+ * @param bool|string $maybe_bool The value being evaluated.
+ * @return boolean True if a boolean, otherwise false.
+ */
+if ( ! function_exists( 'rest_is_boolean' ) ) {
+	function rest_is_boolean( $maybe_bool ) {
+		if ( is_bool( $maybe_bool ) ) {
+			return true;
+		}
+
+		if ( is_string( $maybe_bool ) ) {
+			$maybe_bool = strtolower( $maybe_bool );
+
+			$valid_boolean_values = array(
+				'false',
+				'true',
+				'0',
+				'1',
+			);
+
+			if ( in_array( $maybe_bool, $valid_boolean_values, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -52,9 +52,22 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			rest_validate_request_arg( false, $this->request, 'someboolean' )
 		);
 
+		$this->assertTrue(
+			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'TRUE', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'false', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'False', $this->request, 'someboolean' )
+		);
+
 		$this->assertErrorResponse(
 			'rest_invalid_param',
-			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
+			rest_validate_request_arg( 1, $this->request, 'someboolean' )
 		);
 		$this->assertErrorResponse(
 			'rest_invalid_param',


### PR DESCRIPTION
Fixes #2616 

In `rest_validate_request_arg()` we cannot use the `! is_bool()`conditional to validate if a request argument is either true or false. The query string in the url (example: https://demo.wp-api.org/wp-json/wp/v2/categories?hide_empty=true) will be parsed as a string. Which means you will always get the error: 

```
{ code: "rest_invalid_param", message: "Invalid parameter(s): hide_empty", data: { status: 400, params: { hide_empty: "hide_empty is not of type boolean" } } }
```

This PR introduces the new function `rest_is_boolean` that will allow us to validate boolean strings in API request parameters.  It also changes the conditional in rest_validate_request_args() to use `rest_is_boolean` for a much less strict (and accurate) validation of boolean-type parameters. 
