### PR TITLE
Use Yoda Condition checks, you must

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -596,7 +596,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$supports_trash = ( EMPTY_TRASH_DAYS > 0 );
-		if ( $post->post_type === 'attachment' ) {
+		if ( 'attachment' === $post->post_type ) {
 			$supports_trash = $supports_trash && MEDIA_TRASH;
 		}
 


### PR DESCRIPTION
Use Yoda Condition checks, you must
`$post->post_type === 'attachment'` in `delete_item()` in `class-wp-rest-posts-controller.php`
