### PR TITLE
Add `?{taxonomy}_exclude=` query parameter to posts

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -171,6 +171,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+			$tax_exclude = $base . '_exclude';
 
 			if ( ! empty( $request[ $base ] ) ) {
 				$query_args['tax_query'][] = array(
@@ -178,6 +179,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'field'            => 'term_id',
 					'terms'            => $request[ $base ],
 					'include_children' => false,
+				);
+			}
+
+			if ( ! empty( $request[ $tax_exclude ] ) ) {
+				$query_args['tax_query'][] = array(
+					'taxonomy'         => $taxonomy->name,
+					'field'            => 'term_id',
+					'terms'            => $request[ $tax_exclude ],
+					'include_children' => false,
+					'operator'         => 'NOT IN',
 				);
 			}
 		}

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -335,7 +335,28 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request->set_param( 'tags', array( $tag['term_id'] ) );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertCount( 1, $response->get_data() );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id1, $data[0]['id'] );
+	}
+
+	public function test_get_items_tags_exclude_query() {
+		$id1 = $this->post_id;
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id4 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag = wp_insert_term( 'My Tag', 'post_tag' );
+
+		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags_exclude', array( $tag['term_id'] ) );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertCount( 3, $data );
+		$this->assertEquals( $id4, $data[0]['id'] );
+		$this->assertEquals( $id3, $data[1]['id'] );
+		$this->assertEquals( $id2, $data[2]['id'] );
 	}
 
 	public function test_get_items_tags_and_categories_query() {
@@ -356,6 +377,28 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 1, $response->get_data() );
+	}
+
+	public function test_get_items_tags_and_categories_exclude_query() {
+		$id1 = $this->post_id;
+		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id4 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$tag = wp_insert_term( 'My Tag', 'post_tag' );
+		$category = wp_insert_term( 'My Category', 'category' );
+
+		wp_set_object_terms( $id1, array( $tag['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id2, array( $tag['term_id'] ), 'post_tag' );
+		wp_set_object_terms( $id1, array( $category['term_id'] ), 'category' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'tags', array( $tag['term_id'] ) );
+		$request->set_param( 'categories_exclude', array( $category['term_id'] ) );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id2, $data[0]['id'] );
 	}
 
 	public function test_get_items_sticky_query() {


### PR DESCRIPTION
This mirrors our existing support for `?{taxonomy}=` filtering in the posts controller (which allows querying for only records with are associated with any of the provided term IDs for the specified taxonomy) by adding an equivalent `_exclude` variant to list IDs of terms for which associated posts should NOT be returned.

For categories _e.g._, `/wp/v2/posts?categories[]=7&categories[]=9` would return a post in categories 7 _or_ 9; this PR adds support for the inverse query `?categories_exclude[]=7&categories_exclude[]=9`, meaning "only return posts that are associated with neither category 7 or category 9."

`{term base}_exclude` is supported for any taxonomy registered with the API, and is set within the same loop inside the controller as the existing term include parameters.

While using the existing categories filter with a negative number was considered ([see slack discussion](https://wordpress.slack.com/archives/core-restapi/p1475525429004981)), `{base}_exclude` maintains more consistency with other exclusion filters present in the API such as `parent_exclude` (and is much easier to implement, to boot).
