### PR TITLE
Remove misplaced semicolon.

### DIFF
--- a/lib/endpoints/class-wp-rest-posts-controller.php
+++ b/lib/endpoints/class-wp-rest-posts-controller.php
@@ -1381,7 +1381,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				'href'       => rest_url( 'wp/v2/users/' . $post->post_author ),
 				'embeddable' => true,
 			);
-		};
+		}
 
 		if ( in_array( $post->post_type, array( 'post', 'page' ), true ) || post_type_supports( $post->post_type, 'comments' ) ) {
 			$replies_url = rest_url( 'wp/v2/comments' );


### PR DESCRIPTION
Remove a misplaced semicolon that was trailing after an if-clause brace.
