### PR TITLE
Merge multiple `unset()` class into a single one with multiple arguments.

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -208,8 +208,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		$max_pages = (int) $query->max_num_pages;
 		if ( $total_comments < 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count
-			unset( $prepared_args['number'] );
-			unset( $prepared_args['offset'] );
+			unset( $prepared_args['number'], $prepared_args['offset'] );
 			$query = new WP_Comment_Query;
 			$prepared_args['count'] = true;
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -259,8 +259,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$request_params = $request->get_query_params();
 		if ( ! empty( $request_params['filter'] ) ) {
 			// Normalize the pagination params.
-			unset( $request_params['filter']['posts_per_page'] );
-			unset( $request_params['filter']['paged'] );
+			unset(
+				$request_params['filter']['posts_per_page'],
+				$request_params['filter']['paged']
+			);
 		}
 		$base = add_query_arg( $request_params, rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) );
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -259,10 +259,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$request_params = $request->get_query_params();
 		if ( ! empty( $request_params['filter'] ) ) {
 			// Normalize the pagination params.
-			unset(
-				$request_params['filter']['posts_per_page'],
-				$request_params['filter']['paged']
-			);
+			unset( $request_params['filter']['posts_per_page'], $request_params['filter']['paged'] );
 		}
 		$base = add_query_arg( $request_params, rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) );
 

--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -171,8 +171,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$query_result = get_terms( $this->taxonomy, $prepared_args );
 
 			$count_args = $prepared_args;
-			unset( $count_args['number'] );
-			unset( $count_args['offset'] );
+			unset( $count_args['number'], $count_args['offset'] );
 			$total_terms = wp_count_terms( $this->taxonomy, $count_args );
 
 			// wp_count_terms can return a falsy value when the term has no children

--- a/lib/endpoints/class-wp-rest-users-controller.php
+++ b/lib/endpoints/class-wp-rest-users-controller.php
@@ -190,8 +190,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		$total_users = $query->get_total();
 		if ( $total_users < 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count
-			unset( $prepared_args['number'] );
-			unset( $prepared_args['offset'] );
+			unset( $prepared_args['number'], $prepared_args['offset'] );
 			$count_query = new WP_User_Query( $prepared_args );
 			$total_users = $count_query->get_total();
 		}


### PR DESCRIPTION
There are several places in the code that make two consecutive `unset()` calls.

`unset()` accepts multiple arguments, and can unset all of the passed arguments in one go.

The changes in this PR merge these calls into one single call with multiple arguments, eliminating the overhead of an additional function call.
