### PR TITLE
Documentation and code standards for `WP_REST_Terms_Controller`.

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -1,14 +1,22 @@
 <?php
 
 /**
- * Access terms associated with a taxonomy
+ * Access terms associated with a taxonomy.
  */
 class WP_REST_Terms_Controller extends WP_REST_Controller {
 
+	/**
+	 * Taxonomy key.
+	 *
+	 * @access protected
+	 * @var string
+	 */
 	protected $taxonomy;
 
 	/**
-	 * @param string $taxonomy
+	 * Constructor.
+	 *
+	 * @param string $taxonomy Taxonomy key.
 	 */
 	public function __construct( $taxonomy ) {
 		$this->taxonomy = $taxonomy;
@@ -20,7 +28,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the routes for the objects of the controller.
+	 * Registers the routes for the objects of the controller.
 	 */
 	public function register_routes() {
 
@@ -32,34 +40,34 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'args'                => $this->get_collection_params(),
 			),
 			array(
-				'methods'     => WP_REST_Server::CREATABLE,
-				'callback'    => array( $this, 'create_item' ),
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'        => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
-		));
+		) );
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
-					'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 				),
 			),
 			array(
-				'methods'    => WP_REST_Server::EDITABLE,
-				'callback'   => array( $this, 'update_item' ),
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'        => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				'args'                 => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 			array(
-				'methods'    => WP_REST_Server::DELETABLE,
-				'callback'   => array( $this, 'delete_item' ),
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
 				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
-				'args'       => array(
-					'force'    => array(
+				'args'                => array(
+					'force' => array(
 						'default'     => false,
 						'description' => __( 'Required to be true, as resource does not support trashing.' ),
 					),
@@ -70,7 +78,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to read the terms.
+	 * Checks if a request has access to read terms in the specified taxonomy.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -87,9 +95,9 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get terms associated with a taxonomy
+	 * Gets terms associated with a taxonomy.
 	 *
-	 * @param WP_REST_Request $request Full details about the request
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_items( $request ) {
@@ -108,7 +116,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		if ( ! empty( $request['offset'] ) ) {
 			$prepared_args['offset'] = $request['offset'];
 		} else {
-			$prepared_args['offset']  = ( $request['page'] - 1 ) * $prepared_args['number'];
+			$prepared_args['offset'] = ( $request['page'] - 1 ) * $prepared_args['number'];
 		}
 
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
@@ -125,7 +133,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		}
 
 		/**
-		 * Filter the query arguments, before passing them to `get_terms()`.
+		 * Filters the query arguments before passing them to get_terms().
 		 *
 		 * Enables adding extra arguments or setting defaults for a terms
 		 * collection request.
@@ -133,7 +141,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 * @see https://developer.wordpress.org/reference/functions/get_terms/
 		 *
 		 * @param array           $prepared_args Array of arguments to be
-		 *                                       passed to get_terms.
+		 *                                       passed to get_terms().
 		 * @param WP_REST_Request $request       The current request.
 		 */
 		$prepared_args = apply_filters( "rest_{$this->taxonomy}_query", $prepared_args, $request );
@@ -176,7 +184,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $response );
 
-		// Store pagation values for headers then unset for count query.
+		// Store pagination values for headers.
 		$per_page = (int) $prepared_args['number'];
 		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
 
@@ -203,14 +211,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the terms attached to a post.
+	 * Gets the terms attached to a post.
 	 *
-	 * This is an alternative to `get_terms()` that uses `get_the_terms()`
+	 * This is an alternative to get_terms() that uses get_the_terms()
 	 * instead, which hits the object cache. There are a few things not
 	 * supported, notably `include`, `exclude`. In `self::get_items()` these
 	 * are instead treated as a full query.
 	 *
-	 * @param array $prepared_args Arguments for `get_terms()`
+	 * @param array $prepared_args Arguments for get_terms().
 	 * @return array List of term objects. (Total count in `$this->total_terms`)
 	 */
 	protected function get_terms_for_post( $prepared_args ) {
@@ -220,8 +228,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			return array();
 		}
 
-		// get_items() verifies that we don't have `include` set, and default
-		// ordering is by `name`
+		/*
+		 * get_items() verifies that we don't have `include` set, and default
+		 * ordering is by `name`.
+		 */
 		if ( ! in_array( $prepared_args['orderby'], array( 'name', 'none', 'include' ) ) ) {
 			switch ( $prepared_args['orderby'] ) {
 				case 'id':
@@ -241,7 +251,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$query_result = array_reverse( $query_result );
 		}
 
-		// Pagination
+		// Pagination.
 		$this->total_terms = count( $query_result );
 		$query_result = array_slice( $query_result, $prepared_args['offset'], $prepared_args['number'] );
 
@@ -252,6 +262,8 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * Comparison function for sorting terms by a column.
 	 *
 	 * Uses `$this->sort_column` to determine field to sort by.
+	 *
+	 * @access protected
 	 *
 	 * @param stdClass $left Term object.
 	 * @param stdClass $right Term object.
@@ -270,7 +282,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to read a term.
+	 * Checks if a request has access to read the specified term.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -287,7 +299,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get a single term from a taxonomy
+	 * Gets a single term from a taxonomy.
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_REST_Request|WP_Error
@@ -308,7 +320,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to create a term
+	 * Checks if a request has access to create a term.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -328,7 +340,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Create a single term for a taxonomy
+	 * Creates a single term in a taxonomy.
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_REST_Request|WP_Error
@@ -351,9 +363,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$term = wp_insert_term( $prepared_term->name, $this->taxonomy, $prepared_term );
 		if ( is_wp_error( $term ) ) {
 
-			// If we're going to inform the client that the term exists, give them the identifier
-			// they can actually use.
-
+			/*
+			 * If we're going to inform the client that the term already exists,
+			 * give them the identifier for future use.
+			 */
 			if ( ( $term_id = $term->get_error_data( 'term_exists' ) ) ) {
 				$existing_term = get_term( $term_id, $this->taxonomy );
 				$term->add_data( $existing_term->term_id, 'term_exists' );
@@ -368,8 +381,8 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 * Fires after a single term is created or updated via the REST API.
 		 *
 		 * @param WP_Term         $term     Inserted Term object.
-		 * @param WP_REST_Request $request   Request object.
-		 * @param boolean         $creating  True when creating term, false when updating.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param boolean         $creating True when creating term, false when updating.
 		 */
 		do_action( "rest_insert_{$this->taxonomy}", $term, $request, true );
 
@@ -394,7 +407,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to update a term
+	 * Checks if a request has access to update the specified term.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -419,7 +432,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Update a single term from a taxonomy
+	 * Updates a single term from a taxonomy.
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_REST_Request|WP_Error
@@ -473,7 +486,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to delete a term
+	 * Checks if a request has access to delete the specified term.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -494,7 +507,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Delete a single term from a taxonomy
+	 * Deletes a single term from a taxonomy.
 	 *
 	 * @param WP_REST_Request $request Full details about the request
 	 * @return WP_REST_Response|WP_Error
@@ -503,7 +516,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
 
-		// We don't support trashing for this type, error out
+		// We don't support trashing for this resource type.
 		if ( ! $force ) {
 			return new WP_Error( 'rest_trash_not_supported', __( 'Resource does not support trashing.' ), array( 'status' => 501 ) );
 		}
@@ -530,7 +543,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepare a single term for create or update
+	 * Prepares a single term for create or update.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return object $prepared_term Term object.
@@ -567,7 +580,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		}
 
 		/**
-		 * Filter term data before inserting term via the REST API.
+		 * Filters term data before inserting term via the REST API.
 		 *
 		 * @param object          $prepared_term Term object.
 		 * @param WP_REST_Request $request       Request object.
@@ -576,10 +589,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepare a single term output for response
+	 * Prepares a single term output for response.
 	 *
-	 * @param obj $item Term object
-	 * @param WP_REST_Request $request
+	 * @param obj             $item    Term object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
@@ -623,7 +636,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$response->add_links( $this->prepare_links( $item ) );
 
 		/**
-		 * Filter a term item returned from the API.
+		 * Filters a term item returned from the API.
 		 *
 		 * Allows modification of the term data right before it is returned.
 		 *
@@ -635,7 +648,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Prepare links for the request.
+	 * Prepares links for the request.
 	 *
 	 * @param object $term Term object.
 	 * @return array Links for the given term.
@@ -644,13 +657,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$base = $this->namespace . '/' . $this->rest_base;
 		$links = array(
 			'self'       => array(
-				'href'       => rest_url( trailingslashit( $base ) . $term->term_id ),
+				'href' => rest_url( trailingslashit( $base ) . $term->term_id ),
 			),
 			'collection' => array(
-				'href'       => rest_url( $base ),
+				'href' => rest_url( $base ),
 			),
 			'about'      => array(
-				'href'       => rest_url( sprintf( 'wp/v2/taxonomies/%s', $this->taxonomy ) ),
+				'href' => rest_url( sprintf( 'wp/v2/taxonomies/%s', $this->taxonomy ) ),
 			),
 		);
 
@@ -688,29 +701,29 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the Term's schema, conforming to JSON Schema
+	 * Gets the term's schema, conforming to JSON Schema.
 	 *
 	 * @return array
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema'              => 'http://json-schema.org/draft-04/schema#',
-			'title'                => 'post_tag' === $this->taxonomy ? 'tag' : $this->taxonomy,
-			'type'                 => 'object',
-			'properties'           => array(
-				'id'               => array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'post_tag' === $this->taxonomy ? 'tag' : $this->taxonomy,
+			'type'       => 'object',
+			'properties' => array(
+				'id'          => array(
 					'description'  => __( 'Unique identifier for the resource.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view', 'embed', 'edit' ),
 					'readonly'     => true,
 				),
-				'count'            => array(
+				'count'       => array(
 					'description'  => __( 'Number of published posts for the resource.' ),
 					'type'         => 'integer',
 					'context'      => array( 'view', 'edit' ),
 					'readonly'     => true,
 				),
-				'description'      => array(
+				'description' => array(
 					'description'  => __( 'HTML description of the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'edit' ),
@@ -718,14 +731,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 						'sanitize_callback' => 'wp_filter_post_kses',
 					),
 				),
-				'link'             => array(
+				'link'        => array(
 					'description'  => __( 'URL to the resource.' ),
 					'type'         => 'string',
 					'format'       => 'uri',
 					'context'      => array( 'view', 'embed', 'edit' ),
 					'readonly'     => true,
 				),
-				'name'             => array(
+				'name'        => array(
 					'description'  => __( 'HTML title for the resource.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed', 'edit' ),
@@ -734,7 +747,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					),
 					'required'     => true,
 				),
-				'slug'             => array(
+				'slug'        => array(
 					'description'  => __( 'An alphanumeric identifier for the resource unique to its type.' ),
 					'type'         => 'string',
 					'context'      => array( 'view', 'embed', 'edit' ),
@@ -742,7 +755,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 						'sanitize_callback' => array( $this, 'sanitize_slug' ),
 					),
 				),
-				'taxonomy'         => array(
+				'taxonomy'    => array(
 					'description'  => __( 'Type attribution for the resource.' ),
 					'type'         => 'string',
 					'enum'         => array_keys( get_taxonomies() ),
@@ -765,7 +778,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the query params for collections
+	 * Gets the query params for collections.
 	 *
 	 * @return array
 	 */
@@ -776,42 +789,42 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$query_params['context']['default'] = 'view';
 
 		$query_params['exclude'] = array(
-			'description'        => __( 'Ensure result set excludes specific ids.' ),
-			'type'               => 'array',
-			'default'            => array(),
-			'sanitize_callback'  => 'wp_parse_id_list',
+			'description'       => __( 'Ensure result set excludes specific ids.' ),
+			'type'              => 'array',
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$query_params['include'] = array(
-			'description'        => __( 'Limit result set to specific ids.' ),
-			'type'               => 'array',
-			'default'            => array(),
-			'sanitize_callback'  => 'wp_parse_id_list',
+			'description'       => __( 'Limit result set to specific ids.' ),
+			'type'              => 'array',
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		if ( ! $taxonomy->hierarchical ) {
 			$query_params['offset'] = array(
-				'description'        => __( 'Offset the result set by a specific number of items.' ),
-				'type'               => 'integer',
-				'sanitize_callback'  => 'absint',
-				'validate_callback'  => 'rest_validate_request_arg',
+				'description'       => __( 'Offset the result set by a specific number of items.' ),
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
 			);
 		}
-		$query_params['order']      = array(
-			'description'           => __( 'Order sort attribute ascending or descending.' ),
-			'type'                  => 'string',
-			'sanitize_callback'     => 'sanitize_key',
-			'default'               => 'asc',
-			'enum'                  => array(
+		$query_params['order'] = array(
+			'description'       => __( 'Order sort attribute ascending or descending.' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_key',
+			'default'           => 'asc',
+			'enum'              => array(
 				'asc',
 				'desc',
 			),
-			'validate_callback'     => 'rest_validate_request_arg',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$query_params['orderby']    = array(
-			'description'           => __( 'Sort collection by resource attribute.' ),
-			'type'                  => 'string',
-			'sanitize_callback'     => 'sanitize_key',
-			'default'               => 'name',
-			'enum'                  => array(
+		$query_params['orderby'] = array(
+			'description'       => __( 'Sort collection by resource attribute.' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_key',
+			'default'           => 'name',
+			'enum'              => array(
 				'id',
 				'include',
 				'name',
@@ -820,38 +833,38 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'description',
 				'count',
 			),
-			'validate_callback'     => 'rest_validate_request_arg',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['hide_empty'] = array(
-			'description'           => __( 'Whether to hide resources not assigned to any posts.' ),
-			'type'                  => 'boolean',
-			'default'               => false,
-			'validate_callback'     => 'rest_validate_request_arg',
+			'description'       => __( 'Whether to hide resources not assigned to any posts.' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		if ( $taxonomy->hierarchical ) {
 			$query_params['parent'] = array(
-				'description'        => __( 'Limit result set to resources assigned to a specific parent.' ),
-				'type'               => 'integer',
-				'sanitize_callback'  => 'absint',
-				'validate_callback'  => 'rest_validate_request_arg',
+				'description'       => __( 'Limit result set to resources assigned to a specific parent.' ),
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
 			);
 		}
 		$query_params['post'] = array(
-			'description'           => __( 'Limit result set to resources assigned to a specific post.' ),
-			'type'                  => 'integer',
-			'default'               => null,
-			'validate_callback'     => 'rest_validate_request_arg',
+			'description'       => __( 'Limit result set to resources assigned to a specific post.' ),
+			'type'              => 'integer',
+			'default'           => null,
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$query_params['slug']    = array(
-			'description'        => __( 'Limit result set to resources with a specific slug.' ),
-			'type'               => 'string',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$query_params['slug'] = array(
+			'description'       => __( 'Limit result set to resources with a specific slug.' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $query_params;
 	}
 
 	/**
-	 * Check that the taxonomy is valid
+	 * Checks that the taxonomy is valid.
 	 *
 	 * @param string
 	 * @return WP_Error|boolean


### PR DESCRIPTION
I'm doing line reviews of some of the controllers, and I figured I may as well try to help with some coding standards and documentation standards cleanup as I go.

I realize this is a bit of an omnibus commit. If you'd prefer it broken up into smaller pieces (whitespace vs punctuation, etc), I'm glad to do so.
