### PR TITLE
Remove wp_die in comment creation

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -360,11 +360,11 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$error_code = $prepared_comment['comment_approved']->get_error_code();
 			$error_message = $prepared_comment['comment_approved']->get_error_message();
 
-			if ( $error_code === 'comment_duplicate' ) {
+			if ( 'comment_duplicate' === $error_code ) {
 				return new WP_Error( $error_code, $error_message, array( 'status' => 409 ) );
 			}
 
-			if ( $error_code === 'comment_flood' ) {
+			if ( 'comment_flood' === $error_code ) {
 				return new WP_Error( $error_code, $error_message, array( 'status' => 400 ) );
 			}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -354,7 +354,22 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$prepared_comment['comment_agent'] = '';
-		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
+		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
+
+		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
+			$error_code = $prepared_comment['comment_approved']->get_error_code();
+			$error_message = $prepared_comment['comment_approved']->get_error_message();
+
+			if ( $error_code === 'comment_duplicate' ) {
+				return new WP_Error( $error_code, $error_message, array( 'status' => 409 ) );
+			}
+
+			if ( $error_code === 'comment_flood' ) {
+				return new WP_Error( $error_code, $error_message, array( 'status' => 400 ) );
+			}
+
+			return $prepared_comment['comment_approved'];
+		}
 
 		/**
 		 * Filter a comment before it is inserted via the REST API.

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1048,6 +1048,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_item_duplicate() {
+		global $wp_version;
 		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
 			return $this->markTestSkipped( 'WordPress version not supported.' );
 		}
@@ -1107,6 +1108,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_two_times() {
+		global $wp_version;
 		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
 			return $this->markTestSkipped( 'WordPress version not supported.' );
 		}

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1048,6 +1048,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_item_duplicate() {
+		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
+			return $this->markTestSkipped( 'WordPress version not supported.' );
+		}
+
 		$this->factory->comment->create(
 			array(
 				'comment_post_ID'      => $this->post_id,
@@ -1103,6 +1107,9 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_two_times() {
+		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
+			return $this->markTestSkipped( 'WordPress version not supported.' );
+		}
 
 		wp_set_current_user( 0 );
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1048,7 +1048,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_item_duplicate() {
-		$this->markTestSkipped( 'Needs to be revisited after wp_die handling is added' );
 		$this->factory->comment->create(
 			array(
 				'comment_post_ID'      => $this->post_id,
@@ -1104,8 +1103,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_two_times() {
-
-		$this->markTestSkipped( 'Needs to be revisited after wp_die handling is added' );
 
 		wp_set_current_user( 0 );
 


### PR DESCRIPTION
Solves https://github.com/WP-API/WP-API/issues/1660 and https://github.com/WP-API/WP-API/issues/1784

With https://core.trac.wordpress.org/ticket/36901 in core, we can now use `wp_allow_comment()` without running into `wp_die()` \o/
