### PR TITLE
"WP API" -> "WordPress REST API" in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Update user with ID 4? Send a `POST` request to `/wp-json/wp/v2/users/4`. Get al
 posts with the search term "awesome"? `GET /wp-json/wp/v2/posts?filter[s]=awesome`.
 It's that easy.
 
-WP API exposes a simple yet easy interface to WP Query, the posts API, post
-meta API, users API, revisions API and many more. Chances are, if you can do
-it with WordPress, WP API will let you do it.
+The WordPress REST API exposes a simple yet easy interface to WP Query, the posts
+API, post meta API, users API, revisions API and many more. Chances are, if you
+can do it with WordPress, the API will let you do it.
 
-WP API also includes an easy-to-use JavaScript API based on Backbone models,
+The REST API also includes an easy-to-use JavaScript API based on Backbone models,
 allowing plugin and theme developers to get up and running without needing to
 know anything about the details of getting connected.
 

--- a/bin/readme.txt
+++ b/bin/readme.txt
@@ -16,9 +16,9 @@ This plugin provides an easy to use REST API, available via HTTP. Grab your site
 
 Want to get your site's posts? Simply send a `GET` request to `/wp-json/wp/v2/posts`. Update user with ID 4? Send a `PUT` request to `/wp-json/wp/v2/users/4`. Get all posts with the search term "awesome"? `GET /wp-json/wp/v2/posts?filter[s]=awesome`. It's that easy.
 
-WP API exposes a simple yet easy interface to WP Query, the posts API, post meta API, users API, revisions API and many more. Chances are, if you can do it with WordPress, WP API will let you do it.
+The WordPress REST API exposes a simple yet easy interface to WP Query, the posts API, post meta API, users API, revisions API and many more. Chances are, if you can do it with WordPress, the API will let you do it.
 
-WP API also includes an easy-to-use Javascript API based on Backbone models, allowing plugin and theme developers to get up and running without needing to know anything about the details of getting connected.
+The REST API also includes an easy-to-use JavaScript API based on Backbone models, allowing plugin and theme developers to get up and running without needing to know anything about the details of getting connected.
 
 Check out [our documentation][docs] for information on what's available in the API and how to use it. We've also got documentation on extending the API with extra data for plugin and theme developers!
 


### PR DESCRIPTION
Fixes #2517, based on work by @davetgreen

This only changes content in prose (no change to links or changelog), and varies use of "WordPress REST API", "REST API" and "API" based on context to avoid distracting repetition.
