### PR TITLE
Add raw and rendered to schema

### DIFF
--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -193,11 +193,11 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		}
 		
 		if ( ! empty( $schema['properties']['date_gmt'] ) ) {
-			$data['date'] = $this->prepare_date_response( $post->post_date_gmt );
+			$data['date_gmt'] = $this->prepare_date_response( $post->post_date_gmt );
 		}
 		
 		if ( ! empty( $schema['properties']['id'] ) ) {
-			$data['date'] = $post->ID;
+			$data['id'] = $post->ID;
 		}
 		
 		if ( ! empty( $schema['properties']['modified'] ) ) {
@@ -212,7 +212,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			$data['parent'] = (int) $post->post_parent;
 		}
 		
-		if ( ! empty( $schema['properties']['parent'] ) ) {
+		if ( ! empty( $schema['properties']['slug'] ) ) {
 			$data['slug'] = $post->post_name;
 		}
 

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -187,31 +187,31 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		if ( ! empty( $schema['properties']['author'] ) ) {
 			$data['author'] = $post->post_author;
 		}
-		
+
 		if ( ! empty( $schema['properties']['date'] ) ) {
 			$data['date'] = $this->prepare_date_response( $post->post_date_gmt, $post->post_date );
 		}
-		
+
 		if ( ! empty( $schema['properties']['date_gmt'] ) ) {
 			$data['date_gmt'] = $this->prepare_date_response( $post->post_date_gmt );
 		}
-		
+
 		if ( ! empty( $schema['properties']['id'] ) ) {
 			$data['id'] = $post->ID;
 		}
-		
+
 		if ( ! empty( $schema['properties']['modified'] ) ) {
 			$data['modified'] = $this->prepare_date_response( $post->post_modified_gmt, $post->post_modified );
 		}
-		
+
 		if ( ! empty( $schema['properties']['modified_gmt'] ) ) {
 			$data['modified_gmt'] = $this->prepare_date_response( $post->post_modified_gmt );
 		}
-		
+
 		if ( ! empty( $schema['properties']['parent'] ) ) {
 			$data['parent'] = (int) $post->post_parent;
 		}
-		
+
 		if ( ! empty( $schema['properties']['slug'] ) ) {
 			$data['slug'] = $post->post_name;
 		}

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -233,20 +233,11 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $schema['properties']['content'] ) ) {
 
-			if ( ! empty( $post->post_password ) ) {
-				$this->prepare_password_response( $post->post_password );
-			}
-
 			$data['content'] = array(
 				'raw'      => $post->post_content,
 				/** This filter is documented in wp-includes/post-template.php */
 				'rendered' => apply_filters( 'the_content', $post->post_content ),
 			);
-
-			// Don't leave our cookie lying around: https://github.com/WP-API/WP-API/issues/1055.
-			if ( ! empty( $post->post_password ) ) {
-				$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = '';
-			}
 		}
 
 		if ( ! empty( $schema['properties']['excerpt'] ) ) {
@@ -399,9 +390,6 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @return string|null $excerpt
 	 */
 	protected function prepare_excerpt_response( $excerpt, $post ) {
-		if ( post_password_required() ) {
-			return __( 'There is no excerpt because this is a protected post.' );
-		}
 
 		/** This filter is documented in wp-includes/post-template.php */
 		$excerpt = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $excerpt, $post ) );
@@ -411,21 +399,6 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		}
 
 		return $excerpt;
-	}
-
-	protected function prepare_password_response( $password ) {
-		if ( ! empty( $password ) ) {
-			/**
-			 * Fake the correct cookie to fool post_password_required().
-			 * Without this, get_the_content() will give a password form.
-			 */
-			require_once ABSPATH . WPINC .'/class-phpass.php';
-			$hasher = new PasswordHash( 8, true );
-			$value = $hasher->HashPassword( $password );
-			$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = wp_slash( $value );
-		}
-
-		return $password;
 	}
 
 }

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -413,4 +413,19 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		return $excerpt;
 	}
 
+	protected function prepare_password_response( $password ) {
+		if ( ! empty( $password ) ) {
+			/**
+			 * Fake the correct cookie to fool post_password_required().
+			 * Without this, get_the_content() will give a password form.
+			 */
+			require_once ABSPATH . WPINC .'/class-phpass.php';
+			$hasher = new PasswordHash( 8, true );
+			$value = $hasher->HashPassword( $password );
+			$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = wp_slash( $value );
+		}
+
+		return $password;
+	}
+
 }

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -265,7 +265,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			$this->assertArrayHasKey( '_links', $response );
 			$links = $response['_links'];
 		}
-		
+
 		$this->assertEquals( $revision->post_author, $response['author'] );
 
 		$rendered_content = apply_filters( 'the_content', $revision->post_content );

--- a/tests/test-rest-revisions-controller.php
+++ b/tests/test-rest-revisions-controller.php
@@ -265,18 +265,28 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			$this->assertArrayHasKey( '_links', $response );
 			$links = $response['_links'];
 		}
-
+		
 		$this->assertEquals( $revision->post_author, $response['author'] );
-		$this->assertEquals( $revision->post_content, $response['content'] );
+
+		$rendered_content = apply_filters( 'the_content', $revision->post_content );
+		$this->assertEquals( $rendered_content, $response['content']['rendered'] );
+
 		$this->assertEquals( mysql_to_rfc3339( $revision->post_date ), $response['date'] );
 		$this->assertEquals( mysql_to_rfc3339( $revision->post_date_gmt ), $response['date_gmt'] );
-		$this->assertEquals( $revision->post_excerpt, $response['excerpt'] );
-		$this->assertEquals( $revision->guid, $response['guid'] );
+
+		$rendered_excerpt = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $revision->post_excerpt, $revision ) );
+		$this->assertEquals( $rendered_excerpt, $response['excerpt']['rendered'] );
+
+		$rendered_guid = apply_filters( 'get_the_guid', $revision->guid );
+		$this->assertEquals( $rendered_guid, $response['guid']['rendered'] );
+
 		$this->assertEquals( $revision->ID, $response['id'] );
 		$this->assertEquals( mysql_to_rfc3339( $revision->post_modified ), $response['modified'] );
 		$this->assertEquals( mysql_to_rfc3339( $revision->post_modified_gmt ), $response['modified_gmt'] );
 		$this->assertEquals( $revision->post_name, $response['slug'] );
-		$this->assertEquals( $revision->post_title, $response['title'] );
+
+		$rendered_title = get_the_title( $revision->ID );
+		$this->assertEquals( $rendered_title, $response['title']['rendered'] );
 
 		$parent = get_post( $revision->post_parent );
 		$parent_controller = new WP_REST_Posts_Controller( $parent->post_type );


### PR DESCRIPTION
Solves https://github.com/WP-API/WP-API/issues/2670

For usual posts we give the title, the excerpt, the guid and the content in two formats: `raw` and `rendered`. In case of revisions, we just gave the `raw` content. This PR extends the schema, which acts now like we know it from usual posts.

So, instead of `content` being a string it would now be an object:

```
content : {
     raw : "",
     rendered: "",
}
```

The `raw` property would only be send when `context` is set to `edit`.
