### PR TITLE
Update README to remove mention of `filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ site's data in simple JSON format, including users, posts, taxonomies and more.
 Retrieving or updating data is as simple as sending a HTTP request.
 
 Want to get your site's posts? Simply send a `GET` request to `/wp-json/wp/v2/posts`.
-Update user with ID 4? Send a `PUT` request to `/wp-json/wp/v2/users/4`. Get all
-posts with the search term "awesome"? `GET /wp-json/wp/v2/posts?filter[s]=awesome`.
-It's that easy.
+Update user with ID 4? Send a `PUT` request to `/wp-json/wp/v2/users/4`. Get the page
+with slug "about-me"? `GET /wp-json/wp/v2/pages?slug=about-me`. Get all posts with
+the search term "awesome"? `GET /wp-json/wp/v2/posts?search=awesome`. It's that easy.
 
 The WordPress REST API exposes a simple yet easy interface to WP Query, the posts
 API, post meta API, users API, revisions API and many more. Chances are, if you


### PR DESCRIPTION
As noted in a recent issue we still mention `filter` in our README documentation, despite having removed the parameter in the core API. This PR updates the plugin README to remove any mention of this parameter, and adds a reference to the oft-missed ?slug= parameter as well; this is less to make the README a canonical source of documentation and more to avoid counteracting the ongoing migration of documentation to developer.wordpress.org