### PR TITLE
remove ununsed variable $post_type_obj

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -40,7 +40,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $ret;
 		}
 
-		$post_type_obj = get_post_type_object( $this->post_type );
 		if ( ! current_user_can( 'upload_files' ) ) {
 			return new WP_Error( 'rest_cannot_create', __( 'Sorry, you are not allowed to upload media on this site.' ), array( 'status' => 400 ) );
 		}


### PR DESCRIPTION
It removes following, because `$post_type_obj` isn't used.

```
$post_type_obj = get_post_type_object( $this->post_type );
```
