### PR TITLE
Avoid dynamically declared properties.

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -5,6 +5,14 @@
  */
 class WP_REST_Comments_Controller extends WP_REST_Controller {
 
+	/**
+	 * Instance of a comment meta fields object.
+	 *
+	 * @access protected
+	 * @var WP_REST_Comment_Meta_Fields
+	 */
+	protected $meta;
+
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'comments';

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -4,6 +4,14 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 	protected $post_type;
 
+	/**
+	 * Instance of a post meta fields object.
+	 *
+	 * @access protected
+	 * @var WP_REST_Post_Meta_Fields
+	 */
+	protected $meta;
+
 	public function __construct( $post_type ) {
 		$this->post_type = $post_type;
 		$this->namespace = 'wp/v2';

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -22,6 +22,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	protected $meta;
 
 	/**
+	 * Column to have the terms be sorted by.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $sort_column;
+
+	/**
 	 * Number of terms that were found.
 	 *
 	 * @access protected

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -14,6 +14,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	protected $taxonomy;
 
 	/**
+	 * Number of terms that were found.
+	 *
+	 * @access protected
+	 * @var int
+	 */
+	protected $total_terms;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $taxonomy Taxonomy key.

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -14,6 +14,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	protected $taxonomy;
 
 	/**
+	 * Instance of a term meta fields object.
+	 *
+	 * @access protected
+	 * @var WP_REST_Term_Meta_Fields
+	 */
+	protected $meta;
+
+	/**
 	 * Number of terms that were found.
 	 *
 	 * @access protected

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -5,6 +5,14 @@
  */
 class WP_REST_Users_Controller extends WP_REST_Controller {
 
+	/**
+	 * Instance of a user meta fields object.
+	 *
+	 * @access protected
+	 * @var WP_REST_User_Meta_Fields
+	 */
+	protected $meta;
+
 	public function __construct() {
 		$this->namespace = 'wp/v2';
 		$this->rest_base = 'users';


### PR DESCRIPTION
The following properties are set/retrieved in a dynamic way, without declaring them as being part of the class first:

`WP_REST_Comments_Controller->meta`
`WP_REST_Posts_Controller->meta`
`WP_REST_Users_Controller->meta`
`WP_REST_Terms_Controller->meta`
`WP_REST_Terms_Controller->sort_colum`
`WP_REST_Terms_Controller->total_terms`

This PR adds proper declarations for each of these, to help IDE type-hinting and avoid warnings in code quality tools.
