### PR TITLE
Use wp_kses in place of wp_filter_post_kses to sanitize post title

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -825,9 +825,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		if ( ! empty( $schema['properties']['title'] ) && isset( $request['title'] ) ) {
 			if ( is_string( $request['title'] ) ) {
 				// wp_filter_kses slash handling is lossy: use the underlying methods directly
-				$prepared_post->post_title = wp_kses( $request['title'], current_filter() );
+				$prepared_post->post_title = wp_kses( $request['title'], 'title_save_pre' );
 			} elseif ( ! empty( $request['title']['raw'] ) ) {
-				$prepared_post->post_title = wp_kses( $request['title']['raw'], current_filter() );
+				$prepared_post->post_title = wp_kses( $request['title']['raw'], 'title_save_pre' );
 			}
 		}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -824,9 +824,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Post title.
 		if ( ! empty( $schema['properties']['title'] ) && isset( $request['title'] ) ) {
 			if ( is_string( $request['title'] ) ) {
-				$prepared_post->post_title = wp_filter_post_kses( $request['title'] );
+				// wp_filter_kses slash handling is lossy: use the underlying methods directly
+				$prepared_post->post_title = wp_kses( $request['title'], current_filter() );
 			} elseif ( ! empty( $request['title']['raw'] ) ) {
-				$prepared_post->post_title = wp_filter_post_kses( $request['title']['raw'] );
+				$prepared_post->post_title = wp_kses( $request['title']['raw'], current_filter() );
 			}
 		}
 

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -1275,6 +1275,45 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( "Rob O'Rourke's Diary", $new_data['title']['raw'] );
 	}
 
+	public function test_create_post_with_acceptable_html_in_title() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$params = $this->set_post_data( array(
+			'title' => 'An <em>Emphatic</em> Headline',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( 'An <em>Emphatic</em> Headline', $new_data['title']['raw'] );
+	}
+
+	public function test_create_post_with_unacceptable_html_in_title() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$params = $this->set_post_data( array(
+			'title' => 'A House <div>Divided</div>',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( 'A House Divided', $new_data['title']['raw'] );
+	}
+
+	public function test_create_post_with_backslashes_in_title() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$params = $this->set_post_data( array(
+			'title' => '\o/',
+		) );
+		$request->set_body_params( $params );
+		$response = $this->server->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertEquals( '\o/', $new_data['title']['raw'] );
+	}
+
 	public function test_create_post_with_categories() {
 		wp_set_current_user( $this->editor_id );
 		$category = wp_insert_term( 'Test Category', 'category' );


### PR DESCRIPTION
May fix #2788

This PR switches from using `wp_filter_post_kses()` for `post_title` sanitization to calling `wp_kses` directly: #2788 describes that the core behavior is to call `wp_filter_kses()`, but @westonruter notes in that thread that the slash handling in `wp_filter_kses` is lossy so using the underlying implementation of `wp_filter_kses` without the de-slashing and re-slashing should provide adequate sanitization without compromising the integrity of the content.

Review requested especially from @rachelbaker or @westonruter
