### PR TITLE
Avoid slow `in_array()` for single-item arrays.

### DIFF
--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -16,7 +16,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$query_args['post_status'] = 'inherit';
 		}
 		$media_types = $this->get_media_types();
-		if ( ! empty( $request['media_type'] ) && in_array( $request['media_type'], array_keys( $media_types ), true ) ) {
+		if ( ! empty( $request['media_type'] ) && isset( $media_types[ $request['media_type'] ] ) ) {
 			$query_args['post_mime_type'] = $media_types[ $request['media_type'] ];
 		}
 		if ( ! empty( $request['mime_type'] ) ) {

--- a/lib/endpoints/class-wp-rest-attachments-controller.php
+++ b/lib/endpoints/class-wp-rest-attachments-controller.php
@@ -114,7 +114,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$id = wp_insert_post( $attachment, true );
 		if ( is_wp_error( $id ) ) {
-			if ( in_array( $id->get_error_code(), array( 'db_update_error' ), true ) ) {
+			if ( 'db_update_error' === $id->get_error_code() ) {
 				$id->add_data( array( 'status' => 500 ) );
 			} else {
 				$id->add_data( array( 'status' => 400 ) );

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1602,7 +1602,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		foreach ( $post_type_attributes as $attribute ) {
 			if ( isset( $fixed_schemas[ $this->post_type ] ) && ! in_array( $attribute, $fixed_schemas[ $this->post_type ], true ) ) {
 				continue;
-			} elseif ( ! in_array( $this->post_type, array_keys( $fixed_schemas ), true ) && ! post_type_supports( $this->post_type, $attribute ) ) {
+			} elseif ( ! isset( $fixed_schemas[ $this->post_type ] ) && ! post_type_supports( $this->post_type, $attribute ) ) {
 				continue;
 			}
 

--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -413,7 +413,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( is_wp_error( $post_id ) ) {
 
-			if ( in_array( $post_id->get_error_code(), array( 'db_insert_error' ), true ) ) {
+			if ( 'db_insert_error' === $post_id->get_error_code() ) {
 				$post_id->add_data( array( 'status' => 500 ) );
 			} else {
 				$post_id->add_data( array( 'status' => 400 ) );
@@ -526,7 +526,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// convert the post object to an array, otherwise wp_update_post will expect non-escaped input
 		$post_id = wp_update_post( (array) $post, true );
 		if ( is_wp_error( $post_id ) ) {
-			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ), true ) ) {
+			if ( 'db_update_error' === $post_id->get_error_code() ) {
 				$post_id->add_data( array( 'status' => 500 ) );
 			} else {
 				$post_id->add_data( array( 'status' => 400 ) );


### PR DESCRIPTION
`in_array()` is a rather slow operation, and should not be used to compare against arrays that are known to only contain one element.

This PR replaces such comparisons with a simpler and faster equality check.
