### PR TITLE
#1612 comment children links

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -640,6 +640,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			);
 		}
 
+		// Only grab one comment to verify the comment has children.
+		$comment_children = $comment->get_children( array( 'number' => 1 ) );
+		if ( ! empty( $comment_children ) ) {
+			$args = array( 'parent' => $comment->comment_ID );
+			$rest_url = add_query_arg( $args, rest_url( $this->namespace . $this->rest_base ) );
+
+			$links['children'] = array(
+				'href'       => $rest_url,
+				'embeddable' => true,
+			);
+		}
+
 		return $links;
 	}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -653,7 +653,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$rest_url = add_query_arg( $args, rest_url( $this->namespace . '/' . $this->rest_base ) );
 
 			$links['children'] = array(
-				'href'       => $rest_url,
+				'href' => $rest_url,
 			);
 		}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -644,7 +644,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$comment_children = $comment->get_children( array( 'number' => 1 ) );
 		if ( ! empty( $comment_children ) ) {
 			$args = array( 'parent' => $comment->comment_ID );
-			$rest_url = add_query_arg( $args, rest_url( $this->namespace . $this->rest_base ) );
+			$rest_url = add_query_arg( $args, rest_url( $this->namespace . '/' . $this->rest_base ) );
 
 			$links['children'] = array(
 				'href'       => $rest_url,

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -654,7 +654,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 			$links['children'] = array(
 				'href'       => $rest_url,
-				'embeddable' => true,
 			);
 		}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -647,7 +647,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Only grab one comment to verify the comment has children.
-		$comment_children = $comment->get_children( array( 'number' => 1 ) );
+		$comment_children = $comment->get_children( array( 'number' => 1, 'count' => true ) );
 		if ( ! empty( $comment_children ) ) {
 			$args = array( 'parent' => $comment->comment_ID );
 			$rest_url = add_query_arg( $args, rest_url( $this->namespace . '/' . $this->rest_base ) );


### PR DESCRIPTION
Fixes #1612,

This patch adds a `children` link to the response when the comment has children.  The link is to a collection of comments who share the same parent as the original comment resource.  This enables a client to then recursively move through the links, with pagination parameters to boot, to performantly collect all threaded comments of a single comment.
