### PR TITLE
Allow returning an error from field update callbacks

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -134,7 +134,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $request['alt_text'] ) );
 		}
 
-		$this->update_additional_fields_for_object( $attachment, $request );
+		$fields_update = $this->update_additional_fields_for_object( $attachment, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $attachment, $request );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -371,7 +371,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$comment = get_comment( $comment_id );
-		$this->update_additional_fields_for_object( $comment, $request );
+		$fields_update = $this->update_additional_fields_for_object( $comment, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$context = current_user_can( 'moderate_comments' ) ? 'edit' : 'view';
 		$request->set_param( 'context', $context );
@@ -451,7 +454,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$comment = get_comment( $id );
-		$this->update_additional_fields_for_object( $comment, $request );
+		$fields_update = $this->update_additional_fields_for_object( $comment, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $comment, $request );

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -330,13 +330,12 @@ abstract class WP_REST_Controller {
 	 *
 	 * @param array  $object
 	 * @param WP_REST_Request $request
+	 * @return bool|WP_Error True on success, WP_Error object if a field cannot be updated.
 	 */
 	protected function update_additional_fields_for_object( $object, $request ) {
-
 		$additional_fields = $this->get_additional_fields();
 
 		foreach ( $additional_fields as $field_name => $field_options ) {
-
 			if ( ! $field_options['update_callback'] ) {
 				continue;
 			}
@@ -346,8 +345,13 @@ abstract class WP_REST_Controller {
 				continue;
 			}
 
-			call_user_func( $field_options['update_callback'], $request[ $field_name ], $object, $field_name, $request, $this->get_object_type() );
+			$result = call_user_func( $field_options['update_callback'], $request[ $field_name ], $object, $field_name, $request, $this->get_object_type() );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 		}
+
+		return true;
 	}
 
 	/**

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -340,7 +340,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$post = $this->get_post( $post_id );
-		$this->update_additional_fields_for_object( $post, $request );
+		$fields_update = $this->update_additional_fields_for_object( $post, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		/**
 		 * Fires after a single post is created or updated via the REST API.
@@ -447,7 +450,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$post = $this->get_post( $post_id );
-		$this->update_additional_fields_for_object( $post, $request );
+		$fields_update = $this->update_additional_fields_for_object( $post, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		/* This action is documented in lib/endpoints/class-wp-rest-controller.php */
 		do_action( "rest_insert_{$this->post_type}", $post, $request, false );

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -371,7 +371,11 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 */
 		do_action( "rest_insert_{$this->taxonomy}", $term, $request, true );
 
-		$this->update_additional_fields_for_object( $term, $request );
+		$fields_update = $this->update_additional_fields_for_object( $term, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
 		$request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $term, $request );
 		$response = rest_ensure_response( $response );
@@ -441,7 +445,11 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		/* This action is documented in lib/endpoints/class-wp-rest-terms-controller.php */
 		do_action( "rest_insert_{$this->taxonomy}", $term, $request, false );
 
-		$this->update_additional_fields_for_object( $term, $request );
+		$fields_update = $this->update_additional_fields_for_object( $term, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
 		$request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $term, $request );
 		return rest_ensure_response( $response );

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -322,7 +322,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			array_map( array( $user, 'add_role' ), $request['roles'] );
 		}
 
-		$this->update_additional_fields_for_object( $user, $request );
+		$fields_update = $this->update_additional_fields_for_object( $user, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		/**
 		 * Fires after a user is created or updated via the REST API.
@@ -411,7 +414,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			array_map( array( $user, 'add_role' ), $request['roles'] );
 		}
 
-		$this->update_additional_fields_for_object( $user, $request );
+		$fields_update = $this->update_additional_fields_for_object( $user, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
 
 		/* This action is documented in lib/endpoints/class-wp-rest-users-controller.php */
 		do_action( 'rest_insert_user', $user, $request, false );


### PR DESCRIPTION
Right now, it's not possible to indicate an update failure in a custom callback. This adds the ability to return an error instance and have that passed back to the client.
