### PR TITLE
#2616 boolean validation

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -299,8 +299,8 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'integer' ) );
 		}
 
-		if ( 'boolean' === $args['type'] && ! is_bool( $value ) ) {
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $param, 'boolean' ) );
+		if ( 'boolean' === $args['type'] && ! rest_is_boolean( $value ) ) {
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not of type %s' ), $value, 'boolean' ) );
 		}
 
 		if ( 'string' === $args['type'] && ! is_string( $value ) ) {
@@ -387,6 +387,10 @@ if ( ! function_exists( 'rest_sanitize_request_arg' ) ) {
 			return (int) $value;
 		}
 
+		if ( 'boolean' === $args['type'] ) {
+			return rest_sanitize_boolean( $value );
+		}
+
 		if ( isset( $args['format'] ) ) {
 			switch ( $args['format'] ) {
 				case 'date-time' :
@@ -408,7 +412,6 @@ if ( ! function_exists( 'rest_sanitize_request_arg' ) ) {
 
 		return $value;
 	}
-
 }
 
 if ( ! function_exists( 'rest_is_ip_address' ) ) {
@@ -428,5 +431,59 @@ if ( ! function_exists( 'rest_is_ip_address' ) ) {
 		}
 
 		return $ipv4;
+	}
+}
+
+/**
+ * Changes a boolean-like value into the proper boolean value.
+ *
+ * @param bool|string|int $value The value being evaluated.
+ * @return boolean Returns the proper associated boolean value.
+ */
+if ( ! function_exists( 'rest_sanitize_boolean' ) ) {
+	function rest_sanitize_boolean( $value ) {
+		// String values are translated to `true`; make sure 'false' is false.
+		if ( is_string( $value )  ) {
+			$value = strtolower( $value );
+			if ( in_array( $value, array( 'false', '0' ), true ) ) {
+				$value = false;
+			}
+		}
+
+		// Everything else will map nicely to boolean.
+		return (boolean) $value;
+	}
+}
+
+/**
+ * Determines if a given value is boolean-like.
+ *
+ * @param bool|string $maybe_bool The value being evaluated.
+ * @return boolean True if a boolean, otherwise false.
+ */
+if ( ! function_exists( 'rest_is_boolean' ) ) {
+	function rest_is_boolean( $maybe_bool ) {
+		if ( is_bool( $maybe_bool ) ) {
+			return true;
+		}
+
+		if ( is_string( $maybe_bool ) ) {
+			$maybe_bool = strtolower( $maybe_bool );
+
+			$valid_boolean_values = array(
+				'false',
+				'true',
+				'0',
+				'1',
+			);
+
+			return in_array( $maybe_bool, $valid_boolean_values, true );
+		}
+
+		if ( is_int( $maybe_bool ) ) {
+			return in_array( $maybe_bool, array( 0, 1 ), true );
+		}
+
+		return false;
 	}
 }

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -52,10 +52,57 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			rest_validate_request_arg( false, $this->request, 'someboolean' )
 		);
 
-		$this->assertErrorResponse(
-			'rest_invalid_param',
+		$this->assertTrue(
 			rest_validate_request_arg( 'true', $this->request, 'someboolean' )
 		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'TRUE', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'false', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 'False', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( '1', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( '0', $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 1, $this->request, 'someboolean' )
+		);
+		$this->assertTrue(
+			rest_validate_request_arg( 0, $this->request, 'someboolean' )
+		);
+
+		// Check sanitize testing.
+		$this->assertEquals( false,
+			rest_sanitize_request_arg( 'false', $this->request, 'someboolean' )
+		);
+		$this->assertEquals( false,
+			rest_sanitize_request_arg( '0', $this->request, 'someboolean' )
+		);
+		$this->assertEquals( false,
+			rest_sanitize_request_arg( 0, $this->request, 'someboolean' )
+		);
+		$this->assertEquals( false,
+			rest_sanitize_request_arg( 'FALSE', $this->request, 'someboolean' )
+		);
+		$this->assertEquals( true,
+			rest_sanitize_request_arg( 'true', $this->request, 'someboolean' )
+		);
+		$this->assertEquals( true,
+			rest_sanitize_request_arg( '1', $this->request, 'someboolean' )
+		);
+		$this->assertEquals( true,
+			rest_sanitize_request_arg( 1, $this->request, 'someboolean' )
+		);
+		$this->assertEquals( true,
+			rest_sanitize_request_arg( 'TRUE', $this->request, 'someboolean' )
+		);
+
 		$this->assertErrorResponse(
 			'rest_invalid_param',
 			rest_validate_request_arg( '123', $this->request, 'someboolean' )


### PR DESCRIPTION
Fixes #2616, and #2633, In addition #2630 can be closed. Adds boolean validation/sanitization, to handle integers, strings, and booleans.  `'false'` and `'0'` and integer `0` will evaluate to `false`.  The opposite of those values is `true`.
