### PR TITLE
Send an error if the client tries to delete an option with an non-scalar

### DIFF
--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -123,7 +123,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 				if ( ! is_scalar( get_option( $args['option_name'], false ) ) ) {
 					return new WP_Error(
 						'rest_invalid_stored_value',
-						sprintf( __( 'The %s property has an invalid stored value, and was not able to be updated to null.' ), $name ),
+						sprintf( __( 'The %s property has an invalid stored value, and cannot be updated to null.' ), $name ),
 						array( 'status' => 500 )
 					);
 				}

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -70,6 +70,11 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	protected function prepare_value( $value, $schema ) {
+		// if the value is not a scaler, it's not possible to cast it to anything.
+		if ( ! is_scalar( $value ) ) {
+			return null;
+		}
+
 		switch ( $schema['type'] ) {
 			case 'string':
 				return strval( $value );

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -70,7 +70,8 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	protected function prepare_value( $value, $schema ) {
-		// if the value is not a scaler, it's not possible to cast it to anything.
+		// If the value is not a scalar, it's not possible to cast it to
+		// anything.
 		if ( ! is_scalar( $value ) ) {
 			return null;
 		}

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -103,7 +103,19 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 			}
 			// A null value means reset the option, which is essentially deleting it
 			// from the database and then relying on the default value.
+			//
+			// However, bacause a saved "invalid" value in the database will
+			// cause a null in the response to the client, we only allow deleting of
+			// options that have a scalar value. Otherwise, sending the response back to
+			// the server will cause a delete of all invalid options.
 			if ( is_null( $request[ $name ] ) ) {
+				if ( ! is_scalar( get_option( $args['option_name'], false ) ) ) {
+					return new WP_Error(
+						'rest_invalid_stored_value',
+						sprintf( __( 'The %s property has an invalid stored value, and was not able to be updated to null.' ), $name ),
+						array( 'status' => 500 )
+					);
+				}
 				delete_option( $args['option_name'] );
 			} else {
 				update_option( $args['option_name'], $request[ $name ] );

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -101,14 +101,24 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 			if ( ! array_key_exists( $name, $params ) ) {
 				continue;
 			}
-			// A null value means reset the option, which is essentially deleting it
-			// from the database and then relying on the default value.
-			//
-			// However, bacause a saved "invalid" value in the database will
-			// cause a null in the response to the client, we only allow deleting of
-			// options that have a scalar value. Otherwise, sending the response back to
-			// the server will cause a delete of all invalid options.
+
+			/**
+			* A `null` value for an option would have the same effect as
+			* deleting the option from the database, and relying on the
+			* default value.
+			*/
 			if ( is_null( $request[ $name ] ) ) {
+				/**
+				 * A `null` value is returned in the response for any option
+				 * that has a non-scalar value.
+				 *
+				 * To protect clients from accidentally including the `null`
+				 * values from a response object in a request, we do not allow
+				 * options with non-scalar values to be updated to `null`.
+				 * Without this added protection a client could mistakenly
+				 * delete all options that have non-scalar values from the
+				 * database.
+				 */
 				if ( ! is_scalar( get_option( $args['option_name'], false ) ) ) {
 					return new WP_Error(
 						'rest_invalid_stored_value',

--- a/tests/test-rest-settings-controller.php
+++ b/tests/test-rest-settings-controller.php
@@ -104,6 +104,50 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		unregister_setting( 'somegroup', 'mycustomsetting' );
 	}
 
+	public function test_get_item_with_invalid_value_array_in_options() {
+		wp_set_current_user( $this->administrator );
+
+		register_setting( 'somegroup', 'mycustomsetting', array(
+			'show_in_rest' => array(
+				'name'   => 'mycustomsettinginrest',
+				'schema' => array(
+					'enum'    => array( 'validvalue1', 'validvalue2' ),
+					'default' => 'validvalue1',
+				),
+			),
+			'type'         => 'string',
+		) );
+
+		update_option( 'mycustomsetting', array( 'A sneaky array!' ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( null, $data['mycustomsettinginrest'] );
+	}
+
+	public function test_get_item_with_invalid_object_array_in_options() {
+		wp_set_current_user( $this->administrator );
+
+		register_setting( 'somegroup', 'mycustomsetting', array(
+			'show_in_rest' => array(
+				'name'   => 'mycustomsettinginrest',
+				'schema' => array(
+					'enum'    => array( 'validvalue1', 'validvalue2' ),
+					'default' => 'validvalue1',
+				),
+			),
+			'type'         => 'string',
+		) );
+
+		update_option( 'mycustomsetting', (object) array( 'A sneaky array!' ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( null, $data['mycustomsettinginrest'] );
+	}
+
 	public function test_create_item() {
 	}
 

--- a/tests/test-rest-settings-controller.php
+++ b/tests/test-rest-settings-controller.php
@@ -187,6 +187,23 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 10, $data['posts_per_page'] );
 	}
 
+	public function test_update_item_with_invalid_stored_value_in_options() {
+		wp_set_current_user( $this->administrator );
+
+		register_setting( 'somegroup', 'mycustomsetting', array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+		) );
+		update_option( 'mycustomsetting', array( 'A sneaky array!' ) );
+
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
+		$request->set_param( 'mycustomsetting', null );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_stored_value', $response, 500 );
+	}
+
 	public function test_delete_item() {
 	}
 


### PR DESCRIPTION
This is to cover the case when there is an invalid option value in the database that does not match the one in register_setting(). 

Currently we are only doing this check for setting values to `null` to work around the Client-sends-the-same-response issue, but we _do_ all setting the value to some other value.
