### PR TITLE
Password Protected Posts Support

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -295,7 +295,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Edit context always gets access to passworded posts.
-		if ( $request['context'] === 'edit' ) {
+		if ( 'edit' === $request['context'] ) {
 			return true;
 		}
 

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -63,6 +63,9 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 			$this->assertEquals( is_sticky( $post->ID ), $data['sticky'] );
 		}
 
+		if ( 'post' === $post->post_type && 'edit' === $context ) {
+			$this->assertEquals( $post->post_password, $data['password'] );
+		}
 		if ( 'page' === $post->post_type ) {
 			$this->assertEquals( get_page_template_slug( $post->ID ), $data['template'] );
 		}
@@ -130,7 +133,6 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		if ( 'edit' === $context ) {
 			$this->assertEquals( $post->guid, $data['guid']['raw'] );
 			$this->assertEquals( $post->post_status, $data['status'] );
-			$this->assertEquals( $post->post_password, $data['password'] );
 
 			if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
 				$this->assertNull( $data['date_gmt'] );

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -66,6 +66,7 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		if ( 'post' === $post->post_type && 'edit' === $context ) {
 			$this->assertEquals( $post->post_password, $data['password'] );
 		}
+
 		if ( 'page' === $post->post_type ) {
 			$this->assertEquals( get_page_template_slug( $post->ID ), $data['template'] );
 		}
@@ -104,7 +105,10 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 
 		if ( post_type_supports( $post->post_type, 'editor' ) ) {
 			// TODO: apply content filter for more accurate testing.
-			$this->assertEquals( wpautop( $post->post_content ), $data['content']['rendered'] );
+			if ( ! $post->post_password ) {
+				$this->assertEquals( wpautop( $post->post_content ), $data['content']['rendered'] );
+			}
+
 			if ( 'edit' === $context ) {
 				$this->assertEquals( $post->post_content, $data['content']['raw'] );
 			} else {
@@ -119,7 +123,7 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 				// TODO: apply excerpt filter for more accurate testing.
 				$this->assertEquals( wpautop( $post->post_excerpt ), $data['excerpt']['rendered'] );
 			} else {
-				$this->assertEquals( 'There is no excerpt because this is a protected post.', $data['excerpt']['rendered'] );
+				// TODO: better testing for excerpts for password protected posts.
 			}
 			if ( 'edit' === $context ) {
 				$this->assertEquals( $post->post_excerpt, $data['excerpt']['raw'] );

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -90,7 +90,9 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 
 		// Check filtered values.
 		if ( post_type_supports( $post->post_type, 'title' ) ) {
+			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 			$this->assertEquals( get_the_title( $post->ID ), $data['title']['rendered'] );
+			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 			if ( 'edit' === $context ) {
 				$this->assertEquals( $post->post_title, $data['title']['raw'] );
 			} else {
@@ -291,4 +293,17 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 		) ) );
 	}
 
+	/**
+	 * Overwrite the default protected title format.
+	 *
+	 * By default WordPress will show password protected posts with a title of
+	 * "Protected: %s", as the REST API communicates the protected status of a post
+	 * in a machine readable format, we remove the "Protected: " prefix.
+	 *
+	 * @param  string $format
+	 * @return string
+	 */
+	public function protected_title_format() {
+		return '%s';
+	}
 }

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -704,7 +704,6 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertArrayHasKey( 'media_details', $properties );
 		$this->assertArrayHasKey( 'modified', $properties );
 		$this->assertArrayHasKey( 'modified_gmt', $properties );
-		$this->assertArrayHasKey( 'password', $properties );
 		$this->assertArrayHasKey( 'post', $properties );
 		$this->assertArrayHasKey( 'ping_status', $properties );
 		$this->assertArrayHasKey( 'status', $properties );

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -688,7 +688,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 23, count( $properties ) );
+		$this->assertEquals( 22, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'alt_text', $properties );
 		$this->assertArrayHasKey( 'caption', $properties );

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -359,7 +359,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 21, count( $properties ) );
+		$this->assertEquals( 20, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'comment_status', $properties );
 		$this->assertArrayHasKey( 'content', $properties );

--- a/tests/test-rest-pages-controller.php
+++ b/tests/test-rest-pages-controller.php
@@ -374,7 +374,6 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertArrayHasKey( 'modified', $properties );
 		$this->assertArrayHasKey( 'modified_gmt', $properties );
 		$this->assertArrayHasKey( 'parent', $properties );
-		$this->assertArrayHasKey( 'password', $properties );
 		$this->assertArrayHasKey( 'ping_status', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'status', $properties );

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -616,6 +616,11 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_with_password_using_password() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
+			return $this->markTestSkipped( 'WordPress < 4.6 does not support filtering passwords for posts.' );
+		}
+
 		$post_id = $this->factory->post->create( array(
 			'post_password' => '$inthebananastand',
 			'post_content'  => 'Some secret content.',


### PR DESCRIPTION
In an attempt to better support password protected posts (see #2701) I've done a few things
now it's possible to better filter the password stuf in WordPress Core:
1. Password protected posts are now readable by every one.
2. All posts how have `content.protected` and `excerpt.protected` fields to indicate if those fields are protected by a password.
3. The `content.rendered` and `excerpt.rendered` are now empty strings if the post requires a password to be viewed.
4. Password protected posts in the rest api means "the post's content and excerpt are protected with a password".
5. If the user is viewing a post or listing posts in the `edit` context, they can see the protected fields.
6. The client can pass `?password=thepassword` to a single post endpoint to read it's protected fields.
7. An incorrect password with the above will result in a Forbidden response.
8. A client can now update and create password protected posts.
9. Post Types other than `post` no longer have support (or the property) for `password`.
10. Password protected post titles no longer have the "Protected: " prefix in REST API responses.
