### PR TITLE
Remove temporary fix for upstream bug 35614.

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -157,12 +157,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			unset( $count_args['offset'] );
 			$total_terms = wp_count_terms( $this->taxonomy, $count_args );
 
-			// Ensure we don't return results when offset is out of bounds
-			// see https://core.trac.wordpress.org/ticket/35935
-			if ( $prepared_args['offset'] >= $total_terms ) {
-				$query_result = array();
-			}
-
 			// wp_count_terms can return a falsy value when the term has no children
 			if ( ! $total_terms ) {
 				$total_terms = 0;


### PR DESCRIPTION
PR #2313 included a fix for a core bug that caused `get_terms()` to return
results when the `offset` parameter was greater than the total number
of terms available. This bug was fixed in WP 4.5 and the workaround in
WP-API is no longer needed.
