### PR TITLE
Properly register "{taxonomy}_exclude" parameters in the schema

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1746,6 +1746,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 			);
+			$schema['properties'][ $base . '_exclude' ] = array(
+				'description' => sprintf( __( 'The terms in the %s taxonomy that should not be assigned to the object.' ), $taxonomy->name ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+			);
 		}
 
 		return $this->add_additional_fields_schema( $schema );

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1816,7 +1816,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 23, count( $properties ) );
+		$this->assertEquals( 25, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'comment_status', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
@@ -1839,7 +1839,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'type', $properties );
 		$this->assertArrayHasKey( 'tags', $properties );
+		$this->assertArrayHasKey( 'tags_exclude', $properties );
 		$this->assertArrayHasKey( 'categories', $properties );
+		$this->assertArrayHasKey( 'categories_exclude', $properties );
 	}
 
 	public function test_get_additional_field_registration() {


### PR DESCRIPTION
PR #2756 added an `_exclude` complement to every registered taxonomy query parameter method, e.g. `categories_exclude`, to permit an API consumer to list an array of term IDs with which returned posts should NOT be associated. However, that PR omitted the important step of registering the parameters on the schema! This PR does so.
