### PR TITLE
Alter default comment sort order to be "desc"

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -1006,7 +1006,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'type'                  => 'string',
 			'sanitize_callback'     => 'sanitize_key',
 			'validate_callback'     => 'rest_validate_request_arg',
-			'default'               => 'asc',
+			'default'               => 'desc',
 			'enum'                  => array(
 				'asc',
 				'desc',

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -179,7 +179,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->factory->comment->create( $args );
 		$id3 = $this->factory->comment->create( $args );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		// Orderby=>desc
+		// Order=>asc
+		$request->set_param( 'order', 'asc' );
 		$request->set_param( 'include', array( $id3, $id1 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
@@ -234,6 +235,27 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_param( 'page', 3 );
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 2, $response->get_data() );
+	}
+
+	public function test_get_items_order_query() {
+		wp_set_current_user( $this->admin_id );
+		$args = array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => $this->post_id,
+		);
+		$this->factory->comment->create( $args );
+		$this->factory->comment->create( $args );
+		$id3 = $this->factory->comment->create( $args );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		// order defaults to 'desc'
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $id3, $data[0]['id'] );
+		// order=>asc
+		$request->set_param( 'order', 'asc' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $this->approved_id, $data[0]['id'] );
 	}
 
 	public function test_get_items_private_post_no_permissions() {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -265,7 +265,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'Apple Sauce', $data[0]['title']['rendered'] );
-		// order=>desc
+		// order=>asc
 		$request->set_param( 'order', 'asc' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();


### PR DESCRIPTION
This follows discussion in #2588 and [in slack](https://wordpress.slack.com/archives/core-restapi/p1473088762000227) around standardizing the sort order of the comments endpoint to bring it in line with both the other endpoints in the API, and with `WP_Comment_Query`, by switching back to "desc" as the default sort order. Note that is a breaking change if API consumers are relying on comment order to be ascending by default.

Closes #2588
