### PR TITLE
Exclude unsupported params in all controllers (extends #2770)

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -89,7 +89,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		//Make sure a search string is set in case the orderby is set to 'relevace'
+		// Make sure a search string is set in case the orderby is set to 'relevance'.
 		if ( ! empty( $request['orderby'] ) && 'relevance' === $request['orderby'] && empty( $request['search'] ) && empty( $request['filter']['s'] ) ) {
 			return new WP_Error( 'rest_no_search_term_defined', __( 'You need to define a search term to order by relevance.' ), array( 'status' => 400 ) );
 		}

--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -65,7 +65,11 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_items( $request ) {
-		if ( ! empty( $request['type'] ) ) {
+
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+
+		if ( isset( $registered['type'] ) && ! empty( $request['type'] ) ) {
 			$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
 		} else {
 			$taxonomies = get_taxonomies( '', 'objects' );

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -101,28 +101,50 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+
+		// This array defines mappings between public API query parameters whose
+		// values are accepted as-passed, and their internal WP_Query parameter
+		// name equivalents (some are the same). Only values which are also
+		// present in $registered will be set.
+		$parameter_mappings = array(
+			'exclude'  => 'exclude',
+			'include'  => 'include',
+			'order'    => 'order',
+			'per_page' => 'number',
+			'search'   => 'search',
+			'roles'    => 'role__in',
+		);
+
 		$prepared_args = array();
-		$prepared_args['exclude'] = $request['exclude'];
-		$prepared_args['include'] = $request['include'];
-		$prepared_args['order'] = $request['order'];
-		$prepared_args['number'] = $request['per_page'];
-		if ( ! empty( $request['offset'] ) ) {
+
+		// For each known parameter which is both registered and present in the request,
+		// set the parameter's value on the query $prepared_args.
+		foreach ( $parameter_mappings as $api_param => $wp_param ) {
+			if ( isset( $registered[ $api_param ] ) && isset( $request[ $api_param ] ) ) {
+				$prepared_args[ $wp_param ] = $request[ $api_param ];
+			}
+		}
+
+		if ( isset( $registered['offset'] ) && ! empty( $request['offset'] ) ) {
 			$prepared_args['offset'] = $request['offset'];
 		} else {
-			$prepared_args['offset'] = ( $request['page'] - 1 ) * $prepared_args['number'];
+			$prepared_args['offset']  = ( $request['page'] - 1 ) * $prepared_args['number'];
 		}
-		$orderby_possibles = array(
-			'id'              => 'ID',
-			'include'         => 'include',
-			'name'            => 'display_name',
-			'registered_date' => 'registered',
-			'slug'            => 'user_nicename',
-			'email'           => 'user_email',
-			'url'             => 'user_url',
-		);
-		$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
-		$prepared_args['search'] = $request['search'];
-		$prepared_args['role__in'] = $request['roles'];
+
+		if ( isset( $registered['orderby'] ) ) {
+			$orderby_possibles = array(
+				'id'              => 'ID',
+				'include'         => 'include',
+				'name'            => 'display_name',
+				'registered_date' => 'registered',
+				'slug'            => 'user_nicename',
+				'email'           => 'user_email',
+				'url'             => 'user_url',
+			);
+			$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
+		}
 
 		if ( ! current_user_can( 'list_users' ) ) {
 			$prepared_args['has_published_posts'] = true;
@@ -132,7 +154,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
 
-		if ( ! empty( $request['slug'] ) ) {
+		if ( isset( $registered['slug'] ) && ! empty( $request['slug'] ) ) {
 			$prepared_args['search'] = $request['slug'];
 			$prepared_args['search_columns'] = array( 'user_nicename' );
 		}


### PR DESCRIPTION
This is a PR against #2770, **not `develop`** , and extends the approach taken there to apply to all other controllers in which get_items assigns query properties from requests.
- [x] Attachments (No get_items defined, extends WP_REST_Posts_Controller)
- [x] Comments
- [x] Post Statuses (No change, get_items assigns no values from $request)
- [ ] Post Types (Needed? Only "context" is used)
- [ ] Revisions (Needed? Only "parent" is used, and it's part of the URL string)
- [x] Taxonomies
- [x] Terms
- [x] Users
