### PR TITLE
Do not run revisions excerpts through get_the_excerpt

### DIFF
--- a/lib/endpoints/class-wp-rest-revisions-controller.php
+++ b/lib/endpoints/class-wp-rest-revisions-controller.php
@@ -392,7 +392,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	protected function prepare_excerpt_response( $excerpt, $post ) {
 
 		/** This filter is documented in wp-includes/post-template.php */
-		$excerpt = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $excerpt, $post ) );
+		$excerpt = apply_filters( 'the_excerpt', $excerpt, $post );
 
 		if ( empty( $excerpt ) ) {
 			return '';


### PR DESCRIPTION
Running revisions excerpts through `'get_the_excerpt'` leads to `get_the_content` being called in such a way that `$post` does not get set. This causes

```
<b>Notice</b>: Trying to get property of non-object in <b>/srv/www/wordpress-develop/src/wp-includes/post-template.php</b> on line <b>298</b>
```

to be printed out before the JSON, which prevents the JSON being properly interpreted by requesting clients, e.g. `$.get`.

@Shelob9 can you pull this down and test?
