### PR TITLE
Ensure the terms list is a list

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1217,7 +1217,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 			if ( ! empty( $schema['properties'][ $base ] ) ) {
 				$terms = get_the_terms( $post, $taxonomy->name );
-				$data[ $base ] = $terms ? wp_list_pluck( $terms, 'term_id' ) : array();
+				$data[ $base ] = $terms ? array_values( wp_list_pluck( $terms, 'term_id' ) ) : array();
 			}
 		}
 


### PR DESCRIPTION
A filter could unset() items from this list, which would cause it to be accidentally output as an object.

Fixes #2582.
