### PR TITLE
Fix regular expression used to determine "single" routes

### DIFF
--- a/wp-api.js
+++ b/wp-api.js
@@ -1080,7 +1080,7 @@
 				) {
 
 					// Single items end with a regex (or the special case 'me').
-					if ( /.*[+)|me]$/.test( index ) ) {
+					if ( /.*(\+\)|me)$/.test( index ) ) {
 						modelRoutes.push( { index: index, route: route } );
 					} else {
 


### PR DESCRIPTION
The regular expression was matching "single" routes for anything ending in either "]", "m", or "e", instead of routes that end in either "+)" or "me" as intended. This fixes the regular expression to use subpatterns properly instead of the character set.
