### PR TITLE
Use wrapper for `sanitize_title` to avoid messed up slugs.

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -516,13 +516,17 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Sanitize a post's title.
+	 * Sanitize the slug value.
 	 *
-	 * It's not possible to pass `sanitize_title` directly as the sanitize_callback
-	 * as that will cause 3 params inadvertantly being passed to `sanitize_title`.
+	 * @internal We can't use {@see sanitize_title} directly, as the second
+	 * parameter is the fallback title, which would end up being set to the
+	 * request object.
+	 * @see https://github.com/WP-API/WP-API/issues/1585
 	 *
-	 * @param string $slug
-	 * @return string
+	 * @todo Remove this in favour of https://core.trac.wordpress.org/ticket/34659
+	 *
+	 * @param string $slug Slug value passed in request.
+	 * @return string Sanitized value for the slug.
 	 */
 	public function sanitize_slug( $slug ) {
 		return sanitize_title( $slug );

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -514,4 +514,17 @@ abstract class WP_REST_Controller {
 
 		return $post;
 	}
+
+	/**
+	 * Sanitize a post's title.
+	 *
+	 * It's not possible to pass `sanitize_title` directly as the sanitize_callback
+	 * as that will cause 3 params inadvertantly being passed to `sanitize_title`.
+	 *
+	 * @param string $slug
+	 * @return string
+	 */
+	public function sanitize_slug( $slug ) {
+		return sanitize_title( $slug );
+	}
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1424,7 +1424,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'status'          => array(
@@ -1798,4 +1798,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		return new WP_Error( 'rest_forbidden_status', __( 'Status is forbidden' ), array( 'status' => rest_authorization_required_code() ) );
 	}
 
+	/**
+	 * Sanitize a post's title.
+	 *
+	 * It's not possible to pass `sanitize_title` directly as the sanitize_callback
+	 * as that will cause 3 params inadvertantly being passed to `sanitize_title`.
+	 *
+	 * @param string $slug
+	 * @return string
+	 */
+	public function sanitize_slug( $slug ) {
+		return sanitize_title( $slug );
+	}
 }

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1797,17 +1797,4 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 		return new WP_Error( 'rest_forbidden_status', __( 'Status is forbidden' ), array( 'status' => rest_authorization_required_code() ) );
 	}
-
-	/**
-	 * Sanitize a post's title.
-	 *
-	 * It's not possible to pass `sanitize_title` directly as the sanitize_callback
-	 * as that will cause 3 params inadvertantly being passed to `sanitize_title`.
-	 *
-	 * @param string $slug
-	 * @return string
-	 */
-	public function sanitize_slug( $slug ) {
-		return sanitize_title( $slug );
-	}
 }

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -719,7 +719,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed', 'edit' ),
 					'arg_options'  => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'taxonomy'         => array(

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -802,7 +802,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'arg_options' => array(
-						'sanitize_callback' => 'sanitize_title',
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
 				'registered_date' => array(

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1360,6 +1360,22 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( 'sample-slug', $post->post_name );
 	}
 
+	public function test_update_post_slug_accented_chars() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $this->post_id ) );
+		$params = $this->set_post_data( array(
+			'slug' => 'tęst-acceńted-chäræcters',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertEquals( 'test-accented-charaecters', $new_data['slug'] );
+		$post = get_post( $new_data['id'] );
+		$this->assertEquals( 'test-accented-charaecters', $post->post_name );
+	}
+
 	public function test_update_post_sticky() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
This is required sinse passing sanitize_title directly will result in
messed up slugs due to the `context` param getting a garbage value.

Fixes #2487
