### PR TITLE
Correct copy pasta @see url in Posts Controller query args filter

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -162,7 +162,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * Enables adding extra arguments or setting defaults for a post
 		 * collection request.
 		 *
-		 * @see https://developer.wordpress.org/reference/classes/wp_user_query/
+		 * @see https://developer.wordpress.org/reference/classes/wp_query/
 		 *
 		 * @param array           $args    Key value array of query var to query value.
 		 * @param WP_REST_Request $request The request used.


### PR DESCRIPTION
The query args in the Posts Controller can be found at https://developer.wordpress.org/reference/classes/wp_query/  NOT https://developer.wordpress.org/reference/classes/wp_user_query/
