### PR TITLE
Fill-in comment author data from the provided WP_User when possible

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -909,7 +909,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'context'      => array( 'view', 'edit', 'embed' ),
 					'arg_options'  => array(
 						'sanitize_callback' => 'sanitize_text_field',
-						'default'           => '',
 					),
 				),
 				'author_url'       => array(

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1152,6 +1152,23 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 'rest_comment_login_required', $data['code'] );
 	}
 
+	public function test_create_item_invalid_author() {
+		wp_set_current_user( $this->admin_id );
+
+		$params = array(
+			'post'         => $this->post_id,
+			'author'       => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+			'content'      => "It\'s all over\, people! We don\'t have a prayer!",
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_author_invalid', $response, 400 );
+	}
+
 	public function test_create_comment_two_times() {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -802,7 +802,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'author_name'  => 'Reverend Lovejoy',
 			'author_email' => 'lovejoy@example.com',
 			'author_url'   => 'http://timothylovejoy.jr',
-			'content'      => "It\'s all over\, people! We don\'t have a prayer!",
+			'content'      => 'It\'s all over\, people! We don\'t have a prayer!',
 			'date'         => rand_str(),
 		);
 
@@ -1166,7 +1166,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$params = array(
 			'post'         => $this->post_id,
 			'author'       => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
-			'content'      => "It\'s all over\, people! We don\'t have a prayer!",
+			'content'      => 'It\'s all over\, people! We don\'t have a prayer!',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
@@ -1184,7 +1184,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$params = array(
 			'post'         => $this->post_id,
 			'author'       => $this->author_id,
-			'content'      => "It\'s all over\, people! We don\'t have a prayer!",
+			'content'      => 'It\'s all over\, people! We don\'t have a prayer!',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );


### PR DESCRIPTION
If only the comment author UD (for a known author) is provided when creating a comment, the author's email and URL are not be properly filled in; ID should be sufficient to retrieve supporting author information. This patch uses the ID to retrieve the author's display name, email and URL when preparing a comment for the database.
- [x] Needs description
- [x] Needs tests

Fixes #2632
