### PR TITLE
Remove redundant `isset()` before `unset()`.

### DIFF
--- a/lib/endpoints/class-wp-rest-controller.php
+++ b/lib/endpoints/class-wp-rest-controller.php
@@ -228,9 +228,7 @@ abstract class WP_REST_Controller {
 		$schema = $this->get_item_schema();
 
 		foreach ( $schema['properties'] as &$property ) {
-			if ( isset( $property['arg_options'] ) ) {
-				unset( $property['arg_options'] );
-			}
+			unset( $property['arg_options'] );
 		}
 
 		return $schema;


### PR DESCRIPTION
Making an `isset()` check of a variable before an `unset()` of that same variable is redundant and only produces unnecessarily convoluted code.

This PR removes such a check.
