### PR TITLE
Improve WP_REST_Controller::filter_response_by_context().

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -189,6 +189,7 @@ abstract class WP_REST_Controller {
 
 			if ( ! in_array( $context, $schema['properties'][ $key ]['context'] ) ) {
 				unset( $data[ $key ] );
+				continue;
 			}
 
 			if ( 'object' === $schema['properties'][ $key ]['type'] && ! empty( $schema['properties'][ $key ]['properties'] ) ) {


### PR DESCRIPTION
This pull request improves the `WP_REST_Controller::filter_response_by_context()` method by adding a `continue;` after which the only thing that _could_ be done is to delete stuff that we just deleted. ;) No need for all the unnecessary stuff.
