### PR TITLE
Settings: Add filters to override getting and updating the values of settings

### DIFF
--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -114,6 +114,26 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 			if ( ! array_key_exists( $name, $params ) ) {
 				continue;
 			}
+
+			/**
+			 * Filters whether to preempt a setting value update.
+			 *
+			 * Allow hijacking the setting update logic and overriding the built-in behavior by
+			 * returning true.
+			 *
+			 * @since 4.7.0
+			 *
+			 * @param boolean $result Whether to override the default behavior for updating the
+			 *                        value of a setting.
+			 * @param string  $name   Setting name (as shown in REST API responses).
+			 * @param mixed   $value  Updated setting value.
+			 * @param array   $args   Arguments passed to `register_setting()` for this setting.
+			 */
+			$updated = apply_filters( 'rest_update_setting', false, $name, $request[ $name ], $args );
+			if ( $updated ) {
+				continue;
+			}
+
 			// A null value means reset the option, which is essentially deleting it
 			// from the database and then relying on the default value.
 			if ( is_null( $request[ $name ] ) ) {

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -65,7 +65,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 			 * @param string $name    Setting name (as shown in REST API responses).
 			 * @param array  $args    Arguments passed to `register_setting()` for this setting.
 			 */
-			$response[ $name ] = apply_filters( 'rest_get_setting', null, $name, $args );
+			$response[ $name ] = apply_filters( 'rest_pre_get_setting', null, $name, $args );
 
 			if ( is_null( $response[ $name ] ) ) {
 				// Default to a null value as "null" in the response means "not set".
@@ -129,7 +129,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 			 * @param mixed   $value  Updated setting value.
 			 * @param array   $args   Arguments passed to `register_setting()` for this setting.
 			 */
-			$updated = apply_filters( 'rest_update_setting', false, $name, $request[ $name ], $args );
+			$updated = apply_filters( 'rest_pre_update_setting', false, $name, $request[ $name ], $args );
 			if ( $updated ) {
 				continue;
 			}

--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -51,8 +51,26 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 		$response = array();
 
 		foreach ( $options as $name => $args ) {
-			// Default to a null value as "null" in the response means "not set".
-			$response[ $name ] = get_option( $args['option_name'], $args['schema']['default'] );
+			/**
+			 * Filters the value of a setting recognized by the REST API.
+			 *
+			 * Allow hijacking the setting value and overriding the built-in behavior by returning a
+			 * non-null value.  The returned value will be presented as the setting value instead.
+			 *
+			 * @since 4.7.0
+			 *
+			 * @param mixed  $result  Value to use for the requested setting. Can be a scalar
+			 *                        matching the registered schema for the setting, or null to
+			 *                        follow the default `get_option` behavior.
+			 * @param string $name    Setting name (as shown in REST API responses).
+			 * @param array  $args    Arguments passed to `register_setting()` for this setting.
+			 */
+			$response[ $name ] = apply_filters( 'rest_get_setting', null, $name, $args );
+
+			if ( is_null( $response[ $name ] ) ) {
+				// Default to a null value as "null" in the response means "not set".
+				$response[ $name ] = get_option( $args['option_name'], $args['schema']['default'] );
+			}
 
 			// Because get_option() is lossy, we have to
 			// cast values to the type they are registered with.

--- a/tests/test-rest-settings-controller.php
+++ b/tests/test-rest-settings-controller.php
@@ -166,7 +166,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function update_setting_custom_callback( $result, $name, $value, $args ) {
-		if ( $name === 'title' && $value === 'The new title!' ) {
+		if ( 'title' === $name && 'The new title!' === $value ) {
 			// Do not allow changing the title in this case
 			return true;
 		}

--- a/tests/test-rest-settings-controller.php
+++ b/tests/test-rest-settings-controller.php
@@ -115,7 +115,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_item_with_filter() {
 		wp_set_current_user( $this->administrator );
 
-		add_filter( 'rest_get_setting', array( $this, 'get_setting_custom_callback' ), 10, 3 );
+		add_filter( 'rest_pre_get_setting', array( $this, 'get_setting_custom_callback' ), 10, 3 );
 
 		register_setting( 'somegroup', 'mycustomsetting1', array(
 			'show_in_rest' => array(
@@ -147,7 +147,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 'unfiltered2', $data['mycustomsettinginrest2'] );
 
 		unregister_setting( 'somegroup', 'mycustomsetting' );
-		remove_all_filters( 'get_setting_custom_callback' );
+		remove_all_filters( 'rest_pre_get_setting' );
 	}
 
 	public function test_create_item() {
@@ -188,7 +188,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( get_option( 'blogname' ), $data['title'] );
 		$this->assertEquals( get_option( 'blogdescription' ), $data['description'] );
 
-		add_filter( 'rest_update_setting', array( $this, 'update_setting_custom_callback' ), 10, 4 );
+		add_filter( 'rest_pre_update_setting', array( $this, 'update_setting_custom_callback' ), 10, 4 );
 
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
 		$request->set_param( 'title', 'The new title!' );
@@ -202,7 +202,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( get_option( 'blogname' ), $data['title'] );
 		$this->assertEquals( get_option( 'blogdescription' ), $data['description'] );
 
-		remove_all_filters( 'rest_update_setting' );
+		remove_all_filters( 'rest_pre_update_setting' );
 	}
 
 	public function test_update_item_with_invalid_type() {

--- a/tests/test-rest-settings-controller.php
+++ b/tests/test-rest-settings-controller.php
@@ -104,6 +104,52 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		unregister_setting( 'somegroup', 'mycustomsetting' );
 	}
 
+	public function get_setting_custom_callback( $result, $name, $args ) {
+		switch ( $name ) {
+			case 'mycustomsetting1':
+				return 'filtered1';
+		}
+		return $result;
+	}
+
+	public function test_get_item_with_filter() {
+		wp_set_current_user( $this->administrator );
+
+		add_filter( 'rest_get_setting', array( $this, 'get_setting_custom_callback' ), 10, 3 );
+
+		register_setting( 'somegroup', 'mycustomsetting1', array(
+			'show_in_rest' => array(
+				'name'   => 'mycustomsettinginrest1',
+			),
+			'type'         => 'string',
+		) );
+
+		register_setting( 'somegroup', 'mycustomsetting2', array(
+			'show_in_rest' => array(
+				'name'   => 'mycustomsettinginrest2',
+			),
+			'type'         => 'string',
+		) );
+
+		update_option( 'mycustomsetting1', 'unfiltered1' );
+		update_option( 'mycustomsetting2', 'unfiltered2' );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertArrayHasKey( 'mycustomsettinginrest1', $data );
+		$this->assertEquals( 'unfiltered1', $data['mycustomsettinginrest1'] );
+
+		$this->assertArrayHasKey( 'mycustomsettinginrest2', $data );
+		$this->assertEquals( 'unfiltered2', $data['mycustomsettinginrest2'] );
+
+		unregister_setting( 'somegroup', 'mycustomsetting' );
+		remove_all_filters( 'get_setting_custom_callback' );
+	}
+
 	public function test_create_item() {
 	}
 


### PR DESCRIPTION
This allows for a couple of interesting use cases:
- Making certain settings read-only (we will need to do this on WP.com, if we don't end up removing the settings in question altogether)
- Exposing properties via the settings endpoint that are stored as something other than simple site options (we will need to do this on WP.com as well)
