### PR TITLE
Fix arguments mismatch for `wp_allow_comment()`.

### DIFF
--- a/lib/endpoints/class-wp-rest-comments-controller.php
+++ b/lib/endpoints/class-wp-rest-comments-controller.php
@@ -399,7 +399,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$prepared_comment['comment_agent'] = '';
-		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
+		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment );
 
 		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
 			$error_code = $prepared_comment['comment_approved']->get_error_code();


### PR DESCRIPTION
According to the [Codex](https://codex.wordpress.org/Function_Reference/wp_allow_comment), `wp_allow_comment()` only accepts one argument.

This PR fixes an instance where this function is called with a superfluous second boolean argument.
