### PR TITLE
`in_array()` should only ever be used in strict mode.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -455,7 +455,7 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 		$args = $attributes['args'][ $param ];
 
 		if ( ! empty( $args['enum'] ) ) {
-			if ( ! in_array( $value, $args['enum'] ) ) {
+			if ( ! in_array( $value, $args['enum'], true ) ) {
 				return new WP_Error( 'rest_invalid_param', sprintf( /* translators: 1: parameter, 2: list of valid values */ __( '%1$s is not one of %2$s.' ), $param, implode( ', ', $args['enum'] ) ) );
 			}
 		}

--- a/tests/test-rest-attachments-controller.php
+++ b/tests/test-rest-attachments-controller.php
@@ -169,9 +169,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$data = $response->get_data();
 		$this->assertCount( 2, $data );
 		$ids = wp_list_pluck( $data, 'id' );
-		$this->assertTrue( in_array( $id1, $ids ) );
-		$this->assertFalse( in_array( $id2, $ids ) );
-		$this->assertTrue( in_array( $id3, $ids ) );
+		$this->assertTrue( in_array( $id1, $ids, true ) );
+		$this->assertFalse( in_array( $id2, $ids, true ) );
+		$this->assertTrue( in_array( $id3, $ids, true ) );
 
 		$this->check_get_posts_response( $response );
 	}
@@ -198,9 +198,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$data = $response->get_data();
 		$this->assertCount( 3, $data );
 		$ids = wp_list_pluck( $data, 'id' );
-		$this->assertTrue( in_array( $id1, $ids ) );
-		$this->assertTrue( in_array( $id2, $ids ) );
-		$this->assertTrue( in_array( $id3, $ids ) );
+		$this->assertTrue( in_array( $id1, $ids, true ) );
+		$this->assertTrue( in_array( $id2, $ids, true ) );
+		$this->assertTrue( in_array( $id3, $ids, true ) );
 	}
 
 	public function test_get_items_media_type() {

--- a/tests/test-rest-categories-controller.php
+++ b/tests/test-rest-categories-controller.php
@@ -198,13 +198,13 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 		$request->set_param( 'exclude', array( $id2 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 	}
 
 	public function test_get_items_orderby_args() {

--- a/tests/test-rest-comments-controller.php
+++ b/tests/test-rest-comments-controller.php
@@ -150,7 +150,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$collection_data = $response->get_data();
-		$this->assertFalse( in_array( $private_comment, wp_list_pluck( $collection_data, 'id' ) ) );
+		$this->assertFalse( in_array( $private_comment, wp_list_pluck( $collection_data, 'id' ), true ) );
 	}
 
 	public function test_get_items_with_private_post_permission() {
@@ -168,7 +168,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$collection_data = $response->get_data();
-		$this->assertTrue( in_array( $private_comment, wp_list_pluck( $collection_data, 'id' ) ) );
+		$this->assertTrue( in_array( $private_comment, wp_list_pluck( $collection_data, 'id' ), true ) );
 	}
 
 	public function test_get_items_with_invalid_post() {
@@ -185,7 +185,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$collection_data = $response->get_data();
-		$this->assertFalse( in_array( $comment_id, wp_list_pluck( $collection_data, 'id' ) ) );
+		$this->assertFalse( in_array( $comment_id, wp_list_pluck( $collection_data, 'id' ), true ) );
 
 		wp_delete_comment( $comment_id );
 	}
@@ -204,7 +204,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$collection_data = $response->get_data();
-		$this->assertTrue( in_array( $comment_id, wp_list_pluck( $collection_data, 'id' ) ) );
+		$this->assertTrue( in_array( $comment_id, wp_list_pluck( $collection_data, 'id' ), true ) );
 
 		wp_delete_comment( $comment_id );
 	}
@@ -296,13 +296,13 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 		$request->set_param( 'exclude', array( $id2 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 	}
 
 	public function test_get_items_offset_query() {

--- a/tests/test-rest-posts-controller.php
+++ b/tests/test-rest-posts-controller.php
@@ -180,13 +180,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 		$request->set_param( 'exclude', array( $id2 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 	}
 
 	public function test_get_items_search_query() {

--- a/tests/test-rest-tags-controller.php
+++ b/tests/test-rest-tags-controller.php
@@ -116,13 +116,13 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 		$request->set_param( 'exclude', array( $id2 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 	}
 
 	public function test_get_items_offset_query() {

--- a/tests/test-rest-users-controller.php
+++ b/tests/test-rest-users-controller.php
@@ -403,13 +403,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertTrue( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 		$request->set_param( 'exclude', array( $id2 ) );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
-		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ) ) );
-		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ) ) );
+		$this->assertTrue( in_array( $id1, wp_list_pluck( $data, 'id' ), true ) );
+		$this->assertFalse( in_array( $id2, wp_list_pluck( $data, 'id' ), true ) );
 	}
 
 	public function test_get_items_search() {


### PR DESCRIPTION
Change 1 occurrence in plugin and 30 occurrences in the tests of `in_array()` that are missing the third boolean argument to enable strict mode.
