### PR TITLE
Add github templates to point would-be submitters to trac/forums

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+Development and support is no longer taking place in this repository.
+
+Please post support requests to the WordPress forums at https://wordpress.org/support/forum/how-to-and-troubleshooting/ with the topic tag "rest-api".
+
+For bugs and patches, please post the issue or patch to WordPress core Trac at https://core.trac.wordpress.org -- Be sure to include full details and reproduction steps about the issue you are experiencing.
+
+If you are unfamiliar with Trac, you can refer to the "Opening a Ticket" user guide at https://make.wordpress.org/core/handbook/tutorials/trac/opening-a-ticket/ for an introduction!
+
+Thank you,
+The REST API team

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Development and support is no longer taking place in this repository.
+The REST API has been merged into WordPress core! Development and support is no longer taking place in this repository.
 
 Please post support requests to the WordPress forums at https://wordpress.org/support/forum/how-to-and-troubleshooting/ with the topic tag "rest-api".
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Development and support is no longer taking place in this repository.
+
+Please post support requests to the WordPress forums at https://wordpress.org/support/forum/how-to-and-troubleshooting/ with the topic tag "rest-api".
+
+For bugs and patches, please post the issue or patch to WordPress core Trac at https://core.trac.wordpress.org -- Be sure to include full details and reproduction steps about the issue you are experiencing.
+
+If you are unfamiliar with Trac, you can refer to the "Opening a Ticket" user guide at https://make.wordpress.org/core/handbook/tutorials/trac/opening-a-ticket/ for an introduction!
+
+Thank you,
+The REST API team

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Development and support is no longer taking place in this repository.
+The REST API has been merged into WordPress core! Development and support is no longer taking place in this repository.
 
 Please post support requests to the WordPress forums at https://wordpress.org/support/forum/how-to-and-troubleshooting/ with the topic tag "rest-api".
 


### PR DESCRIPTION
This might help direct the flow of incoming issues and PRs over to the main development and support channels