### PR TITLE
Breaking Change: Return empty taxonomy collections as JSON object, not array

### DIFF
--- a/lib/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/lib/endpoints/class-wp-rest-taxonomies-controller.php
@@ -83,6 +83,12 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			$tax = $this->prepare_response_for_collection( $tax );
 			$data[ $tax_type ] = $tax;
 		}
+
+		if ( empty( $data ) ) {
+			// Response should still be returned as a JSON object when it is empty.
+			$data = (object) $data;
+		}
+
 		return rest_ensure_response( $data );
 	}
 

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -46,11 +46,20 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
 
-	public function test_get_taxonomies_with_types() {
+	public function test_get_taxonomies_for_type() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
 		$request->set_param( 'type', 'post' );
 		$response = $this->server->dispatch( $request );
 		$this->check_taxonomies_for_type_response( 'post', $response );
+	}
+
+	public function test_get_taxonomies_for_invalid_type() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
+		$request->set_param( 'type', 'wingding' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( json_encode( $data ), '{}' );
 	}
 
 	public function test_get_item() {

--- a/tests/test-rest-taxonomies-controller.php
+++ b/tests/test-rest-taxonomies-controller.php
@@ -59,7 +59,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( json_encode( $data ), '{}' );
+		$this->assertEquals( '{}', json_encode( $data ) );
 	}
 
 	public function test_get_item() {


### PR DESCRIPTION
The response from `/wp/v2/taxonomies` is a JSON object, keyed with the name of each taxonomy. If you use the `?type=` query parameter to specify an object for which no taxonomies are available, or to specify an invalid type of object, the empty PHP `array()` will be rendered in JSON as `[]`.

To ensure that the type of this resource's response remains consistent this pull request casts empty arrays to a PHP object, which will be correctly rendered as `{}` in the response JSON.

Fixes #2803
