### PR TITLE
Merge multiple `isset()` checks into a single check with multiple arguments

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -148,7 +148,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		// For each known parameter which is both registered and present in the request,
 		// set the parameter's value on the query $prepared_args.
 		foreach ( $parameter_mappings as $api_param => $wp_param ) {
-			if ( isset( $registered[ $api_param ] ) && isset( $request[ $api_param ] ) ) {
+			if ( isset( $registered[ $api_param ], $request[ $api_param ] ) ) {
 				$prepared_args[ $wp_param ] = $request[ $api_param ];
 			}
 		}
@@ -168,12 +168,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_args['date_query'] = array();
 		// Set before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['before'] ) && isset( $request['before'] ) ) {
+		if ( isset( $registered['before'], $request['before'] ) ) {
 			$prepared_args['date_query'][0]['before'] = $request['before'];
 		}
 
 		// Set after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['after'] ) && isset( $request['after'] ) ) {
+		if ( isset( $registered['after'], $request['after'] ) ) {
 			$prepared_args['date_query'][0]['after'] = $request['after'];
 		}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -124,7 +124,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// For each known parameter which is both registered and present in the request,
 		// set the parameter's value on the query $args.
 		foreach ( $parameter_mappings as $api_param => $wp_param ) {
-			if ( isset( $registered[ $api_param ] ) && isset( $request[ $api_param ] ) ) {
+			if ( isset( $registered[ $api_param ], $request[ $api_param ] ) ) {
 				$args[ $wp_param ] = $request[ $api_param ];
 			}
 		}
@@ -133,12 +133,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$args['date_query'] = array();
 		// Set before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['before'] ) && isset( $request['before'] ) ) {
+		if ( isset( $registered['before'], $request['before'] ) ) {
 			$args['date_query'][0]['before'] = $request['before'];
 		}
 
 		// Set after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['after'] ) && isset( $request['after'] ) ) {
+		if ( isset( $registered['after'], $request['after'] ) ) {
 			$args['date_query'][0]['after'] = $request['after'];
 		}
 
@@ -152,7 +152,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$args['posts_per_page'] = $request['per_page'];
 		}
 
-		if ( isset( $registered['sticky'] ) && isset( $request['sticky'] ) ) {
+		if ( isset( $registered['sticky'], $request['sticky'] ) ) {
 			$sticky_posts = get_option( 'sticky_posts', array() );
 			if ( $sticky_posts && $request['sticky'] ) {
 				// As post__in will be used to only get sticky posts,

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -126,7 +126,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		// For each known parameter which is both registered and present in the request,
 		// set the parameter's value on the query $prepared_args.
 		foreach ( $parameter_mappings as $api_param => $wp_param ) {
-			if ( isset( $registered[ $api_param ] ) && isset( $request[ $api_param ] ) ) {
+			if ( isset( $registered[ $api_param ], $request[ $api_param ] ) ) {
 				$prepared_args[ $wp_param ] = $request[ $api_param ];
 			}
 		}
@@ -139,7 +139,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$taxonomy_obj = get_taxonomy( $this->taxonomy );
 
-		if ( $taxonomy_obj->hierarchical && isset( $registered['parent'] ) && isset( $request['parent'] ) ) {
+		if ( $taxonomy_obj->hierarchical && isset( $registered['parent'], $request['parent'] ) ) {
 			if ( 0 === $request['parent'] ) {
 				// Only query top-level terms.
 				$prepared_args['parent'] = 0;

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -124,7 +124,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		// For each known parameter which is both registered and present in the request,
 		// set the parameter's value on the query $prepared_args.
 		foreach ( $parameter_mappings as $api_param => $wp_param ) {
-			if ( isset( $registered[ $api_param ] ) && isset( $request[ $api_param ] ) ) {
+			if ( isset( $registered[ $api_param ], $request[ $api_param ] ) ) {
 				$prepared_args[ $wp_param ] = $request[ $api_param ];
 			}
 		}


### PR DESCRIPTION
There are several conditional checks that make two separate `isset()` checks and logically combine them with the `&&` operator.

`isset()` accepts multiple arguments, and only returns true if all of them are set.

The changes in this PR merge these checks into one single check with multiple arguments, eliminating the overhead of an additional function call and the boolean operation, and creating shorter and cleaner code.
