### PR TITLE
fixing invalid regex testing for model vs collection route

### DIFF
--- a/wp-api.js
+++ b/wp-api.js
@@ -1080,7 +1080,7 @@
 				) {
 
 					// Single items end with a regex (or the special case 'me').
-					if ( /.*[+)|me]$/.test( index ) ) {
+					if ( /.*([+)]|me)$/.test( index ) ) {
 						modelRoutes.push( { index: index, route: route } );
 					} else {
 


### PR DESCRIPTION
The current regex actually tests for "any route ending with ), +, |, m, or e" which will incorrectly match any collection route as a model route if it ends with a literal "m" or "e".  This fixes that regex.

Side note:  I'm unclear from the repo how you prefer we rebuild the .min and .map but I'm happy to also do that if needed.
