### PR TITLE
Remove "validate_callback" on arrays where it's not used.

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -1073,20 +1073,17 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'description'       => __( 'Limit result set to comments assigned to specific user ids. Requires authorization.' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'type'              => 'array',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['author_exclude'] = array(
 			'description'       => __( 'Ensure result set excludes comments assigned to specific user ids. Requires authorization.' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'type'              => 'array',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['author_email'] = array(
 			'default'           => null,
 			'description'       => __( 'Limit result set to that from a specific author email. Requires authorization.' ),
 			'format'            => 'email',
 			'sanitize_callback' => 'sanitize_email',
-			'validate_callback' => 'rest_validate_request_arg',
 			'type'              => 'string',
 		);
 		$query_params['before'] = array(
@@ -1100,14 +1097,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'type'               => 'array',
 			'default'            => array(),
 			'sanitize_callback'  => 'wp_parse_id_list',
-			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		$query_params['include'] = array(
 			'description'        => __( 'Limit result set to specific ids.' ),
 			'type'               => 'array',
 			'default'            => array(),
 			'sanitize_callback'  => 'wp_parse_id_list',
-			'validate_callback'  => 'rest_validate_request_arg',
 		);
 		$query_params['karma'] = array(
 			'default'           => null,
@@ -1154,21 +1149,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'description'       => __( 'Limit result set to resources of specific parent ids.' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'type'              => 'array',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['parent_exclude'] = array(
 			'default'           => array(),
 			'description'       => __( 'Ensure result set excludes specific parent ids.' ),
 			'sanitize_callback' => 'wp_parse_id_list',
 			'type'              => 'array',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['post']   = array(
 			'default'           => array(),
 			'description'       => __( 'Limit result set to resources assigned to specific post ids.' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['status'] = array(
 			'default'           => 'approve',

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1801,14 +1801,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'type'                => 'array',
 				'default'             => array(),
 				'sanitize_callback'   => 'wp_parse_id_list',
-				'validate_callback'   => 'rest_validate_request_arg',
 			);
 			$params['author_exclude'] = array(
 				'description'         => __( 'Ensure result set excludes posts assigned to specific authors.' ),
 				'type'                => 'array',
 				'default'             => array(),
 				'sanitize_callback'   => 'wp_parse_id_list',
-				'validate_callback'   => 'rest_validate_request_arg',
 			);
 		}
 		$params['before'] = array(


### PR DESCRIPTION
Currently we are specify teh `validate_callback` for the number-list
style params that are passed to `wp_parse_id_list()`, however, the
validate callback never does anything here, as our validate callback
doesn't handle array. When we _do_ support arrays, we won't be able to
use it here anyway, as these are "special" params that are not really
arrays, but in stread comma seperated strings that are converted to
arrays.
