### PR TITLE
Add "?fields" query parameter to return only specific fields in response

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -276,8 +276,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object
 		$response = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -588,6 +588,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object
 		$response = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -210,6 +210,28 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
+	 * Filter a response to include only a subset of response fields
+	 *
+	 * @param array $data
+	 * @param array $fields
+	 * @return array
+	 */
+	public function filter_response_by_fields( $data, $fields ) {
+		if ( empty( $fields ) || 0 === count( $fields ) ) {
+			return $data;
+		}
+
+		$filtered_data = array();
+		foreach ( $fields as $field ) {
+			if ( isset( $data[ $field ] ) ) {
+				$filtered_data[ $field ] = $data[ $field ];
+			}
+		}
+
+		return $filtered_data;
+	}
+
+	/**
 	 * Get the item's schema, conforming to JSON Schema.
 	 *
 	 * @return array

--- a/lib/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/lib/endpoints/class-wp-rest-post-statuses-controller.php
@@ -151,6 +151,8 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		$response = rest_ensure_response( $data );
 

--- a/lib/endpoints/class-wp-rest-post-types-controller.php
+++ b/lib/endpoints/class-wp-rest-post-types-controller.php
@@ -110,6 +110,8 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1276,6 +1276,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -250,6 +250,9 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
+
 		$response = rest_ensure_response( $data );
 
 		if ( ! empty( $data['parent'] ) ) {

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -142,6 +142,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -597,6 +597,8 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		$response = rest_ensure_response( $data );
 

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -583,6 +583,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$data = $this->add_additional_fields_to_object( $data, $request );
 		$data = $this->filter_response_by_context( $data, $context );
+		$fields = ! empty( $request['fields'] ) ? explode( ',', $request['fields'] ) : array();
+		$data = $this->filter_response_by_fields( $data, $fields );
 
 		// Wrap the data in a response object
 		$response = rest_ensure_response( $data );

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -205,4 +205,42 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->rest_the_post_filter_apply_count += 1;
 		return $post;
 	}
+
+	public function test_filter_response_by_fields() {
+		$controller = new WP_REST_Test_Controller();
+		$fields = array( 'id', 'title' );
+		$data = array(
+			'id' => 1,
+			'title' => array(
+				'rendered' => 'Post Title',
+			),
+			'content' => array(
+				'rendered' => 'Post Content',
+			),
+		);
+		$filtered_data = $controller->filter_response_by_fields( $data, $fields );
+		$this->assertNotEquals( $data, $filtered_data );
+		$this->assertEquals( array(
+			'id' => 1,
+			'title' => array(
+				'rendered' => 'Post Title',
+			),
+		), $filtered_data );
+	}
+
+	public function test_filter_response_by_empty_fields() {
+		$controller = new WP_REST_Test_Controller();
+		$fields = array();
+		$data = array(
+			'id' => 1,
+			'title' => array(
+				'rendered' => 'Post Title',
+			),
+			'content' => array(
+				'rendered' => 'Post Content',
+			),
+		);
+		$filtered_data = $controller->filter_response_by_fields( $data, $fields );
+		$this->assertEquals( $data, $filtered_data );
+	}
 }


### PR DESCRIPTION
This PR builds upon discussion in #2771, #572, #2350, #2509, #1530, #1371, #446, #827, and the trac ticket [38131](https://core.trac.wordpress.org/ticket/38131), proposing a solution implemented within this plugin's wp-rest-controller class.

The patch implements a `?fields=` filter parameter that takes a comma-separated list of field names, e.g. "id" and "title" via `?fields=id,title`. It mirrors the fields parameter implemented within the [WordPress.com API](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/):

| Parameter | Type | Description |
| --- | --- | --- |
| fields | (string) | Optional. Returns specified fields only. Comma-separated list. Example: fields=ID,title |

This interface was previously implemented in [this plugin](https://wordpress.org/plugins/wp-rest-api-filter-fields/), and could still be implemented trivially as a plugin; however, referencing the [2016 Ericsson Mobility Report](https://www.ericsson.com/res/docs/2016/mobility-report/ericsson-mobility-report-feb-2016-interim.pdf) and the democratic focus of WordPress, transferring as little data as is necessary for a given interface is a responsibility I submit that we should take on as application developers, and that _should_ therefore be a first-party capability of the API, as it is for .com's.

Introducing this field has no risk of breaking the contract between the API and clients you do not control, as the `fields` list would only alter the response when provided so each client can tailor its own responses to the subset of data relevant to that interface.

Open questions:
- Is there a less repetitive way this could be implemented across controllers, or is this duplication within each controller necessary?
- How would I register `fields` as a globally-applicable parameter for exposure in the schema, whitelisting, etc?
- How could/How should we restrict this to GET requests only?
- What degree of per-controller testing is needed?
