### PR TITLE
Update and add unit tests to account for ignoring filter[posts_per_page]

### DIFF
--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -464,11 +464,16 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
-	public function test_get_items_invalid_filter_posts_per_page() {
+	public function test_get_items_invalid_posts_per_page_ignored() {
+		// This test ensures that filter[posts_per_page] is ignored, and that -1
+		// cannot be used to sidestep per_page's valid range to retrieve all posts
+		for ( $i = 0; $i < 20; $i++ ) {
+			$this->factory->post->create( array( 'post_status' => 'publish' ) );
+		}
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_query_params( array( 'filter' => array( 'posts_per_page' => -1 ) ) );
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertCount( 10, $response->get_data() );
 	}
 
 	public function test_get_items_invalid_context() {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -420,19 +420,21 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertContains( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
 		$this->assertFalse( stripos( $headers['Link'], 'rel="next"' ) );
 
-		// With filter params.
+		// With query params.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_query_params( array( 'filter' => array( 'posts_per_page' => 5, 'paged' => 2 ) ) );
+		$request->set_query_params( array( 'per_page' => 5, 'page' => 2 ) );
 		$response = $this->server->dispatch( $request );
 		$headers = $response->get_headers();
 		$this->assertEquals( 51, $headers['X-WP-Total'] );
 		$this->assertEquals( 11, $headers['X-WP-TotalPages'] );
 		$prev_link = add_query_arg( array(
-			'page'    => 1,
+			'per_page' => 5,
+			'page'     => 1,
 			), rest_url( '/wp/v2/posts' ) );
 		$this->assertContains( '<' . $prev_link . '>; rel="prev"', $headers['Link'] );
 		$next_link = add_query_arg( array(
-			'page'    => 3,
+			'per_page' => 5,
+			'page'     => 3,
 			), rest_url( '/wp/v2/posts' ) );
 		$this->assertContains( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 	}
@@ -453,6 +455,20 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$data = $response->get_data();
 		$this->assertCount( 1, $data );
 		$this->assertEquals( $draft_id, $data[0]['id'] );
+	}
+
+	public function test_get_items_invalid_per_page() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array( 'per_page' => -1 ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_get_items_invalid_filter_posts_per_page() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_query_params( array( 'filter' => array( 'posts_per_page' => -1 ) ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	public function test_get_items_invalid_context() {


### PR DESCRIPTION
@joehoyle @rmccue fixed the test broken in #2699 (the test presumes that filter properties work consistently, which that PR breaks by ignoring posts_per_page entirely), but I am not sure how to handle the test for `filter[posts_per_page]=-1`: should I be testing that it is ignored, as seems to be the case, or should I be testing that it is an error?

The solution in #2699 is the quick fix but seems to introduce confusion around which `filter` properties are valid, and which aren't.
