### PR TITLE
Comments: Check discussion option setting for name & email during create validation

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -189,8 +189,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
 			if ( empty( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
 				return new WP_Error( 'rest_require_valid_comment', __( 'Required fields (name, email) missing.' ), array( 'status' => 400 ) );
-			} elseif ( ! is_email( $prepared_comment['comment_author_email'] ) ) {
-				return new WP_Error( 'rest_require_valid_comment', __( 'Valid email address required.' ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -181,6 +181,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
 		}
 
+		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
+			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || '' == $prepared_comment['comment_author'] ) {
+				return new WP_Error( 'rest_require_name_email', __( 'Required fields (name, email) missing.' ), array( 'status' => 500 ) );
+			} elseif ( ! is_email( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error( 'rest_require_valid_email', __( 'Valid email address required.' ), array( 'status' => 500 ) );
+			}
+		}
+
 		/**
 		 * Filter a comment before it is inserted via the REST API.
 		 *

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -184,14 +184,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		/**
 		 * Filter a comment before it is inserted via the REST API.
 		 *
-		 * Allows modification of the comment right before it is inserted via `wp_insert_comment`.
+		 * Allows modification of the comment right before it is inserted via `wp_new_comment`.
 		 *
-		 * @param array           $prepared_comment The prepared comment data for `wp_insert_comment`.
+		 * @param array           $prepared_comment The prepared comment data for `wp_new_comment`.
 		 * @param WP_REST_Request $request          Request used to insert the comment.
 		 */
 		$prepared_comment = apply_filters( 'rest_pre_insert_comment', $prepared_comment, $request );
 
-		$comment_id = wp_insert_comment( $prepared_comment );
+		$comment_id = wp_new_comment( $prepared_comment );
 		if ( ! $comment_id ) {
 			return new WP_Error( 'rest_comment_failed_create', __( 'Creating comment failed.' ), array( 'status' => 500 ) );
 		}

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -147,7 +147,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_comment = $this->prepare_item_for_database( $request );
 
-		// Check that comment has content
+		// Check that comment has content.
 		if ( empty( $prepared_comment['comment_content'] ) ) {
 			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 400 ) );
 		}
@@ -161,7 +161,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_comment['comment_date'] = current_time( 'mysql' );
 		}
 
-		// Set author data if the user's logged in
+		// Set author data if the user's logged in.
 		$missing_author = empty( $prepared_comment['user_id'] )
 			&& empty( $prepared_comment['comment_author'] )
 			&& empty( $prepared_comment['comment_author_email'] )
@@ -185,7 +185,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment['comment_agent'] = '';
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
-		// Check author name and email if required
+		// Check author name and email if required.
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
 			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
 				return new WP_Error( 'rest_require_valid_comment', __( 'Required fields (name, email) missing.' ), array( 'status' => 400 ) );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -177,6 +177,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment['comment_agent'] = '';
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
+		if ( '' == $prepared_comment['comment_content'] ) {
+			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
+		}
+
 		/**
 		 * Filter a comment before it is inserted via the REST API.
 		 *

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -148,7 +148,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment = $this->prepare_item_for_database( $request );
 
 		// Check that comment has content
-		if ( '' == $prepared_comment['comment_content'] ) {
+		if ( empty( $prepared_comment['comment_content'] ) ) {
 			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
 		}
 
@@ -158,7 +158,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_comment['comment_date_gmt'] = current_time( 'mysql', true );
 		}
 		if ( empty( $prepared_comment['comment_date'] ) ) {
-			$prepared_comment['comment_date'] = current_time('mysql');
+			$prepared_comment['comment_date'] = current_time( 'mysql' );
 		}
 
 		// Set author data if the user's logged in
@@ -187,7 +187,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		// Check author name and email if required
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
-			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || '' == $prepared_comment['comment_author'] ) {
+			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
 				return new WP_Error( 'rest_require_name_email', __( 'Required fields (name, email) missing.' ), array( 'status' => 500 ) );
 			} elseif ( ! is_email( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_require_valid_email', __( 'Valid email address required.' ), array( 'status' => 500 ) );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -192,14 +192,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		/**
 		 * Filter a comment before it is inserted via the REST API.
 		 *
-		 * Allows modification of the comment right before it is inserted via `wp_new_comment`.
+		 * Allows modification of the comment right before it is inserted via `wp_insert_comment`.
 		 *
-		 * @param array           $prepared_comment The prepared comment data for `wp_new_comment`.
+		 * @param array           $prepared_comment The prepared comment data for `wp_insert_comment`.
 		 * @param WP_REST_Request $request          Request used to insert the comment.
 		 */
 		$prepared_comment = apply_filters( 'rest_pre_insert_comment', $prepared_comment, $request );
 
-		$comment_id = wp_new_comment( $prepared_comment );
+		$comment_id = wp_insert_comment( $prepared_comment );
 		if ( ! $comment_id ) {
 			return new WP_Error( 'rest_comment_failed_create', __( 'Creating comment failed.' ), array( 'status' => 500 ) );
 		}

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -147,10 +147,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_comment = $this->prepare_item_for_database( $request );
 
+		// Check that comment has content
+		if ( '' == $prepared_comment['comment_content'] ) {
+			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
+		}
+
 		// Setting remaining values before wp_insert_comment so we can
 		// use wp_allow_comment().
-		if ( ! isset( $prepared_comment['comment_date_gmt'] ) ) {
+		if ( empty( $prepared_comment['comment_date_gmt'] ) ) {
 			$prepared_comment['comment_date_gmt'] = current_time( 'mysql', true );
+		}
+		if ( empty( $prepared_comment['comment_date'] ) ) {
+			$prepared_comment['comment_date'] = current_time('mysql');
 		}
 
 		// Set author data if the user's logged in
@@ -177,10 +185,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$prepared_comment['comment_agent'] = '';
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
-		if ( '' == $prepared_comment['comment_content'] ) {
-			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
-		}
-
+		// Check author name and email if required
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
 			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || '' == $prepared_comment['comment_author'] ) {
 				return new WP_Error( 'rest_require_name_email', __( 'Required fields (name, email) missing.' ), array( 'status' => 500 ) );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -149,7 +149,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		// Check that comment has content
 		if ( empty( $prepared_comment['comment_content'] ) ) {
-			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 500 ) );
+			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 400 ) );
 		}
 
 		// Setting remaining values before wp_insert_comment so we can
@@ -188,9 +188,9 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		// Check author name and email if required
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
 			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
-				return new WP_Error( 'rest_require_name_email', __( 'Required fields (name, email) missing.' ), array( 'status' => 500 ) );
+				return new WP_Error( 'rest_require_valid_comment', __( 'Required fields (name, email) missing.' ), array( 'status' => 400 ) );
 			} elseif ( ! is_email( $prepared_comment['comment_author_email'] ) ) {
-				return new WP_Error( 'rest_require_valid_email', __( 'Valid email address required.' ), array( 'status' => 500 ) );
+				return new WP_Error( 'rest_require_valid_comment', __( 'Valid email address required.' ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -187,7 +187,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		// Check author name and email if required.
 		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
-			if ( 6 > strlen( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
+			if ( empty( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
 				return new WP_Error( 'rest_require_valid_comment', __( 'Required fields (name, email) missing.' ), array( 'status' => 400 ) );
 			} elseif ( ! is_email( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_require_valid_comment', __( 'Valid email address required.' ), array( 'status' => 400 ) );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -410,9 +410,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Check author name and email if required.
-		if ( get_option( 'require_name_email' ) && ! isset( $user ) ) {
-			if ( empty( $prepared_comment['comment_author_email'] ) || empty( $prepared_comment['comment_author'] ) ) {
-				return new WP_Error( 'rest_require_valid_comment', __( 'Required fields (name, email) missing.' ), array( 'status' => 400 ) );
+		if ( get_option( 'require_name_email' ) && ! isset( $prepared_comment['comment_author'] ) ) {
+			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );
+			} elseif ( ! isset( $prepared_comment['comment_author'] ) ) {
+				return new WP_Error( 'rest_comment_author_required', __( 'Creating a comment requires a valid author name.' ), array( 'status' => 400 ) );
+			} elseif ( ! isset( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error( 'rest_comment_author_email_required', __( 'Creating a comment requires a valid author email.' ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -410,7 +410,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Check author name and email if required.
-		if ( get_option( 'require_name_email' ) && ! isset( $prepared_comment['comment_author'] ) ) {
+		if ( get_option( 'require_name_email' ) ) {
 			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );
 			} elseif ( ! isset( $prepared_comment['comment_author'] ) ) {

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -384,6 +384,17 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_comment['comment_author_url'] = $user->user_url;
 		}
 
+		// Check author name and email if required.
+		if ( get_option( 'require_name_email' ) ) {
+			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );
+			} elseif ( ! isset( $prepared_comment['comment_author'] ) ) {
+				return new WP_Error( 'rest_comment_author_required', __( 'Creating a comment requires a valid author name.' ), array( 'status' => 400 ) );
+			} elseif ( ! isset( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error( 'rest_comment_author_email_required', __( 'Creating a comment requires a valid author email.' ), array( 'status' => 400 ) );
+			}
+		}
+
 		if ( ! isset( $prepared_comment['comment_author_email'] ) ) {
 			$prepared_comment['comment_author_email'] = '';
 		}
@@ -407,17 +418,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			}
 
 			return $prepared_comment['comment_approved'];
-		}
-
-		// Check author name and email if required.
-		if ( get_option( 'require_name_email' ) ) {
-			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
-				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );
-			} elseif ( ! isset( $prepared_comment['comment_author'] ) ) {
-				return new WP_Error( 'rest_comment_author_required', __( 'Creating a comment requires a valid author name.' ), array( 'status' => 400 ) );
-			} elseif ( ! isset( $prepared_comment['comment_author_email'] ) ) {
-				return new WP_Error( 'rest_comment_author_email_required', __( 'Creating a comment requires a valid author email.' ), array( 'status' => 400 ) );
-			}
 		}
 
 		/**

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -364,11 +364,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_comment_content_invalid', __( 'Comment content is invalid.' ), array( 'status' => 400 ) );
 		}
 
-		// Check that comment has content.
-		if ( empty( $prepared_comment['comment_content'] ) ) {
-			return new WP_Error( 'rest_require_valid_comment', __( 'Comment content required.' ), array( 'status' => 400 ) );
-		}
-
 		// Setting remaining values before wp_insert_comment so we can
 		// use wp_allow_comment().
 		if ( ! isset( $prepared_comment['comment_date_gmt'] ) ) {

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -384,7 +384,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_comment['comment_author_url'] = $user->user_url;
 		}
 
-		// Check author name and email if required.
+		// Honor the discussion setting that requires a name and email address
+		// of the comment author.
 		if ( get_option( 'require_name_email' ) ) {
 			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );

--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -388,9 +388,11 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( get_option( 'require_name_email' ) ) {
 			if ( ! isset( $prepared_comment['comment_author'] ) && ! isset( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_comment_author_data_required', __( 'Creating a comment requires valid author name and email values.' ), array( 'status' => 400 ) );
-			} elseif ( ! isset( $prepared_comment['comment_author'] ) ) {
+			}
+			if ( ! isset( $prepared_comment['comment_author'] ) ) {
 				return new WP_Error( 'rest_comment_author_required', __( 'Creating a comment requires a valid author name.' ), array( 'status' => 400 ) );
-			} elseif ( ! isset( $prepared_comment['comment_author_email'] ) ) {
+			}
+			if ( ! isset( $prepared_comment['comment_author_email'] ) ) {
 				return new WP_Error( 'rest_comment_author_email_required', __( 'Creating a comment requires a valid author email.' ), array( 'status' => 400 ) );
 			}
 		}

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -1006,7 +1006,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments/' . $this->approved_id );
 		$request->set_body_params(array(
 			'my_custom_int' => 123,
-			'content' => 'abc',
+			'content'       => 'abc',
 		));
 
 		wp_set_current_user( 1 );
@@ -1016,8 +1016,11 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->set_body_params(array(
 			'my_custom_int' => 123,
-			'title' => 'hello',
-			'post' => $this->post_id,
+			'title'         => 'hello',
+			'post'          => $this->post_id,
+			'content'       => 'abc2',
+			'author_name'   => 'Comic Book Guy',
+			'author_email'  => 'cbg@androidsdungeon.com',
 		));
 
 		$response = $this->server->dispatch( $request );

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -625,6 +625,41 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 201, $response->get_status() );
 	}
 
+	public function test_create_comment_without_content() {
+		wp_set_current_user( $this->subscriber_id );
+
+		$params = array(
+			'post'         => $this->post_id,
+			'author_name'  => 'Homer Jay Simpson',
+			'author_email' => 'chunkylover53@aol.com',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_require_valid_comment', $response, 400 );
+	}
+
+	public function test_create_comment_without_author() {
+		add_filter('comment_flood_filter', '__return_false');
+		wp_set_current_user( 0 );
+		update_option( 'require_name_email', 1 );
+
+		$params = array(
+			'post'    => $this->post_id,
+			'content' => 'No TV and no beer makes Homer something something.',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_require_valid_comment', $response, 400 );
+	}
+
 	public function test_create_item_duplicate() {
 		$this->markTestSkipped( 'Needs to be revisited after wp_die handling is added' );
 		$original_id = $this->factory->comment->create(

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -643,7 +643,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_without_author() {
-		add_filter('comment_flood_filter', '__return_false');
+		add_filter( 'comment_flood_filter', '__return_false' );
 		wp_set_current_user( 0 );
 		update_option( 'require_name_email', 1 );
 

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -775,6 +775,62 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( $params['content']['raw'], $new_comment->comment_content );
 	}
 
+	public function test_create_comment_missing_required_author_name_and_email_per_option_value() {
+		update_option( 'require_name_email', 1 );
+
+		$params = array(
+			'post'    => $this->post_id,
+			'content' => 'Now, I don\'t want you to worry class. These tests will have no affect on your grades. They merely determine your future social status and financial success. If any.',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_author_data_required', $response, 400 );
+
+		update_option( 'require_name_email', 0 );
+	}
+
+	public function test_create_comment_missing_required_author_name_per_option_value() {
+		update_option( 'require_name_email', 1 );
+
+		$params = array(
+			'post'         => $this->post_id,
+			'author_email' => 'ekrabappel@springfield-elementary.edu',
+			'content'      => 'Now, I don\'t want you to worry class. These tests will have no affect on your grades. They merely determine your future social status and financial success. If any.',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_author_required', $response, 400 );
+
+		update_option( 'require_name_email', 0 );
+	}
+
+	public function test_create_comment_missing_required_author_email_per_option_value() {
+		update_option( 'require_name_email', 1 );
+
+		$params = array(
+			'post'        => $this->post_id,
+			'author_name' => 'Edna Krabappel',
+			'content'     => 'Now, I don\'t want you to worry class. These tests will have no affect on your grades. They merely determine your future social status and financial success. If any.',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_author_email_required', $response, 400 );
+
+		update_option( 'require_name_email', 0 );
+	}
+
 	public function test_create_item_invalid_blank_content() {
 		wp_set_current_user( 0 );
 


### PR DESCRIPTION
Adds a conditional check to the `create_item()` method in the Comments Controller for the `require_name_email` option.  When this option value is set to `1` comments should not be created without values for the name or email address of the comment author. 

Replaces #2049
