### PR TITLE
Only allow custom meta of types string, number and boolean

### DIFF
--- a/lib/fields/class-wp-rest-meta-fields.php
+++ b/lib/fields/class-wp-rest-meta-fields.php
@@ -286,6 +286,12 @@ abstract class WP_REST_Meta_Fields {
 					continue;
 				}
 
+				// Whitelist the supported types for types, as we don't want invalid types
+				// to be updated with arbitrary values that we can't do decent sanitizing for.
+				if ( ! in_array( $args['type'], array( 'number', 'string', 'boolean' ), true ) ) {
+					continue;
+				}
+
 				if ( $rest_args['single'] ) {
 					$rest_args['schema']['type'] = $args['type'];
 				} else {
@@ -293,6 +299,10 @@ abstract class WP_REST_Meta_Fields {
 					$rest_args['schema']['items'] = array(
 						'type' => $args['type'],
 					);
+				}
+			} else {
+				if ( ! in_array( $rest_args['schema']['type'], array( 'number', 'string', 'boolean' ), true ) ) {
+					continue;
 				}
 			}
 

--- a/tests/test-rest-post-meta-fields.php
+++ b/tests/test-rest-post-meta-fields.php
@@ -43,8 +43,16 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		));
 		register_meta( 'post', 'test_invalid_type', array(
 			'single' => true,
-			'type' => false,
+			'type' => 'mycomplexobject',
 			'show_in_rest' => true,
+		));
+		register_meta( 'post', 'test_invalid_type_in_schema', array(
+			'single' => true,
+			'show_in_rest' => array(
+				'schema' => array(
+					'type' => 'mycomplexobject',
+				),
+			),
 		));
 
 		/** @var WP_REST_Server $wp_rest_server */
@@ -607,6 +615,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$this->assertArrayNotHasKey( 'test_no_rest', $meta_schema );
 		$this->assertArrayNotHasKey( 'test_rest_disabled', $meta_schema );
 		$this->assertArrayNotHasKey( 'test_invalid_type', $meta_schema );
+		$this->assertArrayNotHasKey( 'test_invalid_type_in_schema', $meta_schema );
 	}
 
 	/**


### PR DESCRIPTION
Currently we handle registering meta even if your register the type as
anything other than `boolean` `number` and `string`, however we don't
currently have great ways to handle non-scaler meta. For now, let's
whitelist these types and throw a `doing_it_wrong` if meta is registered
with an invalid type.
