### PR TITLE
Remove unnecessary set of parentheses.

### DIFF
--- a/lib/endpoints/class-wp-rest-terms-controller.php
+++ b/lib/endpoints/class-wp-rest-terms-controller.php
@@ -371,7 +371,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			 * If we're going to inform the client that the term already exists,
 			 * give them the identifier for future use.
 			 */
-			if ( ( $term_id = $term->get_error_data( 'term_exists' ) ) ) {
+			if ( $term_id = $term->get_error_data( 'term_exists' ) ) {
 				$existing_term = get_term( $term_id, $this->taxonomy );
 				$term->add_data( $existing_term->term_id, 'term_exists' );
 			}


### PR DESCRIPTION
Remove unnecessary set of parentheses that were probably left over when the conditions for an if clause were changed.
