### PR TITLE
Use strict comparisons for in_array.

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -21,7 +21,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		}
 		if ( ! empty( $request['mime_type'] ) ) {
 			$parts = explode( '/', $request['mime_type'] );
-			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request['mime_type'], $media_types[ $parts[0] ] ), true ) {
+			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request['mime_type'], $media_types[ $parts[0] ], true ) ) {
 				$query_args['post_mime_type'] = $request['mime_type'];
 			}
 		}

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -12,16 +12,16 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
 		$query_args = parent::prepare_items_query( $prepared_args, $request );
-		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ) ) ) {
+		if ( empty( $query_args['post_status'] ) || ! in_array( $query_args['post_status'], array( 'inherit', 'private', 'trash' ), true ) ) {
 			$query_args['post_status'] = 'inherit';
 		}
 		$media_types = $this->get_media_types();
-		if ( ! empty( $request['media_type'] ) && in_array( $request['media_type'], array_keys( $media_types ) ) ) {
+		if ( ! empty( $request['media_type'] ) && in_array( $request['media_type'], array_keys( $media_types ), true ) ) {
 			$query_args['post_mime_type'] = $media_types[ $request['media_type'] ];
 		}
 		if ( ! empty( $request['mime_type'] ) ) {
 			$parts = explode( '/', $request['mime_type'] );
-			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request['mime_type'], $media_types[ $parts[0] ] ) ) {
+			if ( isset( $media_types[ $parts[0] ] ) && in_array( $request['mime_type'], $media_types[ $parts[0] ] ), true ) {
 				$query_args['post_mime_type'] = $request['mime_type'];
 			}
 		}
@@ -64,7 +64,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function create_item( $request ) {
 
-		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ) ) ) {
+		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ), true ) ) {
 			return new WP_Error( 'rest_invalid_param', __( 'Invalid parent type.' ), array( 'status' => 400 ) );
 		}
 
@@ -114,7 +114,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$id = wp_insert_post( $attachment, true );
 		if ( is_wp_error( $id ) ) {
-			if ( in_array( $id->get_error_code(), array( 'db_update_error' ) ) ) {
+			if ( in_array( $id->get_error_code(), array( 'db_update_error' ), true ) ) {
 				$id->add_data( array( 'status' => 500 ) );
 			} else {
 				$id->add_data( array( 'status' => 400 ) );
@@ -163,7 +163,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ) ) ) {
+		if ( ! empty( $request['post'] ) && in_array( get_post_type( $request['post'] ), array( 'revision', 'attachment' ), true ) ) {
 			return new WP_Error( 'rest_invalid_param', __( 'Invalid parent type.' ), array( 'status' => 400 ) );
 		}
 		$response = parent::update_item( $request );

--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -187,7 +187,7 @@ abstract class WP_REST_Controller {
 				continue;
 			}
 
-			if ( ! in_array( $context, $schema['properties'][ $key ]['context'] ) ) {
+			if ( ! in_array( $context, $schema['properties'][ $key ]['context'], true ) ) {
 				unset( $data[ $key ] );
 				continue;
 			}
@@ -197,7 +197,7 @@ abstract class WP_REST_Controller {
 					if ( empty( $details['context'] ) ) {
 						continue;
 					}
-					if ( ! in_array( $context, $details['context'] ) ) {
+					if ( ! in_array( $context, $details['context'], true ) ) {
 						if ( isset( $data[ $key ][ $attribute ] ) ) {
 							unset( $data[ $key ][ $attribute ] );
 						}

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -413,7 +413,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( is_wp_error( $post_id ) ) {
 
-			if ( in_array( $post_id->get_error_code(), array( 'db_insert_error' ) ) ) {
+			if ( in_array( $post_id->get_error_code(), array( 'db_insert_error' ), true ) ) {
 				$post_id->add_data( array( 'status' => 500 ) );
 			} else {
 				$post_id->add_data( array( 'status' => 400 ) );
@@ -526,7 +526,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// convert the post object to an array, otherwise wp_update_post will expect non-escaped input
 		$post_id = wp_update_post( (array) $post, true );
 		if ( is_wp_error( $post_id ) ) {
-			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ) ) ) {
+			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ), true ) ) {
 				$post_id->add_data( array( 'status' => 500 ) );
 			} else {
 				$post_id->add_data( array( 'status' => 400 ) );
@@ -1021,7 +1021,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @param integer $post_id
 	 */
 	public function handle_template( $template, $post_id ) {
-		if ( in_array( $template, array_keys( wp_get_theme()->get_page_templates( $this->get_post( $post_id ) ) ) ) ) {
+		if ( in_array( $template, array_keys( wp_get_theme()->get_page_templates( $this->get_post( $post_id ) ) ), true ) ) {
 			update_post_meta( $post_id, '_wp_page_template', $template );
 		} else {
 			update_post_meta( $post_id, '_wp_page_template', '' );
@@ -1375,7 +1375,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			),
 		);
 
-		if ( ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'author' ) )
+		if ( ( in_array( $post->post_type, array( 'post', 'page' ), true ) || post_type_supports( $post->post_type, 'author' ) )
 			&& ! empty( $post->post_author ) ) {
 			$links['author'] = array(
 				'href'       => rest_url( 'wp/v2/users/' . $post->post_author ),
@@ -1383,7 +1383,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		};
 
-		if ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'comments' ) ) {
+		if ( in_array( $post->post_type, array( 'post', 'page' ), true ) || post_type_supports( $post->post_type, 'comments' ) ) {
 			$replies_url = rest_url( 'wp/v2/comments' );
 			$replies_url = add_query_arg( 'post', $post->ID, $replies_url );
 			$links['replies'] = array(
@@ -1392,7 +1392,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( in_array( $post->post_type, array( 'post', 'page' ) ) || post_type_supports( $post->post_type, 'revisions' ) ) {
+		if ( in_array( $post->post_type, array( 'post', 'page' ), true ) || post_type_supports( $post->post_type, 'revisions' ) ) {
 			$links['version-history'] = array(
 				'href' => rest_url( trailingslashit( $base ) . $post->ID . '/revisions' ),
 			);
@@ -1413,7 +1413,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'embeddable' => true,
 			);
 		}
-		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
+		if ( ! in_array( $post->post_type, array( 'attachment', 'nav_menu_item', 'revision' ), true ) ) {
 			$attachments_url = rest_url( 'wp/v2/media' );
 			$attachments_url = add_query_arg( 'parent', $post->ID, $attachments_url );
 			$links['https://api.w.org/attachment'] = array(
@@ -1600,9 +1600,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			),
 		);
 		foreach ( $post_type_attributes as $attribute ) {
-			if ( isset( $fixed_schemas[ $this->post_type ] ) && ! in_array( $attribute, $fixed_schemas[ $this->post_type ] ) ) {
+			if ( isset( $fixed_schemas[ $this->post_type ] ) && ! in_array( $attribute, $fixed_schemas[ $this->post_type ], true ) ) {
 				continue;
-			} elseif ( ! in_array( $this->post_type, array_keys( $fixed_schemas ) ) && ! post_type_supports( $this->post_type, $attribute ) ) {
+			} elseif ( ! in_array( $this->post_type, array_keys( $fixed_schemas ), true ) && ! post_type_supports( $this->post_type, $attribute ) ) {
 				continue;
 			}
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -236,7 +236,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 * get_items() verifies that we don't have `include` set, and default
 		 * ordering is by `name`.
 		 */
-		if ( ! in_array( $prepared_args['orderby'], array( 'name', 'none', 'include' ) ) ) {
+		if ( ! in_array( $prepared_args['orderby'], array( 'name', 'none', 'include' ), true ) ) {
 			switch ( $prepared_args['orderby'] ) {
 				case 'id':
 					$this->sort_column = 'term_id';

--- a/plugin.php
+++ b/plugin.php
@@ -493,7 +493,7 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 			}
 		}
 
-		if ( in_array( $args['type'], array( 'numeric', 'integer' ) ) && ( isset( $args['minimum'] ) || isset( $args['maximum'] ) ) ) {
+		if ( in_array( $args['type'], array( 'numeric', 'integer' ), true ) && ( isset( $args['minimum'] ) || isset( $args['maximum'] ) ) ) {
 			if ( isset( $args['minimum'] ) && ! isset( $args['maximum'] ) ) {
 				if ( ! empty( $args['exclusiveMinimum'] ) && $value <= $args['minimum'] ) {
 					return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s must be greater than %2$d (exclusive)' ), $param, $args['minimum'] ) );

--- a/tests/class-wp-test-rest-post-type-controller-testcase.php
+++ b/tests/class-wp-test-rest-post-type-controller-testcase.php
@@ -187,7 +187,7 @@ abstract class WP_Test_REST_Post_Type_Controller_Testcase extends WP_Test_REST_C
 				$this->assertEquals( $links['up'][0]['href'], rest_url( 'wp/v2/' . $post_type->rest_base . '/' . $data['parent'] ) );
 			}
 
-			if ( ! in_array( $data['type'], array( 'attachment', 'nav_menu_item', 'revision' ) ) ) {
+			if ( ! in_array( $data['type'], array( 'attachment', 'nav_menu_item', 'revision' ), true ) ) {
 				$this->assertEquals( $links['https://api.w.org/attachment'][0]['href'], add_query_arg( 'parent', $data['id'], rest_url( 'wp/v2/media' ) ) );
 			}
 


### PR DESCRIPTION
Adds the strict argument to `in_array()` comparisons where safe to do so.

As WordPress can be somewhat inconsistent with the way it returns IDs, I've left them to be juggled in the unit tests.
