### PR TITLE
Replace PHP4 covnersion functions with typecasts.

### DIFF
--- a/lib/endpoints/class-wp-rest-settings-controller.php
+++ b/lib/endpoints/class-wp-rest-settings-controller.php
@@ -72,9 +72,9 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	protected function prepare_value( $value, $schema ) {
 		switch ( $schema['type'] ) {
 			case 'string':
-				return strval( $value );
+				return (string) $value;
 			case 'number':
-				return floatval( $value );
+				return (float) $value;
 			case 'boolean':
 				return (bool) $value;
 			default:

--- a/lib/fields/class-wp-rest-meta-fields.php
+++ b/lib/fields/class-wp-rest-meta-fields.php
@@ -345,10 +345,10 @@ abstract class WP_REST_Meta_Fields {
 
 		switch ( $type ) {
 			case 'string':
-				$value = strval( $value );
+				$value = (string) $value;
 				break;
 			case 'number':
-				$value = floatval( $value );
+				$value = (float) $value;
 				break;
 			case 'boolean':
 				$value = (bool) $value;


### PR DESCRIPTION
The PHP4-style conversion functions like `strval()` and `floatval()` incur an unnecessary function call overhead.

This PR replaces them with the corresponding typecasts (`(string)` and `(float)`, respectively).
