### PR TITLE
Document options of the "status" parameter for Post collection GETs

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1743,6 +1743,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$params['status'] = array(
 			'default'           => 'publish',
 			'description'       => __( 'Limit result set to posts assigned a specific status; can be comma-delimited list of status types.' ),
+			'enum'              => array_merge( array_keys( get_post_stati() ), array( 'any' ) ),
 			'sanitize_callback' => 'sanitize_key',
 			'type'              => 'string',
 			'validate_callback' => array( $this, 'validate_user_can_query_private_statuses' ),


### PR DESCRIPTION
In #2642 we refer API users to the documentation for the `status` parameter, but that parameter does not actually document "any" or the other valid WP_Query Status options that can be passed to the API. Since retrieving a full list of posts regardless of status is a critical action within the context of an admin interface, we should explicitly list out the options accepted for `status`.

I believe this will do the trick but I am on the road and haven't been able to attempt regenerating the docs to validate that this goes through alright.
