### PR TITLE
#2582 call array values on roles

### DIFF
--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -552,7 +552,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! empty( $schema['properties']['roles'] ) ) {
-			$data['roles'] = $user->roles;
+			// Defensively call array_values() to ensure an array is returned.
+			$data['roles'] = array_values( $user->roles );
 		}
 
 		if ( ! empty( $schema['properties']['registered_date'] ) ) {


### PR DESCRIPTION
#2582 was fixed in #2724, but it is also possible to remove user roles from an array in `set_user_role`, `add_user_role`, or `remove_user_role`. It would be pretty hard to do so, and most likely no one does it, but here is a PR just in case. Feel free to close the PR if it is unwanted.
