### PR TITLE
Support setting posts to "auto-draft" status

### DIFF
--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -63,6 +63,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$data = array();
 		$statuses = get_post_stati( array( 'internal' => false ), 'object' );
+		$statuses['auto-draft'] = get_post_status_object( 'auto-draft' );
 		$statuses['trash'] = get_post_status_object( 'trash' );
 		foreach ( $statuses as $slug => $obj ) {
 			$ret = $this->check_read_permission( $obj );
@@ -103,7 +104,7 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 		if ( true === $status->public ) {
 			return true;
 		}
-		if ( false === $status->internal || 'trash' === $status->name ) {
+		if ( false === $status->internal || in_array( $status->name, array( 'auto-draft', 'trash' ) ) ) {
 			$types = get_post_types( array( 'show_in_rest' => true ), 'objects' );
 			foreach ( $types as $type ) {
 				if ( current_user_can( $type->cap->edit_posts ) ) {

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -915,6 +915,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	protected function handle_status_param( $post_status, $post_type ) {
 
 		switch ( $post_status ) {
+			case 'auto-draft':
 			case 'draft':
 			case 'pending':
 				break;
@@ -1480,7 +1481,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'status'          => array(
 					'description' => __( 'A named status for the object.' ),
 					'type'        => 'string',
-					'enum'        => array_keys( get_post_stati( array( 'internal' => false ) ) ),
+					'enum'        => array_merge(
+						array_keys( get_post_stati( array( 'internal' => false ) ) ),
+						array( 'auto-draft' )
+					),
 					'context'     => array( 'edit' ),
 				),
 				'type'            => array(

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -46,6 +46,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 			'publish',
 			'private',
 			'pending',
+			'auto-draft',
 			'draft',
 			'trash',
 			'future',

--- a/tests/test-rest-post-statuses-controller.php
+++ b/tests/test-rest-post-statuses-controller.php
@@ -41,7 +41,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();
-		$this->assertEquals( 6, count( $data ) );
+		$this->assertEquals( 7, count( $data ) );
 		$this->assertEqualSets( array(
 			'publish',
 			'private',

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -902,6 +902,25 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_cannot_create', $response, 401 );
 	}
 
+	public function test_create_post_auto_draft() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$params = $this->set_post_data( array(
+			'status' => 'auto-draft',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+		$new_post = get_post( $data['id'] );
+		$this->assertEquals( 'auto-draft', $data['status'] );
+		$this->assertEquals( 'auto-draft', $new_post->post_status );
+		// Confirm dates are null
+		$this->assertNull( $data['date_gmt'] );
+		$this->assertNull( $data['modified_gmt'] );
+	}
+
 	public function test_create_post_draft() {
 		wp_set_current_user( $this->editor_id );
 


### PR DESCRIPTION
For #2737

The list of statuses supported by the API omits auto-draft, both in the list of statuses a post will accept and in the collection returned from `/wp/v2/statuses`. This PR begins to add support; the prior case should be working with the below, but I'll need to investigate more to understand where I need to make a change to get auto-draft to show up in the queryable statuses list. (Would only show when authenticated)
