### PR TITLE
Disable the schema sanitization on content / excerpt / title polymorphics

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -953,6 +953,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					'description'     => __( 'The content for the object.' ),
 					'type'            => 'object',
 					'context'         => array( 'view', 'edit', 'embed' ),
+					'arg_options' => array(
+						'sanitize_callback' => null,
+					),
 					'properties'      => array(
 						'raw'         => array(
 							'description'     => __( 'Content for the object, as it exists in the database.' ),

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1613,6 +1613,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 						'description' => __( 'The title for the object.' ),
 						'type'        => 'object',
 						'context'     => array( 'view', 'edit', 'embed' ),
+						'arg_options' => array(
+							'sanitize_callback' => null,
+						),
 						'properties'  => array(
 							'raw' => array(
 								'description' => __( 'Title for the object, as it exists in the database.' ),
@@ -1634,6 +1637,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 						'description' => __( 'The content for the object.' ),
 						'type'        => 'object',
 						'context'     => array( 'view', 'edit' ),
+						'arg_options' => array(
+							'sanitize_callback' => null,
+						),
 						'properties'  => array(
 							'raw' => array(
 								'description' => __( 'Content for the object, as it exists in the database.' ),
@@ -1669,6 +1675,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 						'description' => __( 'The excerpt for the object.' ),
 						'type'        => 'object',
 						'context'     => array( 'view', 'edit', 'embed' ),
+						'arg_options' => array(
+							'sanitize_callback' => null,
+						),
 						'properties'  => array(
 							'raw' => array(
 								'description' => __( 'Excerpt for the object, as it exists in the database.' ),


### PR DESCRIPTION
These values are polymorphic, so we can't do any smart sanitization
based off the schema (this sanitization is already implemented in the
`prepare_item_for_database()` function). We'll be supporting deep object
and array validation from the schema at some point, where we won't want
the schema validation for these polymorphic fields.

It only happens that we _dont_ validate / sanitize fields of type object
right now that these slip through the net.
